### PR TITLE
Fix property name typo: change skipFCntCheck to skipFcntCheck in ICre…

### DIFF
--- a/src/interfaces/chirpstack/dispositivo-chirpstack.ts
+++ b/src/interfaces/chirpstack/dispositivo-chirpstack.ts
@@ -7,7 +7,7 @@ export interface ICreateDeviceChirpstack {
     isDisabled?: boolean;
     joinEui?: string;
     name?: string;
-    skipFCntCheck?: boolean;
+    skipFcntCheck?: boolean;
     tags?: Record<string, string>;
     variables?: Record<string, string>;
   };

--- a/src/interfaces/chirpstack/dispositivos-keys.ts
+++ b/src/interfaces/chirpstack/dispositivos-keys.ts
@@ -1,7 +1,6 @@
 export interface ICreateDeviceKeysChirpstack {
   deviceKeys: {
     appKey: string;
-    devEui: string;
     nwkKey: string;
   };
 }


### PR DESCRIPTION
…ateDeviceChirpstack interface; remove devEui from ICreateDeviceKeysChirpstack interface