### PR TITLE
Refactor interfaces to use single quotes for strings and add idsAnces…

### DIFF
--- a/src/interfaces/activo.ts
+++ b/src/interfaces/activo.ts
@@ -1,36 +1,36 @@
-import { ICliente } from "./cliente";
-import { IModoDesactivado } from "./dispositivo-alarma";
-import { estadoCuenta } from "./estado-entidad";
-import { IGrupo } from "./grupo";
-import { IRecorrido } from "./recorrido";
-import { ITracker } from "./tracker";
-import { IUsuario } from "./usuario";
+import { ICliente } from './cliente';
+import { IModoDesactivado } from './dispositivo-alarma';
+import { estadoCuenta } from './estado-entidad';
+import { IGrupo } from './grupo';
+import { IRecorrido } from './recorrido';
+import { ITracker } from './tracker';
+import { IUsuario } from './usuario';
 
 export type TipoVehiculo =
-  | "Colectivo"
-  | "Camion"
-  | "Moto"
-  | "Auto"
-  | "Grua"
-  | "Otro";
+  | 'Colectivo'
+  | 'Camion'
+  | 'Moto'
+  | 'Auto'
+  | 'Grua'
+  | 'Otro';
 
 export type FuncionActivo =
-  | "Transporte"
-  | "Bomberos"
-  | "Mantenimiento"
-  | "Policia"
-  | "Particular"
-  | "Ambulancia"
-  | "Seguridad Privada"
-  | "Servicio Técnico"
-  | "Otro";
+  | 'Transporte'
+  | 'Bomberos'
+  | 'Mantenimiento'
+  | 'Policia'
+  | 'Particular'
+  | 'Ambulancia'
+  | 'Seguridad Privada'
+  | 'Servicio Técnico'
+  | 'Otro';
 
 export type EstadoVehiculo =
-  | "Operativo"
-  | "En mantenimiento"
-  | "Fuera de servicio";
+  | 'Operativo'
+  | 'En mantenimiento'
+  | 'Fuera de servicio';
 
-export type ICategoriaActivo = "Normal" | "Vehículo";
+export type ICategoriaActivo = 'Normal' | 'Vehículo';
 
 export interface IVehiculo {
   tipo?: TipoVehiculo;
@@ -55,6 +55,7 @@ export interface IActivo {
   _id?: string;
   //
   idCliente?: string;
+  idsAncestros?: string[];
   idGrupo?: string;
   idTracker?: string;
   /**
@@ -72,14 +73,15 @@ export interface IActivo {
   estadoCuenta?: estadoCuenta;
   // Populate
   cliente?: ICliente;
+  ancestros?: ICliente[];
   tracker?: ITracker;
   grupo?: IGrupo;
 }
 
-type OmitirCreate = "_id" | "cliente" | "tracker";
+type OmitirCreate = '_id' | 'cliente' | 'tracker';
 
 export interface ICreateActivo extends Omit<Partial<IActivo>, OmitirCreate> {}
 
-type OmitirUpdate = "_id" | "cliente" | "tracker";
+type OmitirUpdate = '_id' | 'cliente' | 'tracker';
 
 export interface IUpdateActivo extends Omit<Partial<IActivo>, OmitirUpdate> {}

--- a/src/interfaces/apikey.ts
+++ b/src/interfaces/apikey.ts
@@ -12,7 +12,8 @@ export interface IApikey {
   modulos?: Modulo[]; // Flotas - Alarmas - etc
 
   // Populate
-  cliente?: ICliente; // Este sería el creador
+  cliente?: ICliente;
+  ancestros?: ICliente[]; // Este sería el creador
   clientes?: ICliente[]; // Estos son los elegidos para ver
 }
 

--- a/src/interfaces/boton-bluetooth.ts
+++ b/src/interfaces/boton-bluetooth.ts
@@ -1,5 +1,5 @@
-import { ICliente } from "./cliente";
-import { IModeloDispositivo } from "./modelo-dispositivo";
+import { ICliente } from './cliente';
+import { IModeloDispositivo } from './modelo-dispositivo';
 
 export interface IBotonBluetooth {
   _id?: string;
@@ -7,20 +7,22 @@ export interface IBotonBluetooth {
 
   fechaCreacion?: string;
   idCliente?: string;
+  idsAncestros?: string[];
   mac?: string;
   serialNumber?: string;
 
   //Populate
   cliente?: ICliente;
+  ancestros?: ICliente[];
   modeloDispositivo?: IModeloDispositivo;
 }
 
-type OmitirCreate = "_id" | "cliente";
+type OmitirCreate = '_id' | 'cliente';
 
 export interface ICreateBotonBluetooth
   extends Omit<Partial<IBotonBluetooth>, OmitirCreate> {}
 
-type OmitirUpdate = "_id" | "cliente";
+type OmitirUpdate = '_id' | 'cliente';
 
 export interface IUpdateBotonBluetooth
   extends Omit<Partial<IBotonBluetooth>, OmitirUpdate> {}

--- a/src/interfaces/camara.ts
+++ b/src/interfaces/camara.ts
@@ -1,8 +1,8 @@
-import { ICliente } from "./cliente";
-import { IModeloDispositivo } from "./modelo-dispositivo";
+import { ICliente } from './cliente';
+import { IModeloDispositivo } from './modelo-dispositivo';
 
-export type TipoHabilitacion = "Siempre" | "Con Evento";
-export type TipoCamara = "Hikvision" | "Dahua" | "Hikvision P2P" | "Dahua P2P";
+export type TipoHabilitacion = 'Siempre' | 'Con Evento';
+export type TipoCamara = 'Hikvision' | 'Dahua' | 'Hikvision P2P' | 'Dahua P2P';
 
 export interface ICanalesCamara {
   numero: string; // 1
@@ -19,6 +19,7 @@ export interface ICanalesCamara {
 export interface ICamara {
   _id?: string;
   idCliente?: string;
+  idsAncestros?: string[];
   fechaCreacion?: string;
   identificacion?: string;
   canales?: ICanalesCamara[];
@@ -33,13 +34,14 @@ export interface ICamara {
   claveDeEncriptacion?: string;
   // Populate
   cliente?: ICliente;
+  ancestros?: ICliente[];
   modeloDispositivo?: IModeloDispositivo;
 }
 
-type OmitirCreate = "_id" | "cliente" | "modeloDispositivo";
+type OmitirCreate = '_id' | 'cliente' | 'modeloDispositivo';
 
 export interface ICreateCamara extends Omit<Partial<ICamara>, OmitirCreate> {}
 
-type OmitirUpdate = "_id" | "cliente" | "modeloDispositivo";
+type OmitirUpdate = '_id' | 'cliente' | 'modeloDispositivo';
 
 export interface IUpdateCamara extends Omit<Partial<ICamara>, OmitirUpdate> {}

--- a/src/interfaces/categoria-evento.ts
+++ b/src/interfaces/categoria-evento.ts
@@ -1,6 +1,6 @@
-import { ICliente } from "./cliente";
+import { ICliente } from './cliente';
 
-export type SonidoEvento = "Silencio" | "Campana" | "Sirena";
+export type SonidoEvento = 'Silencio' | 'Campana' | 'Sirena';
 
 export interface ICategoriaEvento {
   _id?: string;
@@ -13,18 +13,20 @@ export interface ICategoriaEvento {
   noDerivar?: boolean;
   sonido?: SonidoEvento;
   idCliente?: string;
+  idsAncestros?: string[];
   default?: boolean;
   global?: boolean;
   //Populate
   cliente?: ICliente;
+  ancestros?: ICliente[];
 }
 
-type OmitirCreate = "_id" | "cliente";
+type OmitirCreate = '_id' | 'cliente';
 
 export interface ICreateCategoriaEvento
   extends Omit<Partial<ICategoriaEvento>, OmitirCreate> {}
 
-type OmitirUpdate = "_id" | "cliente";
+type OmitirUpdate = '_id' | 'cliente';
 
 export interface IUpdateCategoriaEvento
   extends Omit<Partial<ICategoriaEvento>, OmitirUpdate> {}

--- a/src/interfaces/centro-de-atencion.ts
+++ b/src/interfaces/centro-de-atencion.ts
@@ -1,10 +1,11 @@
-import { DireccionV2, ICoordenadas } from "../auxiliares";
-import { ICliente } from "./cliente";
-import { TipoEmergencia } from "./emergencias";
+import { DireccionV2, ICoordenadas } from '../auxiliares';
+import { ICliente } from './cliente';
+import { TipoEmergencia } from './emergencias';
 
 export interface ICentroDeAtencion {
   _id?: string;
   idCliente?: string;
+  idsAncestros?: string[];
 
   fechaCreacion?: string;
   nombre?: string;
@@ -14,21 +15,22 @@ export interface ICentroDeAtencion {
   email?: string; // Email institucional
   activo?: boolean; // Si está operativo
   circuloArea?: {
-    type?: "Circle";
+    type?: 'Circle';
     center?: number[];
     radius?: number;
   }; //círculo del centro de atención
 
   //Populate
   cliente?: ICliente;
+  ancestros?: ICliente[];
 }
 
-type OmitirCreate = "_id";
+type OmitirCreate = '_id';
 
 export interface ICreateCentroDeAtencion
   extends Omit<Partial<ICentroDeAtencion>, OmitirCreate> {}
 
-type OmitirUpdate = "_id";
+type OmitirUpdate = '_id';
 
 export interface IUpdateCentroDeAtencion
   extends Omit<Partial<ICentroDeAtencion>, OmitirUpdate> {}

--- a/src/interfaces/cliente-hijo.ts
+++ b/src/interfaces/cliente-hijo.ts
@@ -1,20 +1,22 @@
-import { ICliente } from "./cliente";
+import { ICliente } from './cliente';
 
 export interface IClienteHijo {
   _id?: string;
   idCliente?: string;
+  idsAncestros?: string[];
   idHijo?: string;
   nivelCliente?: number;
   nivelHijo?: number;
   //
   cliente?: ICliente;
+  ancestros?: ICliente[];
   hijo?: ICliente;
 }
 
-type OmitirCreate = "_id" | "cliente" | "hijo";
+type OmitirCreate = '_id' | 'cliente' | 'hijo';
 export interface ICreateClienteHijo
   extends Omit<Partial<IClienteHijo>, OmitirCreate> {}
 
-type OmitirUpdate = "_id" | "cliente" | "hijo";
+type OmitirUpdate = '_id' | 'cliente' | 'hijo';
 export interface IUpdateClienteHijo
   extends Omit<Partial<IClienteHijo>, OmitirUpdate> {}

--- a/src/interfaces/codigos-dispositivo.ts
+++ b/src/interfaces/codigos-dispositivo.ts
@@ -1,5 +1,5 @@
-import { ICliente } from "./cliente";
-import { ICategoriaEvento } from "./categoria-evento";
+import { ICliente } from './cliente';
+import { ICategoriaEvento } from './categoria-evento';
 
 export interface ICodigoDispositivo {
   codigo?: string;
@@ -18,13 +18,13 @@ export interface ICodigoDispositivo {
 }
 
 export type TipoDispositivo =
-  | "Tracker"
-  | "Alarma"
-  | "Comunicador"
-  | "Cámara"
-  | "Luminaria"
-  | "DispositivoLorawan"
-  | "BotonBLE";
+  | 'Tracker'
+  | 'Alarma'
+  | 'Comunicador'
+  | 'Cámara'
+  | 'Luminaria'
+  | 'DispositivoLorawan'
+  | 'BotonBLE';
 
 export interface ICodigosDispositivo {
   _id?: string;
@@ -33,17 +33,19 @@ export interface ICodigosDispositivo {
   tipo?: TipoDispositivo;
   codigos?: ICodigoDispositivo[];
   idCliente?: string;
+  idsAncestros?: string[];
   global?: boolean;
   // Populate
   cliente?: ICliente;
+  ancestros?: ICliente[];
 }
 
-type OmitirCreate = "_id" | "cliente";
+type OmitirCreate = '_id' | 'cliente';
 
 export interface ICreateCodigosDispositivo
   extends Omit<Partial<ICodigosDispositivo>, OmitirCreate> {}
 
-type OmitirUpdate = "_id" | "cliente";
+type OmitirUpdate = '_id' | 'cliente';
 
 export interface IUpdateCodigosDispositivo
   extends Omit<Partial<ICodigosDispositivo>, OmitirUpdate> {}

--- a/src/interfaces/comando.ts
+++ b/src/interfaces/comando.ts
@@ -1,12 +1,12 @@
-import { ICliente } from "./cliente";
-import { IDispositivoLorawan } from "./dispositivo-lorawan";
-import { IUsuario } from "./usuario";
+import { ICliente } from './cliente';
+import { IDispositivoLorawan } from './dispositivo-lorawan';
+import { IUsuario } from './usuario';
 
 export type IEstadoComando =
-  | "Enviado"
-  | "Recibido"
-  | "Ejecutado"
-  | "No Ejecutado";
+  | 'Enviado'
+  | 'Recibido'
+  | 'Ejecutado'
+  | 'No Ejecutado';
 
 export interface IComando {
   _id?: string;
@@ -18,6 +18,7 @@ export interface IComando {
   nombre?: string; // Ej: Cambio dimerizacion
   descripcion?: string; /// Cambio dimerizacion 50%
   idCliente?: string;
+  idsAncestros?: string[];
   idUsuario?: string;
   fechaCreacion?: string; // Default: Date.now
   fechaActualizacion?: string;
@@ -28,23 +29,24 @@ export interface IComando {
 
   // Virtuals
   cliente?: ICliente;
+  ancestros?: ICliente[];
   usuario?: IUsuario;
   dispositivo?: IDispositivoLorawan;
 }
 
 type OmitirCreate =
-  | "_id"
-  | "fechaCreacion"
-  | "estado"
-  | "cliente"
-  | "usuario"
-  | "dispositivo";
+  | '_id'
+  | 'fechaCreacion'
+  | 'estado'
+  | 'cliente'
+  | 'usuario'
+  | 'dispositivo';
 export interface ICreateComando extends Omit<Partial<IComando>, OmitirCreate> {}
 
 type OmitirUpdate =
-  | "_id"
-  | "fechaCreacion"
-  | "cliente"
-  | "usuario"
-  | "dispositivo";
+  | '_id'
+  | 'fechaCreacion'
+  | 'cliente'
+  | 'usuario'
+  | 'dispositivo';
 export interface IUpdateComando extends Omit<Partial<IComando>, OmitirUpdate> {}

--- a/src/interfaces/config-dispositivo.ts
+++ b/src/interfaces/config-dispositivo.ts
@@ -1,13 +1,14 @@
-import { ICliente } from "./cliente";
+import { ICliente } from './cliente';
 import {
   IConfigDispositivoLuminaria,
   IDispositivoLorawan,
-} from "./dispositivo-lorawan";
+} from './dispositivo-lorawan';
 
 export interface IConfigDispositivo {
   // Info autogenerada
   _id?: string;
   idCliente?: string;
+  idsAncestros?: string[];
   // Info de carga
   fechaCreacion?: string; // Default: Date.now
   fechaAplicacion?: string;
@@ -16,14 +17,15 @@ export interface IConfigDispositivo {
   // Virtuals
   dispositivo?: IDispositivoLorawan;
   cliente?: ICliente;
+  ancestros?: ICliente[];
 }
 
 // CREATE
-type OmitirCreate = "_id" | "fechaCreacion" | "dispositivo" | "cliente";
+type OmitirCreate = '_id' | 'fechaCreacion' | 'dispositivo' | 'cliente';
 export interface ICreateConfigDispositivo
   extends Omit<Partial<IConfigDispositivo>, OmitirCreate> {}
 
 // UPDATE
-type OmitirUpdate = "_id" | "fechaCreacion" | "dispositivo" | "cliente";
+type OmitirUpdate = '_id' | 'fechaCreacion' | 'dispositivo' | 'cliente';
 export interface IUpdateConfigDispositivo
   extends Omit<Partial<IConfigDispositivo>, OmitirUpdate> {}

--- a/src/interfaces/config-evento-usuario.ts
+++ b/src/interfaces/config-evento-usuario.ts
@@ -125,6 +125,7 @@ export interface IConfigEventoUsuario {
   agrupacion?: Agrupacion;
   // Sobre que entidades se reciben las notificaciones
   idCliente?: string;
+  idsAncestros?: string[];
   idGrupo?: string;
   idEntidad?: string;
   // Los usuarios que van a recibir las notificaciones
@@ -139,6 +140,7 @@ export interface IConfigEventoUsuario {
   // Virtual
   usuarios?: IUsuario[];
   cliente?: ICliente;
+  ancestros?: ICliente[];
   grupo?: IGrupo;
   activo?: IActivo;
   luminaria?: ILuminaria;

--- a/src/interfaces/config-reenvios.ts
+++ b/src/interfaces/config-reenvios.ts
@@ -1,13 +1,13 @@
-import { ICliente } from "./cliente";
-import { IDispositivoAlarma } from "./dispositivo-alarma";
-import { ITracker } from "./tracker";
+import { ICliente } from './cliente';
+import { IDispositivoAlarma } from './dispositivo-alarma';
+import { ITracker } from './tracker';
 
-export type MetodoReenvio = "Básico" | "Seguridad Evento Externo";
+export type MetodoReenvio = 'Básico' | 'Seguridad Evento Externo';
 
 export type IAgrupacionReenvio =
-  | "Todos los trackers del cliente"
-  | "Todas las alarmas del cliente"
-  | "Entidad";
+  | 'Todos los trackers del cliente'
+  | 'Todas las alarmas del cliente'
+  | 'Entidad';
 export interface IOpcionesReenvio {
   metodo?: MetodoReenvio;
   host?: string;
@@ -19,6 +19,7 @@ export interface IConfigReenvio {
   _id?: string;
   activo?: boolean;
   idCliente?: string;
+  idsAncestros?: string[];
   fechaCreacion?: string;
   // Configuracion
   agrupacionReenvio?: IAgrupacionReenvio;
@@ -28,15 +29,16 @@ export interface IConfigReenvio {
 
   // Virtual
   cliente?: ICliente;
+  ancestros?: ICliente[];
   clienteReenvio?: ICliente;
   dispositivoAlarma?: IDispositivoAlarma;
   tracker?: ITracker;
 }
 
-type OmitirCreate = "_id" | "cliente" | "dispositivoAlarma" | "tracker";
+type OmitirCreate = '_id' | 'cliente' | 'dispositivoAlarma' | 'tracker';
 export interface ICreateConfigReenvio
   extends Omit<Partial<IConfigReenvio>, OmitirCreate> {}
 
-type OmitirUpdate = "_id" | "cliente" | "dispositivoAlarma" | "tracker";
+type OmitirUpdate = '_id' | 'cliente' | 'dispositivoAlarma' | 'tracker';
 export interface IUpdateConfigReenvio
   extends Omit<Partial<IConfigReenvio>, OmitirUpdate> {}

--- a/src/interfaces/cronograma.ts
+++ b/src/interfaces/cronograma.ts
@@ -1,11 +1,12 @@
-import { ICliente } from "./cliente";
-import { Dia } from "./config-evento-usuario";
-import { IUbicacion } from "./ubicacion";
+import { ICliente } from './cliente';
+import { Dia } from './config-evento-usuario';
+import { IUbicacion } from './ubicacion';
 
 export interface ICronograma {
   _id?: string;
   //
   idCliente?: string;
+  idsAncestros?: string[];
   idUbicacion?: string;
   //
   fechaCreacion?: string;
@@ -19,20 +20,21 @@ export interface ICronograma {
   configuracion?: ConfigCronograma; // Colores, el nombre de de lo que se está mostrando, etc
   // Populate
   cliente?: ICliente;
+  ancestros?: ICliente[];
   ubicacion?: IUbicacion;
 }
 
-type OmitirCreate = "_id" | "cliente" | "ubicacion";
+type OmitirCreate = '_id' | 'cliente' | 'ubicacion';
 
 export interface ICreateCronograma
   extends Omit<Partial<ICronograma>, OmitirCreate> {}
 
-type OmitirUpdate = "_id" | "cliente" | "ubicacion";
+type OmitirUpdate = '_id' | 'cliente' | 'ubicacion';
 
 export interface IUpdateCronograma
   extends Omit<Partial<ICronograma>, OmitirUpdate> {}
 
-export type TipoDeCronograma = "despacho" | "turnos";
+export type TipoDeCronograma = 'despacho' | 'turnos';
 
 export interface Periodo {
   desde?: string; // Sale

--- a/src/interfaces/despacho.ts
+++ b/src/interfaces/despacho.ts
@@ -8,6 +8,7 @@ export interface IDespacho {
   _id?: string;
   //
   idCliente?: string;
+  idsAncestros?: string[];
   idUsuario?: string;
   //
   fechaCreacion?: string;
@@ -23,6 +24,7 @@ export interface IDespacho {
   cancelado?: boolean; /// Que el despacho fue cancelado
   // Populate
   cliente?: ICliente;
+  ancestros?: ICliente[];
   usuario?: IUsuario;
   activo?: IActivo;
   chofer?: IUsuario;

--- a/src/interfaces/destinatario-asistencia.ts
+++ b/src/interfaces/destinatario-asistencia.ts
@@ -1,5 +1,5 @@
-import { ICliente } from "./cliente";
-import { DireccionV2 } from "../auxiliares";
+import { ICliente } from './cliente';
+import { DireccionV2 } from '../auxiliares';
 
 export interface IInfoAdicional {
   descripcion?: string;
@@ -9,11 +9,12 @@ export interface IInfoAdicional {
 export interface IDestinatarioAsistencia {
   _id?: string; // ID único del destinatario
   idCliente?: string;
+  idsAncestros?: string[];
 
   fechaCreacion?: string;
   nombre?: string;
   apellido?: string;
-  sexo?: "M" | "F" | "X";
+  sexo?: 'M' | 'F' | 'X';
   dni?: string;
   edad?: number;
   obraSocial?: string;
@@ -25,14 +26,15 @@ export interface IDestinatarioAsistencia {
 
   //Populate
   cliente?: ICliente;
+  ancestros?: ICliente[];
 }
 
-type OmitirCreate = "_id";
+type OmitirCreate = '_id';
 
 export interface ICreateDestinatarioAsistencia
   extends Omit<Partial<IDestinatarioAsistencia>, OmitirCreate> {}
 
-type OmitirUpdate = "_id";
+type OmitirUpdate = '_id';
 
 export interface IUpdateDestinatarioAsistencia
   extends Omit<Partial<IDestinatarioAsistencia>, OmitirUpdate> {}

--- a/src/interfaces/dispositivo-alarma.ts
+++ b/src/interfaces/dispositivo-alarma.ts
@@ -434,6 +434,7 @@ export interface IDispositivoAlarma {
   idModelo?: string;
   idDomicilio?: string;
   idCliente?: string;
+  idsAncestros?: string[];
   nombre?: string;
   numeroAbonado?: string;
   sim1?: ISim;
@@ -462,6 +463,7 @@ export interface IDispositivoAlarma {
   domicilio?: IUbicacion;
   modelo?: IModeloDispositivo;
   cliente?: ICliente;
+  ancestros?: ICliente[];
   comunicador?: IModeloDispositivo;
   camaras?: ICamara[];
   serviciosContratados?: IServicioContratado[];

--- a/src/interfaces/dispositivo-lorawan.ts
+++ b/src/interfaces/dispositivo-lorawan.ts
@@ -1,7 +1,7 @@
-import { IGeoJSONPoint } from "../auxiliares";
-import { ICliente } from "./cliente";
-import { IModeloDispositivo } from "./modelo-dispositivo";
-import { IModoLuminaria, IReporteDispositivo } from "./reporte-dispositivo";
+import { IGeoJSONPoint } from '../auxiliares';
+import { ICliente } from './cliente';
+import { IModeloDispositivo } from './modelo-dispositivo';
+import { IModoLuminaria, IReporteDispositivo } from './reporte-dispositivo';
 
 //Notas: En el caso de estos dispositivos:
 // Potencia de dispositivo GPE = consumo instantáneo (W)
@@ -64,11 +64,12 @@ export interface IDispositivoLuminariaWellness {
   alarma?: string;
 }
 
-export type TipoDispositivoLorawan = "Luminaria GPE" | "Luminaria Wellness";
+export type TipoDispositivoLorawan = 'Luminaria GPE' | 'Luminaria Wellness';
 
 export interface IDispositivoLorawan {
   _id?: string;
   idCliente?: string;
+  idsAncestros?: string[];
   idModeloDispositivo?: string;
   fechaCreacion?: string; // Dafault: Date.now
   config?: IConfigDispositivoLuminaria;
@@ -102,15 +103,16 @@ export interface IDispositivoLorawan {
 
   //Populate
   cliente?: ICliente;
+  ancestros?: ICliente[];
   modeloDispositivo?: IModeloDispositivo;
 }
 
-type OmitirCreate = "_id" | "cliente";
+type OmitirCreate = '_id' | 'cliente';
 
 export interface ICreateDispositivoLorawan
   extends Omit<Partial<IDispositivoLorawan>, OmitirCreate> {}
 
-type OmitirUpdate = "_id" | "cliente";
+type OmitirUpdate = '_id' | 'cliente';
 
 export interface IUpdateDispositivoLorawan
   extends Omit<Partial<IDispositivoLorawan>, OmitirUpdate> {}

--- a/src/interfaces/documentacion.ts
+++ b/src/interfaces/documentacion.ts
@@ -13,10 +13,12 @@ export interface IDocumentacion {
   descripcion?: string;
   imagenes?: string[];
   idCliente?: string;
+  idsAncestros?: string[];
   idChofer?: string;
   idActivo?: string;
   // Populate
   cliente?: ICliente;
+  ancestros?: ICliente[];
   chofer?: IUsuario;
   activo?: IActivo;
 }

--- a/src/interfaces/emergencias.ts
+++ b/src/interfaces/emergencias.ts
@@ -1,8 +1,8 @@
-import { DireccionV2 } from "../auxiliares";
-import { ICentroDeAtencion } from "./centro-de-atencion";
-import { ICliente } from "./cliente";
-import { IDestinatarioAsistencia } from "./destinatario-asistencia";
-import { IEventoEmergencia } from "./evento-emergencia";
+import { DireccionV2 } from '../auxiliares';
+import { ICentroDeAtencion } from './centro-de-atencion';
+import { ICliente } from './cliente';
+import { IDestinatarioAsistencia } from './destinatario-asistencia';
+import { IEventoEmergencia } from './evento-emergencia';
 
 //EMERGENCIA MÉDICA
 export interface IEmergencia {
@@ -10,6 +10,7 @@ export interface IEmergencia {
   _id?: string;
   idDestinatarioAsistencia?: string;
   idCliente?: string;
+  idsAncestros?: string[];
   tipo?: TipoEmergencia;
   prioridadApertura?: PrioridadEmergencia; //Prioridad de apertura de la emergencia
   prioridadCierre?: PrioridadEmergencia; //Prioridad asignada por el personal correspondiente
@@ -41,17 +42,18 @@ export interface IEmergencia {
   //Populate
   destinatarioAsistencia?: IDestinatarioAsistencia; // Información del paciente
   cliente?: ICliente;
+  ancestros?: ICliente[];
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 export type PrioridadEmergencia =
-  | "Baja"
-  | "Media"
-  | "Alta"
-  | "Crítica"
-  | "Óbito"; //Óbito es exclusiva de emergencia médica
+  | 'Baja'
+  | 'Media'
+  | 'Alta'
+  | 'Crítica'
+  | 'Óbito'; //Óbito es exclusiva de emergencia médica
 
-export type TipoEmergencia = "Médica" | "Bombero";
+export type TipoEmergencia = 'Médica' | 'Bombero';
 
 export interface IArchivosAdjuntos {
   fechaSubida?: string;
@@ -72,12 +74,12 @@ export interface IEmergenciaBomberos {
   //Por ahora no hay propiedades específicas de emergenciaBomberos
 }
 
-type OmitirCreate = "_id";
+type OmitirCreate = '_id';
 
 export interface ICreateEmergencia
   extends Omit<Partial<IEmergencia>, OmitirCreate> {}
 
-type OmitirUpdate = "_id";
+type OmitirUpdate = '_id';
 
 export interface IUpdateEmergencia
   extends Omit<Partial<IEmergencia>, OmitirUpdate> {}

--- a/src/interfaces/envio-vehiculo.ts
+++ b/src/interfaces/envio-vehiculo.ts
@@ -1,14 +1,14 @@
-import { IActivo } from "./activo";
-import { ICliente } from "./cliente";
-import { IEvento } from "./evento";
-import { IUsuario } from "./usuario";
+import { IActivo } from './activo';
+import { ICliente } from './cliente';
+import { IEvento } from './evento';
+import { IUsuario } from './usuario';
 
 export type EstadoEnvioVehiculo =
-  | "Asignado"
-  | "En Camino"
-  | "Rechazado"
-  | "Finalizado"
-  | "En Destino";
+  | 'Asignado'
+  | 'En Camino'
+  | 'Rechazado'
+  | 'Finalizado'
+  | 'En Destino';
 
 export interface IEnvioVehiculo {
   _id?: string;
@@ -18,6 +18,7 @@ export interface IEnvioVehiculo {
   estado?: EstadoEnvioVehiculo;
   ///
   idCliente?: string;
+  idsAncestros?: string[];
   idConductor?: string;
   idsEventos?: string[];
   //Usuario que lo crea
@@ -25,6 +26,7 @@ export interface IEnvioVehiculo {
   idActivo?: string;
   // Populate
   cliente?: ICliente;
+  ancestros?: ICliente[];
   conductor?: IUsuario;
   usuario?: IUsuario;
   eventos?: IEvento[];
@@ -32,23 +34,23 @@ export interface IEnvioVehiculo {
 }
 
 type OmitirCreate =
-  | "_id"
-  | "usuario"
-  | "activo"
-  | "cliente"
-  | "conductor"
-  | "eventos";
+  | '_id'
+  | 'usuario'
+  | 'activo'
+  | 'cliente'
+  | 'conductor'
+  | 'eventos';
 
 export interface ICreateEnvioVehiculo
   extends Omit<Partial<IEnvioVehiculo>, OmitirCreate> {}
 
 type OmitirUpdate =
-  | "_id"
-  | "usuario"
-  | "activo"
-  | "cliente"
-  | "conductor"
-  | "eventos";
+  | '_id'
+  | 'usuario'
+  | 'activo'
+  | 'cliente'
+  | 'conductor'
+  | 'eventos';
 
 export interface IUpdateEnvioVehiculo
   extends Omit<Partial<IEnvioVehiculo>, OmitirUpdate> {}

--- a/src/interfaces/estado-entidad.ts
+++ b/src/interfaces/estado-entidad.ts
@@ -11,12 +11,14 @@ export interface IEstadoEntidad {
   estado?: estadoCuenta;
   idEntidad?: string; /// POR DISPOSITIVO
   idCliente?: string;
+  idsAncestros?: string[];
   idUsuario?: string;
   nota?: string;
   motivos?: string[];
   vigencia?: string; // Desde cuando se aplica el estado
   // Populate
   cliente?: ICliente;
+  ancestros?: ICliente[];
   usuario?: IUsuario;
   alarma?: IDispositivoAlarma;
   tracker?: ITracker;

--- a/src/interfaces/evento-emergencia.ts
+++ b/src/interfaces/evento-emergencia.ts
@@ -1,15 +1,16 @@
-import { DireccionV2 } from "../auxiliares";
-import { IActivo } from "./activo";
-import { ICliente } from "./cliente";
-import { IDestinatarioAsistencia } from "./destinatario-asistencia";
-import { IEmergencia, IEmergenciaMedica } from "./emergencias";
-import { IHospital } from "./hospitales";
-import { IPersonalSalud } from "./personal-salud";
-import { IUsuario } from "./usuario";
+import { DireccionV2 } from '../auxiliares';
+import { IActivo } from './activo';
+import { ICliente } from './cliente';
+import { IDestinatarioAsistencia } from './destinatario-asistencia';
+import { IEmergencia, IEmergenciaMedica } from './emergencias';
+import { IHospital } from './hospitales';
+import { IPersonalSalud } from './personal-salud';
+import { IUsuario } from './usuario';
 
 export interface IEventoEmergencia {
   _id?: string; // UUID del evento
   idCliente?: string;
+  idsAncestros?: string[];
   idDestinarioAsistencia?: string;
   idEmergencia?: string; // referencia a la emergencia
 
@@ -46,43 +47,44 @@ export interface IEventoEmergencia {
   enfermeros?: IPersonalSalud[];
   hospital?: IHospital;
   cliente?: ICliente;
+  ancestros?: ICliente[];
   usuarioResponsable?: IUsuario;
 }
 
 export type EstadoEmergenciaMedica =
   //LLAMADAS DE EMERGENCIA
-  | "Atendida" //La llamada se atendió exitosamente
+  | 'Atendida' //La llamada se atendió exitosamente
 
   //AUXILIOS
-  | "Pendiente" // Auxilio recién creado
-  | "Asignada" // Se asignó vehículo/médico/enfermero
-  | "Reasignada" //Se reasignó vehículo/médico/enfermero
-  | "En tránsito" // El vehículo salió del centro
-  | "Llegó a destino" // El vehículo llegó al lugar de la emergencia
-  | "Rumbo a hospital" // El vehículo sale hacia el hospital
-  | "Llegada a hospital" //El vehículo Llegó al hospital
-  | "Finalizada" // La emergencia fue tratada. Ya sea porque se llegó al hospital o no
-  | "Cancelada"; // La emergencia se canceló
+  | 'Pendiente' // Auxilio recién creado
+  | 'Asignada' // Se asignó vehículo/médico/enfermero
+  | 'Reasignada' //Se reasignó vehículo/médico/enfermero
+  | 'En tránsito' // El vehículo salió del centro
+  | 'Llegó a destino' // El vehículo llegó al lugar de la emergencia
+  | 'Rumbo a hospital' // El vehículo sale hacia el hospital
+  | 'Llegada a hospital' //El vehículo Llegó al hospital
+  | 'Finalizada' // La emergencia fue tratada. Ya sea porque se llegó al hospital o no
+  | 'Cancelada'; // La emergencia se canceló
 
 export type EstadoEmergenciaBomberos =
   //LLAMADAS DE EMERGENCIA
-  | "Atendida" //La llamada se atendió exitosamente
+  | 'Atendida' //La llamada se atendió exitosamente
 
   //AUXILIOS
-  | "Pendiente" // Auxilio recién creado
-  | "Asignada" // Se asignó vehículo
-  | "Reasignada" //Se reasignó vehículo
-  | "En tránsito" // El vehículo salió del centro
-  | "Llegó a destino" // El vehículo llegó al lugar de la emergencia
-  | "Finalizada" // La emergencia fue tratada
-  | "Cancelada"; // La emergencia se canceló
+  | 'Pendiente' // Auxilio recién creado
+  | 'Asignada' // Se asignó vehículo
+  | 'Reasignada' //Se reasignó vehículo
+  | 'En tránsito' // El vehículo salió del centro
+  | 'Llegó a destino' // El vehículo llegó al lugar de la emergencia
+  | 'Finalizada' // La emergencia fue tratada
+  | 'Cancelada'; // La emergencia se canceló
 
-type OmitirCreate = "_id";
+type OmitirCreate = '_id';
 
 export interface ICreateEventoEmergencia
   extends Omit<Partial<IEventoEmergencia>, OmitirCreate> {}
 
-type OmitirUpdate = "_id";
+type OmitirUpdate = '_id';
 
 export interface IUpdateEventoEmergencia
   extends Omit<Partial<IEventoEmergencia>, OmitirUpdate> {}

--- a/src/interfaces/evento-tecnico.ts
+++ b/src/interfaces/evento-tecnico.ts
@@ -1,17 +1,17 @@
-import { ICliente } from "./cliente";
-import { ITracker } from "./tracker";
-import { IDispositivoAlarma } from "./dispositivo-alarma";
-import { IActivo } from "./activo";
-import { IUsuario } from "./usuario";
+import { ICliente } from './cliente';
+import { ITracker } from './tracker';
+import { IDispositivoAlarma } from './dispositivo-alarma';
+import { IActivo } from './activo';
+import { IUsuario } from './usuario';
 
-export type CategoriaTecnica = "Alarma" | "Tracker" | "Luminaria";
+export type CategoriaTecnica = 'Alarma' | 'Tracker' | 'Luminaria';
 
 export type estadoEventoTecnico =
-  | "Pendiente"
-  | "Asignado"
-  | "En Atención"
-  | "Pendiente de Aprobación"
-  | "Finalizado";
+  | 'Pendiente'
+  | 'Asignado'
+  | 'En Atención'
+  | 'Pendiente de Aprobación'
+  | 'Finalizado';
 
 export interface IEventoTecnico {
   _id?: string;
@@ -27,6 +27,7 @@ export interface IEventoTecnico {
   idActivo?: string;
   idLuminaria?: string;
   idCliente?: string;
+  idsAncestros?: string[];
   //
   idsClientesQuePuedenAtender?: string[];
   idsClientesAtendiendo?: string[];
@@ -38,28 +39,29 @@ export interface IEventoTecnico {
   activo?: IActivo;
   luminaria?: IActivo;
   cliente?: ICliente;
+  ancestros?: ICliente[];
   usuario?: IUsuario;
   tecnico?: IUsuario;
 }
 
 type OmitirCreate =
-  | "_id"
-  | "cliente"
-  | "tracker"
-  | "alarma"
-  | "reporte"
-  | "activo";
+  | '_id'
+  | 'cliente'
+  | 'tracker'
+  | 'alarma'
+  | 'reporte'
+  | 'activo';
 
 export interface ICreateEventoTecnico
   extends Omit<Partial<IEventoTecnico>, OmitirCreate> {}
 
 type OmitirUpdate =
-  | "_id"
-  | "cliente"
-  | "tracker"
-  | "alarma"
-  | "reporte"
-  | "activo";
+  | '_id'
+  | 'cliente'
+  | 'tracker'
+  | 'alarma'
+  | 'reporte'
+  | 'activo';
 
 export interface IUpdateEventoTecnico
   extends Omit<Partial<IEventoTecnico>, OmitirUpdate> {}

--- a/src/interfaces/evento-traccar.ts
+++ b/src/interfaces/evento-traccar.ts
@@ -9,6 +9,7 @@ export interface IEventoTraccar {
   idTracker?: string;
   idActivo?: string;
   idCliente?: string;
+  idsAncestros?: string[];
   tipo?: 'events' | 'devices';
   //
   fechaCreacion?: string;
@@ -17,6 +18,7 @@ export interface IEventoTraccar {
   tracker?: ITracker;
   activo?: IActivo;
   cliente?: ICliente;
+  ancestros?: ICliente[];
 }
 
 type OmitirCreate = '_id' | 'fechaCreacion' | 'cliente' | 'tracker' | 'activo';

--- a/src/interfaces/evento.ts
+++ b/src/interfaces/evento.ts
@@ -1,13 +1,13 @@
-import { ICliente } from "./cliente";
-import { ITracker } from "./tracker";
-import { IDispositivoAlarma } from "./dispositivo-alarma";
-import { IReporte } from "./reporte";
-import { IActivo } from "./activo";
-import { IConfigEventoUsuario } from "./config-evento-usuario";
-import { SonidoEvento } from "./categoria-evento";
-import { IUsuario } from "./usuario";
-import { ILuminaria } from "./luminaria";
-import { IBotonBluetooth } from "./boton-bluetooth";
+import { ICliente } from './cliente';
+import { ITracker } from './tracker';
+import { IDispositivoAlarma } from './dispositivo-alarma';
+import { IReporte } from './reporte';
+import { IActivo } from './activo';
+import { IConfigEventoUsuario } from './config-evento-usuario';
+import { SonidoEvento } from './categoria-evento';
+import { IUsuario } from './usuario';
+import { ILuminaria } from './luminaria';
+import { IBotonBluetooth } from './boton-bluetooth';
 
 export interface IContactID {
   numeroCuenta?: string;
@@ -20,21 +20,21 @@ export interface IContactID {
 }
 
 export type estadoEvento =
-  | "Sin Tratamiento"
-  | "Pendiente"
-  | "En Atención"
-  | "En Espera"
-  | "Liberada"
-  | "Finalizada";
+  | 'Sin Tratamiento'
+  | 'Pendiente'
+  | 'En Atención'
+  | 'En Espera'
+  | 'Liberada'
+  | 'Finalizada';
 
 export type tipoEvento =
-  | "Colectivo"
-  | "Activo"
-  | "Tracker"
-  | "Vehiculo"
-  | "Alarma"
-  | "Luminaria"
-  | "BotonBLE";
+  | 'Colectivo'
+  | 'Activo'
+  | 'Tracker'
+  | 'Vehiculo'
+  | 'Alarma'
+  | 'Luminaria'
+  | 'BotonBLE';
 export interface IValoresEvento {
   titulo?: string;
   mensaje?: string;
@@ -46,7 +46,7 @@ export interface IValoresEvento {
   contactId?: IContactID;
   codigoAlarma?: string;
   codigoComunicador?: string;
-  tiposEvento?: ("Armado" | "Desarmado" | "Detonación" | "Test")[]; // Armado, Desarmado, detonacion, etc
+  tiposEvento?: ('Armado' | 'Desarmado' | 'Detonación' | 'Test')[]; // Armado, Desarmado, detonacion, etc
   // Otros campos
   [key: string]: any;
 }
@@ -54,6 +54,7 @@ export interface IValoresEvento {
 export interface IEvento {
   _id?: string;
   idCliente?: string;
+  idsAncestros?: string[];
   //
 
   notificar?: boolean;
@@ -88,6 +89,7 @@ export interface IEvento {
   luminaria?: ILuminaria;
   usuario?: IUsuario;
   cliente?: ICliente;
+  ancestros?: ICliente[];
   reporte?: IReporte;
   activo?: IActivo;
   configEventoUsuario?: IConfigEventoUsuario;
@@ -95,25 +97,25 @@ export interface IEvento {
 }
 
 type OmitirCreate =
-  | "_id"
-  | "cliente"
-  | "tracker"
-  | "alarma"
-  | "reporte"
-  | "activo"
-  | "botonBluetooth"
-  | "configEventoUsuario";
+  | '_id'
+  | 'cliente'
+  | 'tracker'
+  | 'alarma'
+  | 'reporte'
+  | 'activo'
+  | 'botonBluetooth'
+  | 'configEventoUsuario';
 
 export interface ICreateEvento extends Omit<Partial<IEvento>, OmitirCreate> {}
 
 type OmitirUpdate =
-  | "_id"
-  | "cliente"
-  | "tracker"
-  | "alarma"
-  | "reporte"
-  | "activo"
-  | "botonBluetooth"
-  | "configEventoUsuario";
+  | '_id'
+  | 'cliente'
+  | 'tracker'
+  | 'alarma'
+  | 'reporte'
+  | 'activo'
+  | 'botonBluetooth'
+  | 'configEventoUsuario';
 
 export interface IUpdateEvento extends Omit<Partial<IEvento>, OmitirUpdate> {}

--- a/src/interfaces/grupo.ts
+++ b/src/interfaces/grupo.ts
@@ -1,26 +1,28 @@
-import { ICliente } from "./cliente";
+import { ICliente } from './cliente';
 
 export type CategoriaGrupo =
-  | "Línea de colectivo"
-  | "Flota"
-  | "Activo"
-  | "Normal"
-  | "Luminaria";
+  | 'Línea de colectivo'
+  | 'Flota'
+  | 'Activo'
+  | 'Normal'
+  | 'Luminaria';
 
 export interface IGrupo {
   _id?: string;
   idCliente?: string;
+  idsAncestros?: string[];
   nombre?: string;
   color?: string;
   categoria?: CategoriaGrupo;
   // Populate
   cliente?: ICliente;
+  ancestros?: ICliente[];
 }
 
-type OmitirCreate = "_id" | "cliente";
+type OmitirCreate = '_id' | 'cliente';
 
 export interface ICreateGrupo extends Omit<Partial<IGrupo>, OmitirCreate> {}
 
-type OmitirUpdate = "_id" | "cliente";
+type OmitirUpdate = '_id' | 'cliente';
 
 export interface IUpdateGrupo extends Omit<Partial<IGrupo>, OmitirUpdate> {}

--- a/src/interfaces/hospitales.ts
+++ b/src/interfaces/hospitales.ts
@@ -1,28 +1,30 @@
-import { DireccionV2 } from "../auxiliares";
-import { ICliente } from "./cliente";
+import { DireccionV2 } from '../auxiliares';
+import { ICliente } from './cliente';
 
 export interface IHospital {
   _id?: string;
   idCliente?: string;
+  idsAncestros?: string[];
 
   fechaCreacion?: string;
   nombre?: string; // Nombre del hospital
   direccion?: DireccionV2; //Es autoexplicativo no?
   telefono?: string; // Teléfono de contacto
   email?: string; // Email institucional
-  tipo?: "Público" | "Privado" | "Público-privado"; // Tipo de gestión
+  tipo?: 'Público' | 'Privado' | 'Público-privado'; // Tipo de gestión
   activo?: boolean; // Si está operativo
 
   //Populate
   cliente?: ICliente;
+  ancestros?: ICliente[];
 }
 
-type OmitirCreate = "_id";
+type OmitirCreate = '_id';
 
 export interface ICreateHospital
   extends Omit<Partial<IHospital>, OmitirCreate> {}
 
-type OmitirUpdate = "_id";
+type OmitirUpdate = '_id';
 
 export interface IUpdateHospital
   extends Omit<Partial<IHospital>, OmitirUpdate> {}

--- a/src/interfaces/log-despacho.ts
+++ b/src/interfaces/log-despacho.ts
@@ -3,6 +3,7 @@ import { ICliente } from './cliente';
 export interface ILogDespacho {
   _id: string;
   idCliente?: string;
+  idsAncestros?: string[];
   fechaCreacion?: string;
   idExternoVehiculo?: string;
   idExternoRecorrido?: string;
@@ -10,6 +11,7 @@ export interface ILogDespacho {
   fecha?: string;
   // Populate
   cliente?: ICliente;
+  ancestros?: ICliente[];
 }
 
 ////// CREATE

--- a/src/interfaces/log-reenvio.ts
+++ b/src/interfaces/log-reenvio.ts
@@ -1,15 +1,16 @@
-import { ICliente } from "./cliente";
-import { IDispositivoAlarma } from "./dispositivo-alarma";
-import { ITracker } from "./tracker";
+import { ICliente } from './cliente';
+import { IDispositivoAlarma } from './dispositivo-alarma';
+import { ITracker } from './tracker';
 
 export interface ILogReenvio {
   _id?: string;
   //
   idCliente?: string;
+  idsAncestros?: string[];
   fecha?: string;
   idEntidad?: string;
 
-  protocolo?: "UDP" | "TCP";
+  protocolo?: 'UDP' | 'TCP';
   host?: string;
   puerto?: number;
   body?: string;
@@ -18,16 +19,17 @@ export interface ILogReenvio {
 
   // Populate
   cliente?: ICliente;
+  ancestros?: ICliente[];
   dispositivoAlarma?: IDispositivoAlarma;
   tracker?: ITracker;
 }
 
-type OmitirCreate = "_id" | "cliente" | "dispositivoAlarma" | "tracker";
+type OmitirCreate = '_id' | 'cliente' | 'dispositivoAlarma' | 'tracker';
 
 export interface ICreateLogReenvio
   extends Omit<Partial<ILogReenvio>, OmitirCreate> {}
 
-type OmitirUpdate = "_id" | "cliente" | "dispositivoAlarma" | "tracker";
+type OmitirUpdate = '_id' | 'cliente' | 'dispositivoAlarma' | 'tracker';
 
 export interface IUpdateLogReenvio
   extends Omit<Partial<ILogReenvio>, OmitirUpdate> {}

--- a/src/interfaces/log-trackeo.ts
+++ b/src/interfaces/log-trackeo.ts
@@ -5,6 +5,7 @@ export interface ILogTrackeo {
   _id?: string;
   //
   idCliente?: string;
+  idsAncestros?: string[];
   idActivo?: string;
   fecha?: string;
   nuevaParada?: boolean;
@@ -17,6 +18,7 @@ export interface ILogTrackeo {
 
   // Populate
   cliente?: ICliente;
+  ancestros?: ICliente[];
   activo?: IActivo;
 }
 

--- a/src/interfaces/log-twilio.ts
+++ b/src/interfaces/log-twilio.ts
@@ -25,6 +25,7 @@ export interface ILogTwilio {
   _id: string;
   fechaCreacion?: string;
   idCliente?: string;
+  idsAncestros?: string[];
   phone?: string;
   sid?: string;
   body?: string;
@@ -36,6 +37,7 @@ export interface ILogTwilio {
   errorMessage?: string;
   // Populate
   cliente?: ICliente;
+  ancestros?: ICliente[];
 }
 
 ////// CREATE

--- a/src/interfaces/luminaria.ts
+++ b/src/interfaces/luminaria.ts
@@ -1,16 +1,17 @@
-import { IGeoJSONPoint } from "../auxiliares";
-import { ICliente } from "./cliente";
-import { IDispositivoLorawan } from "./dispositivo-lorawan";
-import { IGrupo } from "./grupo";
-import { IModeloDispositivo } from "./modelo-dispositivo";
-import { IReporteDispositivo } from "./reporte-dispositivo";
+import { IGeoJSONPoint } from '../auxiliares';
+import { ICliente } from './cliente';
+import { IDispositivoLorawan } from './dispositivo-lorawan';
+import { IGrupo } from './grupo';
+import { IModeloDispositivo } from './modelo-dispositivo';
+import { IReporteDispositivo } from './reporte-dispositivo';
 
-export type EstadoLuminaria = "Operativa" | "Mantenimiento";
+export type EstadoLuminaria = 'Operativa' | 'Mantenimiento';
 
 export interface ILuminaria {
   _id?: string;
   fechaCreacion?: string; // Default: Date.now
   idCliente?: string;
+  idsAncestros?: string[];
   deveui?: string; // Deveui del dispositivo lorawan
   identificacion?: string;
   ubicacion?: IGeoJSONPoint; // GeoJSON de la ubicacion de la luminaria
@@ -23,6 +24,7 @@ export interface ILuminaria {
   ultimoReporte?: IReporteDispositivo;
   // Virtuals
   cliente?: ICliente;
+  ancestros?: ICliente[];
   dispositivo?: IDispositivoLorawan;
   modeloDispositivo?: IModeloDispositivo;
   grupos?: IGrupo[];
@@ -30,20 +32,20 @@ export interface ILuminaria {
 
 ////// CREATE
 type OmitirCreate =
-  | "_id"
-  | "fechaCreacion"
-  | "cliente"
-  | "dispositivo"
-  | "modeloDispositivo";
+  | '_id'
+  | 'fechaCreacion'
+  | 'cliente'
+  | 'dispositivo'
+  | 'modeloDispositivo';
 export interface ICreateLuminaria
   extends Omit<Partial<ILuminaria>, OmitirCreate> {}
 
 ////// UPDATE
 type OmitirUpdate =
-  | "_id"
-  | "fechaCreacion"
-  | "cliente"
-  | "dispositivo"
-  | "modeloDispositivo";
+  | '_id'
+  | 'fechaCreacion'
+  | 'cliente'
+  | 'dispositivo'
+  | 'modeloDispositivo';
 export interface IUpdateLuminaria
   extends Omit<Partial<ILuminaria>, OmitirUpdate> {}

--- a/src/interfaces/modelo-dispositivo.ts
+++ b/src/interfaces/modelo-dispositivo.ts
@@ -1,5 +1,5 @@
-import { ICliente } from "./cliente";
-import { ICodigosDispositivo, TipoDispositivo } from "./codigos-dispositivo";
+import { ICliente } from './cliente';
+import { ICodigosDispositivo, TipoDispositivo } from './codigos-dispositivo';
 
 export interface PotenciasDimerizacionLuminarias {
   dim20?: number;
@@ -23,20 +23,22 @@ export interface IModeloDispositivo {
   formatoMensaje?: string;
   idCodigos?: string;
   idCliente?: string;
+  idsAncestros?: string[];
   //Datos técnicos para luminarias
   luminarias?: IDetallesLuminarias;
   global?: boolean;
   // Populate
   cliente?: ICliente;
+  ancestros?: ICliente[];
   codigos?: ICodigosDispositivo;
 }
 
-type OmitirCreate = "_id" | "codigos" | "cliente";
+type OmitirCreate = '_id' | 'codigos' | 'cliente';
 
 export interface ICreateModeloDispositivo
   extends Omit<Partial<IModeloDispositivo>, OmitirCreate> {}
 
-type OmitirUpdate = "_id" | "codigos" | "cliente";
+type OmitirUpdate = '_id' | 'codigos' | 'cliente';
 
 export interface IUpdateModeloDispositivo
   extends Omit<Partial<IModeloDispositivo>, OmitirUpdate> {}

--- a/src/interfaces/nota.ts
+++ b/src/interfaces/nota.ts
@@ -1,9 +1,9 @@
-import { IActivo } from "./activo";
-import { ICliente } from "./cliente";
-import { IDispositivoAlarma } from "./dispositivo-alarma";
-import { ILuminaria } from "./luminaria";
+import { IActivo } from './activo';
+import { ICliente } from './cliente';
+import { IDispositivoAlarma } from './dispositivo-alarma';
+import { ILuminaria } from './luminaria';
 
-export type TipoNota = "Contacto" | "Nota";
+export type TipoNota = 'Contacto' | 'Nota';
 
 export interface IInformacionNota {
   nota?: string;
@@ -24,6 +24,7 @@ export type IInformacion = IInformacionNota & IInformacionContacto;
 export interface INota {
   _id?: string;
   idCliente?: string;
+  idsAncestros?: string[];
   idAsignado?: string;
   permanente?: boolean;
   vigenciaDesde?: string;
@@ -33,15 +34,16 @@ export interface INota {
   orden?: number;
   // Populate
   cliente?: ICliente;
+  ancestros?: ICliente[];
   activo?: IActivo;
   alarma?: IDispositivoAlarma;
   luminaria?: ILuminaria;
 }
 
-type OmitirCreate = "_id" | "cliente";
+type OmitirCreate = '_id' | 'cliente';
 
 export interface ICreateNota extends Omit<Partial<INota>, OmitirCreate> {}
 
-type OmitirUpdate = "_id" | "cliente";
+type OmitirUpdate = '_id' | 'cliente';
 
 export interface IUpdateNota extends Omit<Partial<INota>, OmitirUpdate> {}

--- a/src/interfaces/notificacion.ts
+++ b/src/interfaces/notificacion.ts
@@ -1,10 +1,11 @@
-import { ICliente } from "./cliente";
-import { IRecordatorio } from "./recordatorio";
-import { IUsuario } from "./usuario";
+import { ICliente } from './cliente';
+import { IRecordatorio } from './recordatorio';
+import { IUsuario } from './usuario';
 
 export interface INotificacion {
   _id?: string;
   idCliente?: string;
+  idsAncestros?: string[];
   idUsuario?: string;
   fechaCreacion?: string;
   fechaLeido?: string;
@@ -15,15 +16,16 @@ export interface INotificacion {
 
   // Populate
   cliente?: ICliente;
+  ancestros?: ICliente[];
   usuario?: IUsuario;
 }
 
-type OmitirCreate = "_id" | "cliente" | "usuario";
+type OmitirCreate = '_id' | 'cliente' | 'usuario';
 
 export interface ICreateNotificacion
   extends Omit<Partial<INotificacion>, OmitirCreate> {}
 
-type OmitirUpdate = "_id" | "cliente" | "usuario";
+type OmitirUpdate = '_id' | 'cliente' | 'usuario';
 
 export interface IUpdateNotificacion
   extends Omit<Partial<INotificacion>, OmitirUpdate> {}

--- a/src/interfaces/personal-salud.ts
+++ b/src/interfaces/personal-salud.ts
@@ -1,12 +1,13 @@
-import { ICliente } from "./cliente";
+import { ICliente } from './cliente';
 
 export interface IPersonalSalud {
   _id?: string;
   idCliente?: string;
+  idsAncestros?: string[];
 
   fechaCreacion?: string;
   nombre?: string; // Nombre completo
-  rol?: "Médico" | "Enfermero";
+  rol?: 'Médico' | 'Enfermero';
   matricula?: string; // Matrícula profesional
   dni?: string;
   telefono?: string;
@@ -15,14 +16,15 @@ export interface IPersonalSalud {
 
   //Populate
   cliente?: ICliente;
+  ancestros?: ICliente[];
 }
 
-type OmitirCreate = "_id";
+type OmitirCreate = '_id';
 
 export interface ICreatePersonalSalud
   extends Omit<Partial<IPersonalSalud>, OmitirCreate> {}
 
-type OmitirUpdate = "_id";
+type OmitirUpdate = '_id';
 
 export interface IUpdatePersonalSalud
   extends Omit<Partial<IPersonalSalud>, OmitirUpdate> {}

--- a/src/interfaces/proveedor.ts
+++ b/src/interfaces/proveedor.ts
@@ -1,24 +1,26 @@
-import { ICoordenadas } from "../auxiliares";
-import { ICliente } from "./cliente";
+import { ICoordenadas } from '../auxiliares';
+import { ICliente } from './cliente';
 
-export type TipoProveedor = "Mecanico" | "Combustible";
+export type TipoProveedor = 'Mecanico' | 'Combustible';
 
 export interface IProveedor {
   _id?: string;
   tipos?: TipoProveedor[];
   idCliente?: string;
+  idsAncestros?: string[];
   nombre?: string;
   ubicacion?: ICoordenadas;
   // Populate
   cliente?: ICliente;
+  ancestros?: ICliente[];
 }
 
-type OmitirCreate = "_id" | "cliente";
+type OmitirCreate = '_id' | 'cliente';
 
 export interface ICreateProveedor
   extends Omit<Partial<IProveedor>, OmitirCreate> {}
 
-type OmitirUpdate = "_id" | "cliente";
+type OmitirUpdate = '_id' | 'cliente';
 
 export interface IUpdateProveedor
   extends Omit<Partial<IProveedor>, OmitirUpdate> {}

--- a/src/interfaces/recordatorio.ts
+++ b/src/interfaces/recordatorio.ts
@@ -8,6 +8,7 @@ export type TipoRecordatorio = 'km' | 'fecha';
 export interface IRecordatorio {
   _id?: string;
   idCliente?: string;
+  idsAncestros?: string[];
   idUsuario?: string;
   tipo?: TipoRecordatorio[];
   notificado?: boolean;
@@ -22,6 +23,7 @@ export interface IRecordatorio {
 
   // Populate
   cliente?: ICliente;
+  ancestros?: ICliente[];
   usuario?: IUsuario;
   activo?: IActivo;
   documentacion?: IDocumentacion;

--- a/src/interfaces/recorrido.ts
+++ b/src/interfaces/recorrido.ts
@@ -41,6 +41,7 @@ export interface IFranjaHoraria {
 export interface IRecorrido {
   _id?: string;
   idCliente?: string;
+  idsAncestros?: string[];
   //
   idExterno?: string;
   idGrupo?: string;
@@ -56,6 +57,7 @@ export interface IRecorrido {
   idsUbicaciones?: string[];
   // Populate
   cliente?: ICliente;
+  ancestros?: ICliente[];
   grupo?: IGrupo;
   recorrido?: ICoordenadas[];
   recorridoOl?: ICoordenadaOL[];

--- a/src/interfaces/reporte-consumo-luminaria-gpe.ts
+++ b/src/interfaces/reporte-consumo-luminaria-gpe.ts
@@ -1,5 +1,5 @@
-import { ICliente } from "./cliente";
-import { IDispositivoLorawan } from "./dispositivo-lorawan";
+import { ICliente } from './cliente';
+import { IDispositivoLorawan } from './dispositivo-lorawan';
 
 export interface IConsumoLuminariaGPE {
   corriente: number; // mA
@@ -14,6 +14,7 @@ export interface IReporteConsumoLuminariaGPE {
   _id?: string;
   fechaCreacion?: string;
   idCliente?: string;
+  idsAncestros?: string[];
   idDispositivoLorawan?: string;
   // Ids de otras entidades que tienen asignado el dispositivo
   idsAsignados?: string[];
@@ -23,15 +24,16 @@ export interface IReporteConsumoLuminariaGPE {
 
   // Virtuals
   cliente?: ICliente;
+  ancestros?: ICliente[];
   dispositivoLorawan?: IDispositivoLorawan;
 }
 
-type OmitirCreate = "_id" | "fechaCreacion" | "cliente";
+type OmitirCreate = '_id' | 'fechaCreacion' | 'cliente';
 
 export interface ICreateReporteConsumoLuminariaGPE
   extends Omit<Partial<IReporteConsumoLuminariaGPE>, OmitirCreate> {}
 
-type OmitirUpdate = "_id" | "fechaCreacion" | "cliente";
+type OmitirUpdate = '_id' | 'fechaCreacion' | 'cliente';
 
 export interface IUpdateReporteConsumoLuminariaGPE
   extends Omit<Partial<IReporteConsumoLuminariaGPE>, OmitirUpdate> {}

--- a/src/interfaces/reporte-dispositivo.ts
+++ b/src/interfaces/reporte-dispositivo.ts
@@ -1,17 +1,17 @@
-import { ICliente } from "./cliente";
-import { IDispositivoLorawan } from "./dispositivo-lorawan";
+import { ICliente } from './cliente';
+import { IDispositivoLorawan } from './dispositivo-lorawan';
 
 export type ModoForzado =
-  | "No Forzado"
-  | "Forzado Encendido"
-  | "Forzado Apagado";
+  | 'No Forzado'
+  | 'Forzado Encendido'
+  | 'Forzado Apagado';
 
 export type IModoLuminaria =
-  | "Indeterminado"
-  | "Fotocélula"
-  | "Calendario"
-  | "Manual"
-  | "GPS";
+  | 'Indeterminado'
+  | 'Fotocélula'
+  | 'Calendario'
+  | 'Manual'
+  | 'GPS';
 
 export interface IReporteLuminaria {
   // TODO: Definir los tipos de las propiedades cuando sean conocidos
@@ -44,6 +44,7 @@ export interface IReporteDispositivo {
   _id?: string;
   fechaCreacion?: string;
   idCliente?: string;
+  idsAncestros?: string[];
   idDispositivoLorawan?: string;
   // Ids de otras entidades que tienen asignado el dispositivo
   idsAsignados?: string[];
@@ -54,15 +55,16 @@ export interface IReporteDispositivo {
 
   // Virtuals
   cliente?: ICliente;
+  ancestros?: ICliente[];
   dispositivoLorawan?: IDispositivoLorawan;
 }
 
-type OmitirCreate = "_id" | "fechaCreacion" | "cliente";
+type OmitirCreate = '_id' | 'fechaCreacion' | 'cliente';
 
 export interface ICreateReporteDispositivo
   extends Omit<Partial<IReporteDispositivo>, OmitirCreate> {}
 
-type OmitirUpdate = "_id" | "fechaCreacion" | "cliente";
+type OmitirUpdate = '_id' | 'fechaCreacion' | 'cliente';
 
 export interface IUpdateReporteDispositivo
   extends Omit<Partial<IReporteDispositivo>, OmitirUpdate> {}

--- a/src/interfaces/reporte.ts
+++ b/src/interfaces/reporte.ts
@@ -1,23 +1,24 @@
-import { ICoordenadaOL, ICoordenadas, IGeoJSONPoint } from "../auxiliares";
-import { IActivo, TipoVehiculo } from "./activo";
-import { ICliente } from "./cliente";
-import { IGrupo } from "./grupo";
-import { IRecorrido } from "./recorrido";
-import { ITracker } from "./tracker";
-import { IUsuario } from "./usuario";
+import { ICoordenadaOL, ICoordenadas, IGeoJSONPoint } from '../auxiliares';
+import { IActivo, TipoVehiculo } from './activo';
+import { ICliente } from './cliente';
+import { IGrupo } from './grupo';
+import { IRecorrido } from './recorrido';
+import { ITracker } from './tracker';
+import { IUsuario } from './usuario';
 
-export type TipoTriangulacion = "GNSS" | "Wifi";
+export type TipoTriangulacion = 'GNSS' | 'Wifi';
 export interface IReporte {
   _id?: string;
   //
   idCliente?: string;
+  idsAncestros?: string[];
   idGrupo?: string;
   idTracker?: string;
   idActivo?: string;
   idRecorrido?: string;
   idChofer?: string;
   fechaCreacion?: string;
-  tipo?: "Colectivo" | "Activo" | "Tracker" | "Vehiculo";
+  tipo?: 'Colectivo' | 'Activo' | 'Tracker' | 'Vehiculo';
   geojson?: IGeoJSONPoint;
   fechaDevice?: string;
   tipoTriangulacion?: TipoTriangulacion;
@@ -45,6 +46,7 @@ export interface IReporte {
 
   // Populate
   cliente?: ICliente;
+  ancestros?: ICliente[];
   grupo?: IGrupo;
   tracker?: ITracker;
   activo?: IActivo;
@@ -55,27 +57,27 @@ export interface IReporte {
 }
 
 type OmitirCreate =
-  | "_id"
-  | "cliente"
-  | "tracker"
-  | "activo"
-  | "recorrido"
-  | "grupo"
-  | "chofer"
-  | "ubicacion"
-  | "ubicacionOl";
+  | '_id'
+  | 'cliente'
+  | 'tracker'
+  | 'activo'
+  | 'recorrido'
+  | 'grupo'
+  | 'chofer'
+  | 'ubicacion'
+  | 'ubicacionOl';
 
 export interface ICreateReporte extends Omit<Partial<IReporte>, OmitirCreate> {}
 
 type OmitirUpdate =
-  | "_id"
-  | "cliente"
-  | "tracker"
-  | "activo"
-  | "recorrido"
-  | "grupo"
-  | "chofer"
-  | "ubicacion"
-  | "ubicacionOl";
+  | '_id'
+  | 'cliente'
+  | 'tracker'
+  | 'activo'
+  | 'recorrido'
+  | 'grupo'
+  | 'chofer'
+  | 'ubicacion'
+  | 'ubicacionOl';
 
 export interface IUpdateReporte extends Omit<Partial<IReporte>, OmitirUpdate> {}

--- a/src/interfaces/servicio-contratado.ts
+++ b/src/interfaces/servicio-contratado.ts
@@ -1,22 +1,24 @@
-import { ICliente } from "./cliente";
+import { ICliente } from './cliente';
 
 export interface IServicioContratado {
   _id?: string;
   idCliente?: string;
+  idsAncestros?: string[];
   nombre?: string;
   icono?: string;
   costo?: number;
   global?: boolean;
   // Populate
   cliente?: ICliente;
+  ancestros?: ICliente[];
 }
 
-type OmitirCreate = "_id" | "cliente";
+type OmitirCreate = '_id' | 'cliente';
 
 export interface ICreateServicioContratado
   extends Omit<Partial<IServicioContratado>, OmitirCreate> {}
 
-type OmitirUpdate = "_id" | "cliente";
+type OmitirUpdate = '_id' | 'cliente';
 
 export interface IUpdateServicioContratado
   extends Omit<Partial<IServicioContratado>, OmitirUpdate> {}

--- a/src/interfaces/servicio.ts
+++ b/src/interfaces/servicio.ts
@@ -9,6 +9,7 @@ export interface IServicio {
   _id?: string;
   tipo?: TipoServicio;
   idCliente?: string;
+  idsAncestros?: string[];
   idActivo?: string;
   fechaRealizacion?: string;
   fechaCreacion?: string;
@@ -19,6 +20,7 @@ export interface IServicio {
   idProveedor?: string;
   // Populate
   cliente?: ICliente;
+  ancestros?: ICliente[];
   proveedor?: IProveedor;
   activo?: IActivo;
 }

--- a/src/interfaces/soap.ts
+++ b/src/interfaces/soap.ts
@@ -1,8 +1,9 @@
-import { ICliente } from "./cliente";
+import { ICliente } from './cliente';
 
 export interface ISoap {
   _id?: string;
   idCliente?: string;
+  idsAncestros?: string[];
   fechaCreacion?: string;
 
   alta?: ISoapAlta;
@@ -15,13 +16,14 @@ export interface ISoap {
 
   // Populate
   cliente?: ICliente;
+  ancestros?: ICliente[];
 }
 
-type OmitirCreate = "_id" | "cliente";
+type OmitirCreate = '_id' | 'cliente';
 
 export interface ICreateSoap extends Omit<Partial<ISoap>, OmitirCreate> {}
 
-type OmitirUpdate = "_id" | "cliente";
+type OmitirUpdate = '_id' | 'cliente';
 
 export interface IUpdateSoap extends Omit<Partial<ISoap>, OmitirUpdate> {}
 

--- a/src/interfaces/tipo-evento.ts
+++ b/src/interfaces/tipo-evento.ts
@@ -1,6 +1,6 @@
-import { ICliente } from "./cliente";
+import { ICliente } from './cliente';
 
-export type ICategoriaTipoEvento = "Alarma" | "Tracker" | "Luminaria";
+export type ICategoriaTipoEvento = 'Alarma' | 'Tracker' | 'Luminaria';
 
 export interface ITipoEvento {
   _id?: string;
@@ -8,18 +8,20 @@ export interface ITipoEvento {
   nombre?: string;
   categoria?: ICategoriaTipoEvento;
   idCliente?: string;
+  idsAncestros?: string[];
   default?: boolean;
   global?: boolean;
   //Populate
   cliente?: ICliente;
+  ancestros?: ICliente[];
 }
 
-type OmitirCreate = "_id" | "cliente";
+type OmitirCreate = '_id' | 'cliente';
 
 export interface ICreateTipoEvento
   extends Omit<Partial<ITipoEvento>, OmitirCreate> {}
 
-type OmitirUpdate = "_id" | "cliente";
+type OmitirUpdate = '_id' | 'cliente';
 
 export interface IUpdateTipoEvento
   extends Omit<Partial<ITipoEvento>, OmitirUpdate> {}

--- a/src/interfaces/trackeo.ts
+++ b/src/interfaces/trackeo.ts
@@ -1,12 +1,13 @@
-import { IActivo } from "./activo";
-import { ICliente } from "./cliente";
-import { IGrupo } from "./grupo";
-import { IParada, IRecorrido } from "./recorrido";
+import { IActivo } from './activo';
+import { ICliente } from './cliente';
+import { IGrupo } from './grupo';
+import { IParada, IRecorrido } from './recorrido';
 
 export interface ITrackeo {
   _id?: string;
   //
   idCliente?: string;
+  idsAncestros?: string[];
   idGrupo?: string;
   idRecorrido?: string;
   idActivo?: string;
@@ -19,6 +20,7 @@ export interface ITrackeo {
 
   // Populate
   cliente?: ICliente;
+  ancestros?: ICliente[];
   grupo?: IGrupo;
   activo?: IActivo;
   recorrido?: IRecorrido;
@@ -27,23 +29,23 @@ export interface ITrackeo {
 }
 
 type OmitirCreate =
-  | "_id"
-  | "cliente"
-  | "grupo"
-  | "activo"
-  | "recorrido"
-  | "parada"
-  | "proximaParada";
+  | '_id'
+  | 'cliente'
+  | 'grupo'
+  | 'activo'
+  | 'recorrido'
+  | 'parada'
+  | 'proximaParada';
 
 export interface ICreateTrackeo extends Omit<Partial<ITrackeo>, OmitirCreate> {}
 
 type OmitirUpdate =
-  | "_id"
-  | "cliente"
-  | "grupo"
-  | "activo"
-  | "recorrido"
-  | "parada"
-  | "proximaParada";
+  | '_id'
+  | 'cliente'
+  | 'grupo'
+  | 'activo'
+  | 'recorrido'
+  | 'parada'
+  | 'proximaParada';
 
 export interface IUpdateTrackeo extends Omit<Partial<ITrackeo>, OmitirUpdate> {}

--- a/src/interfaces/tracker.ts
+++ b/src/interfaces/tracker.ts
@@ -1,11 +1,11 @@
-import { IActivo } from "./activo";
-import { ICliente } from "./cliente";
-import { ISim } from "./dispositivo-alarma";
-import { estadoCuenta } from "./estado-entidad";
-import { IModeloDispositivo } from "./modelo-dispositivo";
-import { IServicioContratado } from "./servicio-contratado";
+import { IActivo } from './activo';
+import { ICliente } from './cliente';
+import { ISim } from './dispositivo-alarma';
+import { estadoCuenta } from './estado-entidad';
+import { IModeloDispositivo } from './modelo-dispositivo';
+import { IServicioContratado } from './servicio-contratado';
 
-export type TipoTracker = "Qualcomm" | "Traccar" | "T1000-B" | "Telefono";
+export type TipoTracker = 'Qualcomm' | 'Traccar' | 'T1000-B' | 'Telefono';
 export interface ITraccarDevice {
   // Datos de traccar
   id?: number;
@@ -42,6 +42,7 @@ export interface ITracker {
   fechaAlta?: string;
   imagenes?: string[];
   idCliente?: string;
+  idsAncestros?: string[];
   idsClientesQuePuedenAtenderEventos?: string[];
   idsClientesQuePuedenAtenderEventosTecnicos?: string[];
   idModelo?: string;
@@ -66,25 +67,26 @@ export interface ITracker {
   idServiciosContratados?: string[];
   // Populate
   cliente?: ICliente;
+  ancestros?: ICliente[];
   activo?: IActivo;
   modelo?: IModeloDispositivo;
   serviciosContratados?: IServicioContratado[];
 }
 
 type OmitirCreate =
-  | "_id"
-  | "cliente"
-  | "activo"
-  | "modelo"
-  | "serviciosContratados";
+  | '_id'
+  | 'cliente'
+  | 'activo'
+  | 'modelo'
+  | 'serviciosContratados';
 
 export interface ICreateTracker extends Omit<Partial<ITracker>, OmitirCreate> {}
 
 type OmitirUpdate =
-  | "_id"
-  | "cliente"
-  | "activo"
-  | "modelo"
-  | "serviciosContratados";
+  | '_id'
+  | 'cliente'
+  | 'activo'
+  | 'modelo'
+  | 'serviciosContratados';
 
 export interface IUpdateTracker extends Omit<Partial<ITracker>, OmitirUpdate> {}

--- a/src/interfaces/ubicacion.ts
+++ b/src/interfaces/ubicacion.ts
@@ -1,12 +1,13 @@
-import { IGeoJSON } from "../auxiliares";
-import { ICliente } from "./cliente";
+import { IGeoJSON } from '../auxiliares';
+import { ICliente } from './cliente';
 
-export type ICategoriaUbicacion = "Normal" | "Terminal" | "Domicilio";
+export type ICategoriaUbicacion = 'Normal' | 'Terminal' | 'Domicilio';
 
 export interface IUbicacion {
   _id?: string;
   //
   idCliente?: string;
+  idsAncestros?: string[];
   identificacion?: string;
   fechaCreacion?: string;
   categoria?: ICategoriaUbicacion;
@@ -15,12 +16,13 @@ export interface IUbicacion {
   fotos?: string[];
   // Virtuals
   cliente?: ICliente;
+  ancestros?: ICliente[];
 }
 
-type OmitirCreate = "_id" | "cliente";
+type OmitirCreate = '_id' | 'cliente';
 export interface ICreateUbicacion
   extends Omit<Partial<IUbicacion>, OmitirCreate> {}
 
-type OmitirUpdate = "_id" | "cliente";
+type OmitirUpdate = '_id' | 'cliente';
 export interface IUpdateUbicacion
   extends Omit<Partial<IUbicacion>, OmitirUpdate> {}

--- a/src/interfaces/usuario.ts
+++ b/src/interfaces/usuario.ts
@@ -1,16 +1,16 @@
-import { ICliente } from "./cliente";
+import { ICliente } from './cliente';
 
 export type Rol =
-  | "Administrador"
-  | "Operador"
-  | "Conductor"
-  | "Chofer Colectivo"
-  | "Consultor"
-  | "Técnico"
-  | "Final"
-  | "Coordinador Emergencias"
-  | "Registrador Emergencias"
-  | "Móvil Emergencias";
+  | 'Administrador'
+  | 'Operador'
+  | 'Conductor'
+  | 'Chofer Colectivo'
+  | 'Consultor'
+  | 'Técnico'
+  | 'Final'
+  | 'Coordinador Emergencias'
+  | 'Registrador Emergencias'
+  | 'Móvil Emergencias';
 
 export interface IModulos {
   moduloColectivos?: boolean;
@@ -51,18 +51,21 @@ export interface IClaveUsuarioAlarma {
 
 export interface IPermiso {
   idCliente?: string;
+  idsAncestros?: string[];
   idsEntidades?: string[];
   roles?: Rol[];
   modulos?: IModulos;
   activo?: boolean;
   // Virtual
   cliente?: ICliente;
+  ancestros?: ICliente[];
 }
 
 export interface IUsuario {
   _id?: string;
   identificacionInterna?: string;
   idCliente?: string;
+  idsAncestros?: string[];
   permisos?: IPermiso[];
   //
   idExterno?: string;
@@ -73,12 +76,13 @@ export interface IUsuario {
   config?: IConfigUsuario;
   // Populate
   cliente?: ICliente;
+  ancestros?: ICliente[];
 }
 
-type OmitirCreate = "_id" | "cliente" | "fechaCreacion";
+type OmitirCreate = '_id' | 'cliente' | 'fechaCreacion';
 
 export interface ICreateUsuario extends Omit<Partial<IUsuario>, OmitirCreate> {}
 
-type OmitirUpdate = "_id" | "cliente" | "fechaCreacion";
+type OmitirUpdate = '_id' | 'cliente' | 'fechaCreacion';
 
 export interface IUpdateUsuario extends Omit<Partial<IUsuario>, OmitirUpdate> {}


### PR DESCRIPTION
…tros and ancestros properties where applicable

- Updated string literals in interfaces to use single quotes instead of double quotes for consistency.
- Added `idsAncestros` and `ancestros` properties to multiple interfaces to enhance data structure and relationships.