### PR TITLE
style(interfaces): standardize string quotes in activo interface

### DIFF
--- a/src/interfaces/activo.ts
+++ b/src/interfaces/activo.ts
@@ -1,36 +1,36 @@
-import { ICliente } from './cliente';
-import { IModoDesactivado } from './dispositivo-alarma';
-import { estadoCuenta } from './estado-entidad';
-import { IGrupo } from './grupo';
-import { IRecorrido } from './recorrido';
-import { ITracker } from './tracker';
-import { IUsuario } from './usuario';
+import { ICliente } from "./cliente";
+import { IModoDesactivado } from "./dispositivo-alarma";
+import { estadoCuenta } from "./estado-entidad";
+import { IGrupo } from "./grupo";
+import { IRecorrido } from "./recorrido";
+import { ITracker } from "./tracker";
+import { IUsuario } from "./usuario";
 
 export type TipoVehiculo =
-  | 'Colectivo'
-  | 'Camion'
-  | 'Moto'
-  | 'Auto'
-  | 'Grua'
-  | 'Otro';
+  | "Colectivo"
+  | "Camion"
+  | "Moto"
+  | "Auto"
+  | "Grua"
+  | "Otro";
 
 export type FuncionActivo =
-  | 'Transporte'
-  | 'Bomberos'
-  | 'Mantenimiento'
-  | 'Policia'
-  | 'Particular'
-  | 'Ambulancia'
-  | 'Seguridad Privada'
-  | 'Servicio Técnico'
-  | 'Otro';
+  | "Transporte"
+  | "Bomberos"
+  | "Mantenimiento"
+  | "Policia"
+  | "Particular"
+  | "Ambulancia"
+  | "Seguridad Privada"
+  | "Servicio Técnico"
+  | "Otro";
 
 export type EstadoVehiculo =
-  | 'Operativo'
-  | 'En mantenimiento'
-  | 'Fuera de servicio';
+  | "Operativo"
+  | "En mantenimiento"
+  | "Fuera de servicio";
 
-export type ICategoriaActivo = 'Normal' | 'Vehículo';
+export type ICategoriaActivo = "Normal" | "Vehículo";
 
 export interface IVehiculo {
   tipo?: TipoVehiculo;
@@ -39,6 +39,8 @@ export interface IVehiculo {
   modelo?: string;
   marca?: string;
   anio?: string;
+  fechaAlta?: string;
+  imagenes?: string[];
   //
   idChofer?: string;
   idRecorrido?: string;
@@ -78,10 +80,10 @@ export interface IActivo {
   grupo?: IGrupo;
 }
 
-type OmitirCreate = '_id' | 'cliente' | 'tracker';
+type OmitirCreate = "_id" | "cliente" | "tracker";
 
 export interface ICreateActivo extends Omit<Partial<IActivo>, OmitirCreate> {}
 
-type OmitirUpdate = '_id' | 'cliente' | 'tracker';
+type OmitirUpdate = "_id" | "cliente" | "tracker";
 
 export interface IUpdateActivo extends Omit<Partial<IActivo>, OmitirUpdate> {}


### PR DESCRIPTION
The change replaces single quotes with double quotes for string literals and type definitions to maintain consistency across the codebase. Also adds new fields 'fechaAlta' and 'imagenes' to IVehiculo interface.