### PR TITLE
feat(tema): interfaces para temáticas estéticas configurables

### DIFF
--- a/src/interfaces/index.ts
+++ b/src/interfaces/index.ts
@@ -69,3 +69,4 @@ export * from './log-generico';
 export * from './rol';
 export * from './auditoria';
 export * from './listado-categoria';
+export * from './tema';

--- a/src/interfaces/tema.ts
+++ b/src/interfaces/tema.ts
@@ -1,0 +1,86 @@
+import { ICliente } from './cliente';
+
+export type IMotorEfectoFullscreen = 'particulas';
+
+export interface IRangoNumerico {
+  min: number;
+  max: number;
+}
+
+export interface IDiaMes {
+  mes: number; // 0-11
+  dia: number; // 1-31
+}
+
+export interface IRangoRecurrenteAnual {
+  inicio: IDiaMes;
+  fin: IDiaMes;
+}
+
+export interface IDecal {
+  urlAsset: string;
+  tamañoPct?: number; // 0-100
+}
+
+export interface IEfectoFullscreen {
+  motor: IMotorEfectoFullscreen;
+  spriteUrl: string;
+  cantidad: number; // 1-128
+  velocidad: IRangoNumerico; // segundos por ciclo
+  tamano: IRangoNumerico; // pixeles
+  drift: number; // pixeles laterales (0 = caída recta)
+  paleta?: string[]; // hex tints opcionales
+}
+
+export interface ITemaPayload {
+  decalAvatar?: IDecal;
+  decalLogoLogin?: IDecal;
+  decalTopbar?: IDecal;
+  decalLogin?: IDecal;
+  efectoFullscreen?: IEfectoFullscreen;
+}
+
+export interface ITema {
+  _id?: string;
+  //
+  nombre?: string;
+  descripcion?: string;
+  activa?: boolean;
+  fechaInicio?: string;
+  fechaFin?: string;
+  diasRecurrentes?: IRangoRecurrenteAnual;
+  prioridad?: number; // 0-100
+  global?: boolean;
+  idCliente?: string;
+  idsAncestros?: string[];
+  payload?: ITemaPayload;
+  fechaCreacion?: string;
+  fechaActualizacion?: string;
+  // Populate
+  cliente?: ICliente;
+  ancestros?: ICliente[];
+}
+
+type OmitirCreate = '_id' | 'cliente' | 'ancestros' | 'fechaCreacion' | 'fechaActualizacion';
+
+export interface ICreateTema extends Omit<
+  Partial<ITema>,
+  OmitirCreate
+> {}
+
+type OmitirUpdate = '_id' | 'cliente' | 'ancestros' | 'fechaCreacion' | 'fechaActualizacion';
+
+export interface IUpdateTema extends Omit<
+  Partial<ITema>,
+  OmitirUpdate
+> {}
+
+export interface ITemaCache extends Omit<
+  ITema,
+  'cliente' | 'ancestros'
+> {}
+
+export interface ITemaPublico extends Omit<
+  ITema,
+  'cliente' | 'ancestros' | 'idCliente' | 'idsAncestros' | 'fechaCreacion' | 'fechaActualizacion'
+> {}


### PR DESCRIPTION
## Summary

Fase 0 del plan de **temáticas estéticas configurables** para IRIX. Agrega interfaces TS compartidas para soportar el nuevo recurso `Tema` (gestionable por admin root nivel-0).

### Tipos agregados

- `ITema` — recurso principal con activación, fechas absolutas, fechas recurrentes anuales (`IRangoRecurrenteAnual`), prioridad y payload.
- `ITemaPayload` — assets a aplicar en los 4 puntos visuales: avatar, logo login, topbar, form login + efecto fullscreen.
- `IDecal` — referencia a asset (URL pública) + tamaño porcentual.
- `IEfectoFullscreen` — motor (`IMotorEfectoFullscreen` = `'particulas'` en V1) + sprite + parámetros de partículas (cantidad, velocidad, tamaño, drift, paleta).
- Auxiliares: `IRangoNumerico`, `IDiaMes`.
- Variantes `ICreateTema`, `IUpdateTema`, `ITemaCache`, `ITemaPublico` siguiendo el patrón existente del repo (ver `IListadoCategoria`).

### Notas

- `idCliente` / `idsAncestros` quedan en el modelo sin uso en V1 (solo se usan temas con `global: true`). Habilitan extensión V2 con temas por subárbol sin nuevo cambio de modelo.
- Sin breaking changes — solo agregados.

## Test plan

- [ ] Mergear este PR.
- [ ] En repos consumidores correr `npm run modelos` para actualizar la dependencia.
- [ ] Continuar con Fase 1 (backend `gestion-api-gestion`) y Fase 2 (panel admin `gestion-web-cliente`) que dependen de estas interfaces.

🤖 Generated with [Claude Code](https://claude.com/claude-code)