### PR TITLE
fix(tema): renombrar IDecal.tamañoPct → tamanoPct

### DIFF
--- a/src/interfaces/tema.ts
+++ b/src/interfaces/tema.ts
@@ -19,7 +19,7 @@ export interface IRangoRecurrenteAnual {
 
 export interface IDecal {
   urlAsset: string;
-  tamañoPct?: number; // 0-100
+  tamanoPct?: number; // 0-100
 }
 
 export interface IEfectoFullscreen {


### PR DESCRIPTION
## Summary

Pequeño fix de naming. El parser de templates Angular no soporta acceso encadenado a propiedades con caracteres no-ASCII (ñ) en expresiones complejas tipo:

\`\`\`
[style.height.%]="(tema\$ | async)?.payload?.decalTopbar?.tamañoPct ?? 70"
\`\`\`

falla con \`TS2339 Property 'tama' does not exist on type 'IDecal'\` (el parser corta la palabra en la ñ).

Renombrar a \`tamanoPct\` (sin ñ) elimina el problema y queda alineado con el campo \`tamano\` ya usado en \`IRangoNumerico\` del efectoFullscreen del mismo modelo.

Cambio mínimo: 1 línea.

## Test plan

- [ ] Mergear.
- [ ] \`npm run modelos\` en gestion-api-datos y gestion-api-gestion (luego redeploy a test).
- [ ] \`npm run modelos\` en gestion-web-cliente (paralelo, luego refactor del código que aún usa el nombre viejo).

🤖 Generated with [Claude Code](https://claude.com/claude-code)