### PR TITLE
feat: agregar comunicador UNICOM (WiFi DUO) — tipos additive

### DIFF
--- a/src/interfaces/dispositivo-alarma.ts
+++ b/src/interfaces/dispositivo-alarma.ts
@@ -52,6 +52,11 @@ export interface ISensorPorZona {
   marca?: string;
   tipo?: CodigoTipoSensor;
   modelo?: string;
+  // UNICOM (sensores RF inalámbricos). El panel guarda por sensor el código RF
+  // (3 bytes) + un atributo que codifica el modo de zona (attr = 0x10 + code).
+  codigoRf?: string; // 6 hex (3 bytes), ej. "AABBCC"
+  modoRf?: string; // modo de zona UNICOM "R###" (Interior, Entrada/Salida, Perimetral, ...)
+  attrRf?: number; // byte de atributo (0x10 + code del modo)
 }
 export interface IParticionZona {
   nombre?: string;
@@ -98,6 +103,30 @@ export type CodigoTipoSensor =
   | 'AMK';
 export type ModoSensor = 'Seguidor' | 'Demorado' | 'Instantaneo';
 export type Operador = 'Personal' | 'Claro' | 'Movistar' | 'Tuenti' | 'Otro';
+
+/// UNICOM "WiFi DUO" ──────────────────────────────────────────────
+/// Comunicador WiFi (no SIM) que opera por MQTT contra el broker propio
+/// de IRIX. Modos de armado del panel (selectivo = total excluyendo zonas).
+export type ModoArmadoUnicom = 'Total' | 'Perimetral' | 'Selectivo' | 'Desarmado';
+
+export interface IEstadoArmadoUnicom {
+  modo?: ModoArmadoUnicom;
+  zonasExcluidas?: number[]; // solo para 'Selectivo' (zonas excluidas del armado)
+  actualizado?: string; // fecha ISO del último cambio de estado conocido
+}
+
+/// Config por dispositivo del comunicador UNICOM. La identidad es el devid
+/// (= idUnicoComunicador, "uw"+MAC). El broker/credenciales son de flota y
+/// viven a nivel backend (env), NO por dispositivo en DB. Los topics se
+/// derivan del devid (cmd/<devid>, dev/uw/0001/<devid>).
+export interface IConfigComunicadorUnicom {
+  devid?: string; // "uw"+MAC (redundante con idUnicoComunicador, por claridad)
+  canal?: string; // "chan" del firmware (ej. "dev")
+  topicCmd?: string; // override opcional del topic de comandos
+  topicDev?: string; // override opcional del topic de eventos
+  tls?: boolean; // reservado: hoy plaintext, TLS es mejora futura
+}
+
 export interface IDispositivoAlarma {
   _id?: string;
   //
@@ -124,6 +153,10 @@ export interface IDispositivoAlarma {
   idsCamaras?: string[];
   armado?: boolean[];
   armando?: string;
+  // UNICOM: estado de armado con semántica propia (total/perimetral/selectivo).
+  // Additive — NO reemplaza `armado`/`TiposDeArmado` (uso productivo de otras alarmas).
+  estadoArmadoUnicom?: IEstadoArmadoUnicom;
+  configUnicom?: IConfigComunicadorUnicom;
   imagenes?: string[];
   ultimaConexion?: IUltimaConexion;
   modoDesactivado?: IModoDesactivado;

--- a/src/interfaces/evento-generico.ts
+++ b/src/interfaces/evento-generico.ts
@@ -1,7 +1,7 @@
 // evento-generico.ts
 import { ICliente, IConfigHorario } from './cliente';
 import { ITracker } from './tracker';
-import { IDispositivoAlarma } from './dispositivo-alarma';
+import { IDispositivoAlarma, ModoArmadoUnicom } from './dispositivo-alarma';
 import { IActivo } from './activo';
 import { IConfigEventoUsuario } from './config-evento-usuario';
 import { SonidoEvento } from './categoria-evento';
@@ -144,6 +144,12 @@ export interface IValoresEventoAlarma extends IValoresEventoBase {
   codigoAlarma?: string;
   codigoComunicador?: string;
   tiposEvento?: ('Armado' | 'Desarmado' | 'Detonación' | 'Test')[];
+  // UNICOM (additive): datos crudos del evento MQTT para trazabilidad/diagnóstico.
+  cidUnicom?: string; // "<estado> <opcode>" original, ej. "3 407"
+  opcodeUnicom?: string; // opcode del cid, ej. "407"
+  modoArmado?: ModoArmadoUnicom; // si el evento es de armado/desarmado
+  idSensor?: number; // índice del sensor en reportes 1 606 / disparos 1 134
+  crf?: string; // 8 hex del reporte de sensor (código RF + attr)
 }
 
 export interface IValoresEventoLuminaria extends IValoresEventoBase {

--- a/src/interfaces/modelo-dispositivo.ts
+++ b/src/interfaces/modelo-dispositivo.ts
@@ -9,7 +9,11 @@ export type FormatosMensajeComunicador =
   | 'Garnet'
   | 'Dahua'
   | 'Hikvision'
-  | 'Intelbras';
+  | 'Intelbras'
+  // UNICOM "WiFi DUO": comunicador WiFi (AVR128 + ESP32) que habla MQTT
+  // contra el broker propio de IRIX. NO usa SIM/GPRS (sim1/sim2/numeroAbonado
+  // quedan vacíos); su identidad es el devid en idUnicoComunicador.
+  | 'UNICOM';
 
 export type NivelDimerizacion =
   | 'dim10'


### PR DESCRIPTION
## Qué

Fase 0 del plan de integración de la alarma **UNICOM "WiFi DUO"** en IRIX: tipos compartidos en `gestion-modelos` para que el resto de los servicios (api-datos, api-alarmas, IRIX Mobile) puedan consumirlos.

UNICOM es un comunicador **WiFi** (dos micros: AVR128DA48 + ESP32) que opera por **MQTT** contra el broker propio de IRIX. **No usa SIM/GPRS.**

## Cambios (additive-only, todo opcional)

- **`modelo-dispositivo.ts`** — `'UNICOM'` en `FormatosMensajeComunicador`.
- **`dispositivo-alarma.ts`**
  - `ModoArmadoUnicom` (`Total`/`Perimetral`/`Selectivo`/`Desarmado`)
  - `IEstadoArmadoUnicom` (`modo`, `zonasExcluidas`, `actualizado`)
  - `IConfigComunicadorUnicom` (devid, canal, topics; broker/creds son de flota a nivel backend, no por device)
  - campos RF en `ISensorPorZona`: `codigoRf` / `modoRf` / `attrRf`
  - `estadoArmadoUnicom?` y `configUnicom?` en `IDispositivoAlarma`
- **`evento-generico.ts`** — `IValoresEventoAlarma` enriquecido: `cidUnicom` / `opcodeUnicom` / `modoArmado` / `idSensor` / `crf`.

## Garantías

- **Additive-only**: NO toca `armado` / `TiposDeArmado` ni ningún tipo productivo.
- `ICreate*` / `IUpdate*` / `*Cache` se derivan solos (`Omit<Partial<…>>`); exports vía `export *`.
- `sim1`/`sim2`/`numeroAbonado` ya son opcionales → el caso "sin SIM" no requiere cambio de modelo.
- Compila: `tsc --noEmit` exit 0.

## Contexto

Plan completo: `PLAN_IMPLEMENTACION_UNICOM_IRIX.md`. Doc de la RE: `gestion-doc-alarmas/alarmas-unicom/`.

Decisiones ratificadas: broker propio (EMQX `mensajero`), plaintext 61613 (TLS diferido), creds de flota compartidas, provisioning SoftAP+HTTP.

🤖 Generated with [Claude Code](https://claude.com/claude-code)