### PR TITLE
feat(unicom): IUltimoEstadoUnicom (estado energía/panel)

### DIFF
--- a/src/interfaces/dispositivo-alarma.ts
+++ b/src/interfaces/dispositivo-alarma.ts
@@ -115,6 +115,19 @@ export interface IEstadoArmadoUnicom {
   actualizado?: string; // fecha ISO del último cambio de estado conocido
 }
 
+/// Último estado de energía/panel del UNICOM, decodificado del bitmask `sts` que el equipo
+/// reporta por MQTT. Lo persiste el gateway (gestion-api-alarmas) en el doc para que el resto
+/// del sistema (p.ej. consultarEstado → indicadores batería/220V) lo lea sin depender del broker.
+export interface IUltimoEstadoUnicom {
+  hay220v?: boolean; // false = falta de energía (corte 220V)
+  bateriaBaja?: boolean;
+  armadoTotal?: boolean;
+  perimetral?: boolean;
+  disparo?: boolean;
+  sirena?: boolean;
+  fecha?: string; // ISO del último sts procesado
+}
+
 /// Config por dispositivo del comunicador UNICOM. La identidad es el devid
 /// (= idUnicoComunicador, "uw"+MAC). El broker/credenciales son de flota y
 /// viven a nivel backend (env), NO por dispositivo en DB. Los topics se
@@ -157,6 +170,8 @@ export interface IDispositivoAlarma {
   // Additive — NO reemplaza `armado`/`TiposDeArmado` (uso productivo de otras alarmas).
   estadoArmadoUnicom?: IEstadoArmadoUnicom;
   configUnicom?: IConfigComunicadorUnicom;
+  // UNICOM: último estado de energía/panel decodificado del `sts` (persistido por el gateway).
+  ultimoEstadoUnicom?: IUltimoEstadoUnicom;
   imagenes?: string[];
   ultimaConexion?: IUltimaConexion;
   modoDesactivado?: IModoDesactivado;


### PR DESCRIPTION
Agrega `IUltimoEstadoUnicom` (hay220v/bateriaBaja/armadoTotal/perimetral/disparo/sirena/fecha) y el campo `ultimoEstadoUnicom` en `IDispositivoAlarma`, decodificado del `sts` del equipo.

Lo persiste el gateway (gestion-api-alarmas) para que `consultarEstado` (gestion-api-gestion) devuelva batería/220V sin acceso al Redis del gateway.

⚠️ **Mergear ESTE primero** — los consumers (gestion-api-datos / -alarmas / -gestion) no compilan hasta que su dep `modelos` (#main) tenga el campo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)