### PR TITLE
Atención múltiple de eventos: config de cliente + tipos de atención atómica

### DIFF
--- a/src/interfaces/cliente.ts
+++ b/src/interfaces/cliente.ts
@@ -57,6 +57,10 @@ export interface IConfigCliente {
   idsClientesQuePuedenAtenderEventos?: string[];
   idsClientesQuePuedenAtenderEventosTecnicos?: string[];
   configHorarioAtencion?: IConfigHorario;
+  /** Si es true, los operadores de este cliente pueden sumarse a atender
+   *  eventos que ya están siendo atendidos por otro operador.
+   *  Default false: solo un operador atiende a la vez (lock). */
+  atencionMultipleEventos?: boolean;
   solicitantesEmergencias?: string[];
   solicitantePredeterminado?: string;
   credencialesAlarmas?: ICredencialesAlarma[];

--- a/src/interfaces/evento-generico.ts
+++ b/src/interfaces/evento-generico.ts
@@ -327,6 +327,7 @@ export interface IEventoBaseGenerico<T extends keyof MapaEventoGenerico> {
   // Populate opcional
   cliente?: ICliente;
   ancestros?: ICliente[];
+  usuariosAtendiendo?: IUsuario[];
   // idEntidad
   tracker?: ITracker;
   alarma?: IDispositivoAlarma;
@@ -410,6 +411,7 @@ type OmitirCreate =
   | 'requiereAtencion'
   | 'cliente'
   | 'ancestros'
+  | 'usuariosAtendiendo'
   | 'tracker'
   | 'alarma'
   | 'luminaria'
@@ -530,6 +532,7 @@ export type IEventoGenericoCache = Omit<
   IEventoGenerico,
   | 'cliente'
   | 'ancestros'
+  | 'usuariosAtendiendo'
   | 'tracker'
   | 'vehiculo'
   | 'alarma'

--- a/src/interfaces/evento-generico.ts
+++ b/src/interfaces/evento-generico.ts
@@ -525,6 +525,27 @@ export type IUpdateEventoGenerico =
     >);
 
 /* ────────────────────────────────────────────────
+ *  ATENCIÓN (arrays idsUsuariosAtendiendo / idsClientesAtendiendo)
+ * ────────────────────────────────────────────────*/
+
+export type AccionAtencionEvento = 'atender' | 'desatender' | 'limpiar';
+
+/** Body de PUT /eventos-genericos/:id/atencion (api-datos).
+ *  Actualiza estado + arrays de atención en una sola operación atómica
+ *  ($addToSet/$pull), sin ventana de carrera entre operadores. */
+export interface IActualizarAtencionEventoGenerico {
+  accion: AccionAtencionEvento;
+  idUsuario: string;
+  idCliente: string;
+  estado: EstadoEvento;
+  /** Solo para 'limpiar' (En Espera) */
+  posponerHasta?: string;
+  /** Solo para 'atender': si es true, falla con 409 si otro usuario ya está
+   *  atendiendo (lock de atención única). */
+  exclusivo?: boolean;
+}
+
+/* ────────────────────────────────────────────────
  *  TIPO CACHE (SIN POPULATE)
  * ────────────────────────────────────────────────*/
 


### PR DESCRIPTION
## Cambios

- `IConfigCliente.atencionMultipleEventos?: boolean` — default `false`: solo un operador atiende a la vez (lock). Con `true`, los operadores del cliente pueden sumarse a eventos ya atendidos.
- `IEventoBaseGenerico.usuariosAtendiendo?: IUsuario[]` — populate de `idsUsuariosAtendiendo` para mostrar quién atiende.
- `IActualizarAtencionEventoGenerico` — body del endpoint atómico `PUT /eventos-genericos/:id/atencion` de api-datos (acciones `atender`/`desatender`/`limpiar`, flag `exclusivo`).

Parte 1/4 de atención múltiple de eventos. Orden de merge: **modelos → api-datos → api-gestion → web-cliente**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)