### PR TITLE
Acción 'Eventos - Ver eventos en atención'

### DIFF
--- a/src/interfaces/rol.ts
+++ b/src/interfaces/rol.ts
@@ -7,6 +7,9 @@ export type AccionesRol =
   | 'Eventos - Ver eventos'
   | 'Eventos - Atender eventos'
   | 'Eventos - Finalizar eventos'
+  // Ver en el listado los eventos que otro operador ya está atendiendo
+  // (sin esta acción, en modo atención simple, se ocultan)
+  | 'Eventos - Ver eventos en atención'
   // *******************************************
   // LOGS
   // *******************************************


### PR DESCRIPTION
Acción de rol nueva: quien la tiene ve en el listado Pendientes los eventos que otro operador ya está atendiendo (en modo atención simple se ocultan para el resto; en modo múltiple no aplica).

Complementa la atención múltiple de eventos (#337). Los roles Administrador existentes la reciben por seed automático en api-datos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)