### PR TITLE
feat(eventos): usuario generador en valores de evento de alarma

### DIFF
--- a/src/interfaces/evento-generico.ts
+++ b/src/interfaces/evento-generico.ts
@@ -145,6 +145,10 @@ export interface IValoresEventoAlarma extends IValoresEventoBase {
   codigoAlarma?: string;
   codigoComunicador?: string;
   tiposEvento?: ('Armado' | 'Desarmado' | 'Detonación' | 'Test')[];
+  // Usuario que generó el armado/desarmado. Ausentes si no se pudo resolver
+  // (armado rápido/llave/automático, zona sin contacto configurado, eventos históricos).
+  idUsuario?: string; // Solo si se resolvió a un IUsuario de la plataforma
+  usuario?: string; // Nombre ya resuelto (denormalizado): IUsuario, contacto del panel o "Usuario N"
   // UNICOM (additive): datos crudos del evento MQTT para trazabilidad/diagnóstico.
   cidUnicom?: string; // "<estado> <opcode>" original, ej. "3 407"
   opcodeUnicom?: string; // opcode del cid, ej. "407"


### PR DESCRIPTION
## Qué

Agrega `idUsuario?` y `usuario?` (opcionales) a `IValoresEventoAlarma`, replicando el patrón ya existente en `IValoresEventoSirena`.

## Por qué

`gestion-api-alarmas` va a persistir denormalizado quién armó/desarmó la alarma en el evento genérico, para que la app mobile muestre el nombre en el listado de eventos sin lookups a `/usuarios` (los roles Final no tienen permiso para ese endpoint).

- `idUsuario`: solo si se resolvió a un usuario de la plataforma.
- `usuario`: nombre ya resuelto — usuario de la plataforma, contacto del panel, o "Usuario N".
- Ausentes = no identificado (armado rápido/llave, zona sin contacto, eventos históricos).

Cambio aditivo, backward-compatible. Sin migración (`valores` es `Object` libre en el schema).

🤖 Generated with [Claude Code](https://claude.com/claude-code)