### PR TITLE
Migración a Zod v4: schemas + tipos inferidos + OpenAPI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 dist
 **.js
+node_modules
+*.tsbuildinfo

--- a/CONSUMIDORES.md
+++ b/CONSUMIDORES.md
@@ -1,0 +1,63 @@
+# Consumidores de gestion-modelos
+
+Relevado 2026-07-17 (migración a Zod v4) grepeando `"modelos"` en los `package.json` de los repos locales de `Repos/GPE/`.
+
+> ⚠️ **Esta lista puede estar incompleta.** La fuente de verdad de lo que está
+> deployado es `Repos/GPE/DevOps/iot-cluster/` (manifiestos K8s por cliente:
+> novit, smartium, bioanalitica, oficinas, uvcarg). **Pendiente**: barrer los
+> deployments/images de iot-cluster para completar esta lista ANTES de mergear
+> a main — el hook `prepare` de la git-dep corre en el `npm install` de TODOS
+> los consumidores; si el build fallara, les rompe el install.
+
+## Consumidores locales detectados (dependencia `gestion-modelos`)
+
+| Repo | Ref | Nota |
+|------|-----|------|
+| gestion-api-alarmas | `#main` | |
+| gestion-api-cache | (default) | sin `#ref` → toma la branch default |
+| gestion-api-camaras | (default) | |
+| gestion-api-datos | `#main` | |
+| gestion-api-eventos | `#main` | |
+| gestion-api-gestion | `#main` | |
+| gestion-api-sirenas | `#main` | |
+| gestion-api-t1000b | (default) | |
+| gestion-api-trackers | (default) | deprecado (reemplazado por trackers-go), pero la dep existe |
+| gestion-api-websocket-io | (default) | |
+| gestion-cron | `#main` | |
+| gestion-lora-luminarias | `#main` | |
+| gestion-web-cliente | `#main` | Angular; `declaration: false`, `strict: true` |
+| gestion-websocket | (default) | |
+| seguridad-boton-nest | — | referencia a gestion-modelos detectada, confirmar |
+| seguridad-boton-web | — | ídem |
+
+No consumidores (usan `transporte-modelos`): gestion-api-auth, gestion-api-integraciones.
+
+## Cambios de contrato a verificar por consumidor (migración Zod)
+
+1. **`ICreateDispositivoAlarma` / `CreateDispositivoAlarmaSchema`**: el original
+   tenía el typo `'comunicador '` (espacio final) en `OmitirCreate`, por lo que
+   el Create **no** omitía `comunicador`. El schema nuevo lo omite (fix). El
+   type legacy conserva el comportamiento original. Si alguna API valida el
+   create con el schema y mandaba `comunicador`, el strip-mode lo descarta.
+2. **Enums de `externos/osrm.ts`** (`DrivingSide`, `Mode`): eran `enum` TS,
+   ahora son `z.enum` + type. Verificado que ningún consumidor los usaba como
+   valor; si alguno externo lo hiciera, debe migrar a `DrivingSideSchema.enum.Left`
+   o al literal `'left'`.
+3. **Renombres de schemas por colisión de barrel** (solo exports NUEVOS, no
+   afectan tipos existentes): `EstadoCuentaEntidadSchema` (estado-entidad),
+   `RolUsuarioSchema` (usuario), `AccessoryInfoItemSchema` (dispositivo-alarma),
+   `DeviceInfoChirpstackSchema` (chirpstack).
+4. **Schemas de reporte/evento genérico** (`ReporteGenericoSchema`,
+   `EventoGenericoSchema` y sus Create/Update): el discriminante
+   (`tipoReporte`/`tipoEvento`) es **requerido** al validar, a diferencia de los
+   tipos legacy donde es opcional. Los tipos legacy no cambiaron.
+5. El paquete ahora tiene `dependencies: { zod }` y hook `prepare` (build tsc):
+   el `npm install` del consumidor compila el paquete y hoistea zod. El import
+   `from 'modelos/src'` sigue funcionando igual.
+
+## Checklist de adopción por consumidor
+
+- [ ] `npm run modelos` (o reinstalar la dep) apuntando a la rama/main nueva
+- [ ] `npm run build` del consumidor pasa (tsc compila el fuente de modelos)
+- [ ] Si valida bodies: adoptar `CreateXSchema.safeParse(body)` en endpoints
+- [ ] Opcional NestJS: `nestjs-zod` (`createZodDto`) para Swagger

--- a/CONSUMIDORES.md
+++ b/CONSUMIDORES.md
@@ -77,6 +77,21 @@ usan `transporte-modelos`, NO este paquete.
    el `npm install` del consumidor compila el paquete y hoistea zod. El import
    `from 'modelos/src'` sigue funcionando igual.
 
+## Fricciones de adopción detectadas (probando en gestion-api-datos)
+
+La migración es transparente salvo en las **entidades que son uniones
+discriminadas** (hoy `IUbicacion`, y las genéricas reporte/evento). Al asignar
+un documento Mongoose a esos tipos, TS falla el narrowing si el paquete usa
+`z.infer` en las piezas de la union. Ya corregido en el paquete (commits de la
+rama), pero es el patrón a vigilar si se agregan uniones discriminadas nuevas:
+- discriminante = type alias de literales plano (NO `z.infer<z.enum>`)
+- `valores` de cada variante = interface hand-written (NO `z.infer<z.object>`)
+- populate hacia la union desde otra entidad = `z.custom<ITipo>()` (NO el schema)
+
+Verificado end-to-end: **gestion-api-datos compila 0 errores** (`nest build`
+genera `dist/main.js`) contra la rama, y los 6 consumidores deployados +
+api-gestion también (ver estado abajo).
+
 ## Checklist de adopción por consumidor
 
 - [ ] `npm run modelos` (o reinstalar la dep) apuntando a la rama/main nueva

--- a/CONSUMIDORES.md
+++ b/CONSUMIDORES.md
@@ -92,6 +92,23 @@ Verificado end-to-end: **gestion-api-datos compila 0 errores** (`nest build`
 genera `dist/main.js`) contra la rama, y los 6 consumidores deployados +
 api-gestion también (ver estado abajo).
 
+## Estado de verificación (build contra la rama feat/migracion-zod-v4)
+
+**18 consumidores NestJS deployados en novit: 0 errores de build cada uno.**
+api-datos + api-gestion + notificaciones + trackeo-colectivos + dispositivos-lora
++ qualcomm-aware + twilio-api + websocket-traccar + alarmas + cache + eventos +
+sirenas + t1000b + websocket-io + cron + lora-luminarias + websocket + camaras.
+
+Además, **api-datos corrió estable en el cluster de test** (imagen de la rama,
+pod Running/ready, 0 restarts, atendiendo tráfico real, sin ZodError/crash).
+
+Pendientes de verificar antes del merge:
+- **gestion-web-cliente** (Angular): validado a nivel typecheck con perfil
+  `strict:true` (0 errores); falta `ng build` real.
+- **seguridad-boton-nest** y **seguridad-boton-web** (subsistema Seguridad):
+  consumen gestion-modelos bajo el alias **`modelos-gestion`** (import
+  `modelos-gestion/src`), no `modelos`. Aplican el cambio al mergear.
+
 ## Checklist de adopción por consumidor
 
 - [ ] `npm run modelos` (o reinstalar la dep) apuntando a la rama/main nueva

--- a/CONSUMIDORES.md
+++ b/CONSUMIDORES.md
@@ -1,13 +1,32 @@
 # Consumidores de gestion-modelos
 
-Relevado 2026-07-17 (migración a Zod v4) grepeando `"modelos"` en los `package.json` de los repos locales de `Repos/GPE/`.
+Relevado 2026-07-17 (migración a Zod v4): (1) `"modelos"` en los `package.json`
+de los repos locales de `Repos/GPE/`; (2) barrido de imágenes deployadas en
+`Repos/GPE/DevOps/iot-cluster/novit/apis-gestion-irix/{gestion-prod,gestion-test}`.
 
-> ⚠️ **Esta lista puede estar incompleta.** La fuente de verdad de lo que está
-> deployado es `Repos/GPE/DevOps/iot-cluster/` (manifiestos K8s por cliente:
-> novit, smartium, bioanalitica, oficinas, uvcarg). **Pendiente**: barrer los
-> deployments/images de iot-cluster para completar esta lista ANTES de mergear
-> a main — el hook `prepare` de la git-dep corre en el `npm install` de TODOS
-> los consumidores; si el build fallara, les rompe el install.
+> El hook `prepare` de la git-dep corre en el `npm install` de TODOS los
+> consumidores; si el build de gestion-modelos fallara, les rompe el install.
+> Por eso importa la lista completa. iot-cluster hoy solo tiene el cliente
+> **novit** activo (más `acceso-coliving`, que usa acceso-modelos, no este);
+> el CLAUDE.md menciona bioanalitica/smartium/etc. pero están en `_deprecated`/
+> `_otros` o ya no se manifiestan acá.
+
+## Deployados en prod SIN repo clonado localmente (VERIFICAR)
+
+El barrido de iot-cluster encontró estos servicios NestJS corriendo en
+`gestion-prod` (y varios también en `gestion-test`) que NO tengo clonados, así
+que no pude leer su `package.json`. Son candidatos a consumir `modelos/src` y
+hay que confirmar su build contra la rama antes del merge:
+
+`gestion-api-consultas`, `gestion-api-notificaciones`,
+`gestion-api-trackeo-colectivos`, `gestion-coap`, `gestion-dispositivos-lora`,
+`gestion-irix-deeplinks`, `gestion-qualcomm-aware`, `gestion-twilio-api`,
+`gestion-websocket-traccar` (todos en prod). En test además:
+`gestion-api-reportes-truchos`.
+
+No dependen de gestion-modelos (npm): `gestion-trackers-go` (Go), y los sidecars
+externos del manifiesto (`go2rtc`, `mediaMTX`, `rtspToWeb`, `traccar`, `emqx5`,
+`loki-stack`).
 
 ## Consumidores locales detectados (dependencia `gestion-modelos`)
 
@@ -25,12 +44,15 @@ Relevado 2026-07-17 (migración a Zod v4) grepeando `"modelos"` en los `package.
 | gestion-api-websocket-io | (default) | |
 | gestion-cron | `#main` | |
 | gestion-lora-luminarias | `#main` | |
-| gestion-web-cliente | `#main` | Angular; `declaration: false`, `strict: true` |
-| gestion-websocket | (default) | |
+| gestion-web-cliente | `#main` | Angular; `declaration: false`, `strict: true`; deployado (prod+test) |
+| gestion-websocket | (default) | deployado en prod |
 | seguridad-boton-nest | — | referencia a gestion-modelos detectada, confirmar |
 | seguridad-boton-web | — | ídem |
 
-No consumidores (usan `transporte-modelos`): gestion-api-auth, gestion-api-integraciones.
+Todos los de arriba salvo trackers (deprecado) y camaras/websocket aparecen
+también en el manifiesto de prod o test de novit → deploy real, aplican el
+cambio. `gestion-api-auth` y `gestion-api-integraciones` están deployados pero
+usan `transporte-modelos`, NO este paquete.
 
 ## Cambios de contrato a verificar por consumidor (migración Zod)
 

--- a/README.md
+++ b/README.md
@@ -4,21 +4,45 @@ Modelos para el sistema de gestión: **schemas Zod v4 + tipos TypeScript inferid
 
 Cada entidad exporta su schema runtime (`ActivoSchema`, `CreateActivoSchema`, `UpdateActivoSchema`) y los tipos derivados con los mismos nombres de siempre (`IActivo`, `ICreateActivo`, `IUpdateActivo`). Los imports existentes de tipos no cambian.
 
+## ⚠️ Hay que buildearlo para usarlo
+
+Este paquete **NO se publica compilado**: `dist/` está en `.gitignore`, así que un
+checkout crudo del repo no trae los `.js`/`.d.ts`. El `main`/`types` del
+`package.json` apuntan a `dist/index.js` / `dist/index.d.ts`, que **solo existen
+después de compilar** (`npm run build` → `tsc`).
+
+Hay dos formas válidas de consumirlo, y **ambas requieren build**:
+
+1. **Import desde `modelos/src`** (lo que hacen las APIs NestJS / Angular): se
+   importa el fuente `.ts` y lo compila el **tsc del consumidor**. No necesita el
+   `dist` de este paquete, pero el consumidor debe compilar (build del servicio).
+2. **Import desde `modelos`** (entrypoint `dist`): requiere que `dist/` exista. Se
+   genera automáticamente por el hook **`prepare` → `tsc`** que corre en el
+   `npm install` / `npm ci` del consumidor (por eso el Dockerfile hace `npm ci` y
+   funciona). Si ese build fallara, **rompe el install del consumidor**.
+
+> Consecuencia operativa: cualquier cambio en modelos hay que verificarlo con
+> `npm run build` acá **y** con el build del consumidor antes de mergear. Si
+> alguna vez se consume este repo fuera de `npm install` (checkout directo),
+> correr `npm run build` primero.
+
 ## Instalación (consumidores)
 
-En `package.json` del servicio:
+En `package.json` del servicio, como git-dependency apuntando a un branch:
 
 ```json
-"modelos": "git://github.com/GPE-Sistemas/gestion-modelos.git"
+"modelos": "github:GPE-Sistemas/gestion-modelos#main"
 ```
 
-Script para actualizar:
+En este monorepo los servicios traen un script `modelos` (`sh modelo.sh <branch>`)
+para (re)apuntar y refrescar el lockfile:
 
-```json
-"modelos": "yarn upgrade modelos"
+```bash
+npm run modelos              # instala desde #main (default)
+npm run modelos feat/migracion-zod-v4   # instala desde un branch puntual
 ```
 
-El paquete se compila solo al instalarse (hook `prepare` → `tsc`). El import clásico sigue funcionando:
+El import clásico de tipos sigue funcionando sin cambios:
 
 ```typescript
 import { ICoordenadas, IActivo } from 'modelos/src';
@@ -66,3 +90,27 @@ npm run gen:json-schema -- --only=Activo --verbose
 ```
 
 Usa `z.toJSONSchema(schema, { target: 'openapi-3.0' })` nativo de Zod v4, sin librerías extra. Para Swagger en las APIs NestJS se puede usar `nestjs-zod` (`createZodDto(CreateActivoSchema)`).
+
+## Pasaje a producción (migración Zod)
+
+Los consumidores resuelven la git-dependency a un **commit fijo** en su
+`package-lock.json`, y el Dockerfile usa `npm ci` (respeta el lock exacto). Por
+eso **mergear a `main` no cambia nada en prod por sí solo**: cada consumidor
+sigue clavado a su commit hasta que refresque el lock y rebuildee su imagen.
+
+Pasos para promover la migración:
+
+1. **Mergear `feat/migracion-zod-v4` → `main`** en gestion-modelos (PR). El branch
+   está rebaseado sobre `main` (0 commits detrás) y compila (`npm run build` OK).
+2. **Por cada consumidor deployado**, en su repo:
+   - `npm run modelos` (repunta la dep a `#main` y **regenera el lock** con el
+     commit nuevo de zod). Si el consumidor estaba pineado a
+     `#feat/migracion-zod-v4` (ej. gestion-api-datos), este paso es obligatorio.
+   - `npm run build` (o `nest build`) local para verificar 0 errores.
+   - Commit del `package.json` + `package-lock.json` y deploy (rebuild de imagen:
+     `npm ci` recompila modelos vía `prepare` y luego buildea el servicio).
+3. **Verificar consumidores no cubiertos localmente** antes o junto al deploy:
+   `gestion-web-cliente` (`ng build` real), `seguridad-boton-nest` /
+   `seguridad-boton-web` (alias `modelos-gestion`). Ver `CONSUMIDORES.md`.
+
+Estado de verificación y lista completa de consumidores: **`CONSUMIDORES.md`**.

--- a/README.md
+++ b/README.md
@@ -1,23 +1,68 @@
-## _1-_ En package.json agregar la dependencia
+# gestion-modelos
 
-```
+Modelos para el sistema de gestión: **schemas Zod v4 + tipos TypeScript inferidos**.
+
+Cada entidad exporta su schema runtime (`ActivoSchema`, `CreateActivoSchema`, `UpdateActivoSchema`) y los tipos derivados con los mismos nombres de siempre (`IActivo`, `ICreateActivo`, `IUpdateActivo`). Los imports existentes de tipos no cambian.
+
+## Instalación (consumidores)
+
+En `package.json` del servicio:
+
+```json
 "modelos": "git://github.com/GPE-Sistemas/gestion-modelos.git"
 ```
 
-## _2-_ En package.json agregar el script para actualizar
+Script para actualizar:
 
-```
+```json
 "modelos": "yarn upgrade modelos"
 ```
 
-## _3-_ Instalar la dependencia
+El paquete se compila solo al instalarse (hook `prepare` → `tsc`). El import clásico sigue funcionando:
 
-```
-# yarn install
+```typescript
+import { ICoordenadas, IActivo } from 'modelos/src';
 ```
 
-## _4-_ Importar los modelos requeridos
+## Uso de los schemas
 
+```typescript
+import { CreateActivoSchema, TipoVehiculoSchema } from 'modelos/src';
+
+// Validación runtime de un body
+const resultado = CreateActivoSchema.safeParse(body);
+if (!resultado.success) {
+  // resultado.error.issues tiene el detalle campo por campo
+}
+
+// Valores de un enum en runtime (ej: opciones de un select)
+TipoVehiculoSchema.options; // ['Auto', 'Camion', ...]
 ```
-import { ICoordenadas } from 'modelos/src';
+
+## Convenciones (Zod v4)
+
+- API canónica: `z.object` / `z.discriminatedUnion` / `z.enum`. **No** usar `z.nativeEnum` ni los deprecados `.passthrough()` / `.strict()` / `.strip()`.
+- Modo **strip por defecto**: `z.object()` descarta claves desconocidas al parsear (interop con Mongoose). Si un endpoint necesita conservar extras, usar `Schema.loose()` localmente.
+- Tipos siempre por `z.infer<typeof XSchema>`, sin casts manuales (evita TS7056 en cadenas de populates profundas).
+- ids y fechas son `z.string()` plano (fechas en ISO string, como siempre).
+- `Create` = `XSchema.omit({...})` (la base ya es todo-opcional); `Update` ídem; `Cache` = omit de populates.
+- Enums de dominio: `z.enum([...])` + `export type TipoX = z.infer<typeof TipoXSchema>` con el mismo nombre de tipo que antes.
+- **Ciclos de import** (populates entre entidades que se referencian mutuamente): el campo va como *getter* dentro del `z.object`:
+
+  ```typescript
+  get tracker() {
+    return TrackerSchema.optional();
+  },
+  ```
+
+  Nunca spreadear un objeto que contenga getters (`{...Base}` los evalúa eager y rompe el ciclo en runtime).
+
+## JSON Schema / OpenAPI
+
+```bash
+npm run build
+npm run gen:json-schema            # dist/json-schema/<Name>.json + index.json
+npm run gen:json-schema -- --only=Activo --verbose
 ```
+
+Usa `z.toJSONSchema(schema, { target: 'openapi-3.0' })` nativo de Zod v4, sin librerías extra. Para Swagger en las APIs NestJS se puede usar `nestjs-zod` (`createZodDto(CreateActivoSchema)`).

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,42 @@
+{
+  "name": "gestion-modelos",
+  "version": "2.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "gestion-modelos",
+      "version": "2.0.0",
+      "license": "Private",
+      "dependencies": {
+        "zod": "^4.4.3"
+      },
+      "devDependencies": {
+        "typescript": "^5.4.0"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/zod": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,8 +1,27 @@
 {
   "name": "gestion-modelos",
-  "version": "1.0.0",
-  "description": "Modelos para el sitema de gestión",
+  "version": "2.0.0",
+  "description": "Modelos para el sistema de gestión. Schemas Zod + tipos TypeScript inferidos.",
   "author": "GPE Sistemas",
   "license": "Private",
-  "repository": "https://github.com/GPE-Sistemas/gestion-modelos"
+  "repository": "https://github.com/GPE-Sistemas/gestion-modelos",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "files": [
+    "dist",
+    "src",
+    "README.md"
+  ],
+  "scripts": {
+    "build": "tsc",
+    "clean": "rm -rf dist",
+    "gen:json-schema": "node scripts/gen-json-schema.mjs",
+    "prepare": "npm run build"
+  },
+  "dependencies": {
+    "zod": "^4.4.3"
+  },
+  "devDependencies": {
+    "typescript": "^5.4.0"
+  }
 }

--- a/scripts/gen-json-schema.mjs
+++ b/scripts/gen-json-schema.mjs
@@ -77,7 +77,12 @@ function main() {
     }
 
     try {
-      const jsonSchema = z.toJSONSchema(value, { target: "openapi-3.0" });
+      // unrepresentable: 'any' → los z.custom (populates del SCC) se emiten
+      // como {} (any) en vez de fallar
+      const jsonSchema = z.toJSONSchema(value, {
+        target: "openapi-3.0",
+        unrepresentable: "any",
+      });
       const payload = JSON.stringify(jsonSchema, null, 2);
       writeFileSync(join(OUT_DIR, `${name}.json`), payload + "\n", "utf-8");
       defs[name] = jsonSchema;

--- a/scripts/gen-json-schema.mjs
+++ b/scripts/gen-json-schema.mjs
@@ -1,0 +1,118 @@
+// Generador JSON Schema desde schemas Zod.
+//
+// Itera todos los *Schema exportados por dist/index.js (Zod v4),
+// corre z.toJSONSchema con target openapi-3.0 y escribe:
+//   - dist/json-schema/<name>.json   (un archivo por schema)
+//   - dist/json-schema/index.json    (bundle único con todos los $defs)
+//
+// Zod es el single source of truth: los tipos TS se infieren de los
+// schemas y el OpenAPI de las APIs puede referenciar estos JSON Schemas.
+//
+// Pre-requisito: dist/ ya compilado (npm run build).
+//
+// Uso:
+//   npm run gen:json-schema                            # genera todos
+//   npm run gen:json-schema -- --only=Activo,Tracker --verbose
+//   npm run gen:json-schema -- --skip=EventoGenerico   # excluye sin fallar
+
+import { z } from "zod";
+import { writeFileSync, mkdirSync, existsSync } from "node:fs";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import * as Modelos from "../dist/index.js";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = join(__dirname, "..");
+const OUT_DIR = join(REPO_ROOT, "dist", "json-schema");
+
+// Schemas excluidos del bundle de forma permanente (ej: ciclos de populate
+// que z.toJSONSchema no puede resolver). Documentar el motivo al agregar.
+const SKIP_SCHEMAS = [];
+
+function parseArgs(argv) {
+  const only = [];
+  const skip = [...SKIP_SCHEMAS];
+  let verbose = false;
+  for (const arg of argv.slice(2)) {
+    if (arg === "--verbose" || arg === "-v") verbose = true;
+    else if (arg.startsWith("--only=")) {
+      only.push(...arg.slice("--only=".length).split(",").filter(Boolean));
+    } else if (arg.startsWith("--skip=")) {
+      skip.push(...arg.slice("--skip=".length).split(",").filter(Boolean));
+    }
+  }
+  return { only: only.length ? only : null, skip, verbose };
+}
+
+function isZodSchema(value) {
+  return !!value && typeof value === "object" && "_zod" in value;
+}
+
+function main() {
+  const args = parseArgs(process.argv);
+
+  if (!existsSync(OUT_DIR)) {
+    mkdirSync(OUT_DIR, { recursive: true });
+  }
+
+  const entries = Object.entries(Modelos)
+    .filter(([name]) => name.endsWith("Schema"))
+    .filter(([name]) =>
+      args.only ? args.only.some((needle) => name.includes(needle)) : true,
+    );
+
+  const results = [];
+  const defs = {};
+
+  for (const [name, value] of entries) {
+    if (args.skip.some((needle) => name.includes(needle))) {
+      results.push({ name, status: "skipped", error: "en skip-list" });
+      if (args.verbose) console.log(`  skip ${name}`);
+      continue;
+    }
+    if (!isZodSchema(value)) {
+      results.push({ name, status: "skipped", error: "not a Zod schema" });
+      continue;
+    }
+
+    try {
+      const jsonSchema = z.toJSONSchema(value, { target: "openapi-3.0" });
+      const payload = JSON.stringify(jsonSchema, null, 2);
+      writeFileSync(join(OUT_DIR, `${name}.json`), payload + "\n", "utf-8");
+      defs[name] = jsonSchema;
+      results.push({ name, status: "ok", bytes: payload.length });
+      if (args.verbose) {
+        console.log(`  ok  ${name}  (${payload.length} bytes)`);
+      }
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      results.push({ name, status: "error", error: msg });
+      console.error(`  ERR ${name}: ${msg}`);
+    }
+  }
+
+  const bundle = {
+    $schema: "https://json-schema.org/draft/2020-12/schema",
+    "x-source": "gestion-modelos",
+    "x-generator": "z.toJSONSchema({target:'openapi-3.0'})",
+    "x-generated-at": new Date().toISOString(),
+    $defs: defs,
+  };
+  const bundlePath = join(OUT_DIR, "index.json");
+  writeFileSync(bundlePath, JSON.stringify(bundle, null, 2) + "\n", "utf-8");
+
+  const ok = results.filter((r) => r.status === "ok").length;
+  const skipped = results.filter((r) => r.status === "skipped").length;
+  const errored = results.filter((r) => r.status === "error").length;
+
+  console.log("");
+  console.log(`Resumen: ok=${ok} skipped=${skipped} error=${errored}`);
+  console.log(`Bundle: ${bundlePath}`);
+
+  if (errored > 0) {
+    process.exit(1);
+  }
+}
+
+main();

--- a/src/auxiliares/coordenadas.ts
+++ b/src/auxiliares/coordenadas.ts
@@ -1,7 +1,10 @@
-export interface ICoordenadas {
-  lat: number;
-  lng: number;
-}
+import { z } from "zod";
+
+export const CoordenadasSchema = z.object({
+  lat: z.number(),
+  lng: z.number(),
+});
+export type ICoordenadas = z.infer<typeof CoordenadasSchema>;
 
 /**
  * Coordenadas en formato OpenLayers (Coordinate).
@@ -11,4 +14,5 @@ export interface ICoordenadas {
  * An array of numbers representing an xy, xyz or xyzm coordinate.
  * @example [-58.3816, -34.6037]
  */
-export type ICoordenadaOL = number[];
+export const CoordenadaOLSchema = z.array(z.number());
+export type ICoordenadaOL = z.infer<typeof CoordenadaOLSchema>;

--- a/src/auxiliares/counters.ts
+++ b/src/auxiliares/counters.ts
@@ -1,11 +1,14 @@
-export interface ICounter {
-  _id?: string;
-  colection?: string;
-  seq?: number;
-}
+import { z } from "zod";
 
-type OmitirCreate = "_id";
-export interface ICreateCounter extends Omit<Partial<ICounter>, OmitirCreate> {}
+export const CounterSchema = z.object({
+  _id: z.string().optional(),
+  colection: z.string().optional(),
+  seq: z.number().optional(),
+});
 
-type OmitirUpdate = "_id";
-export interface IUpdateCounter extends Omit<Partial<ICounter>, OmitirUpdate> {}
+export const CreateCounterSchema = CounterSchema.omit({ _id: true });
+export const UpdateCounterSchema = CounterSchema.omit({ _id: true });
+
+export type ICounter = z.infer<typeof CounterSchema>;
+export type ICreateCounter = z.infer<typeof CreateCounterSchema>;
+export type IUpdateCounter = z.infer<typeof UpdateCounterSchema>;

--- a/src/auxiliares/direccionV2.ts
+++ b/src/auxiliares/direccionV2.ts
@@ -1,15 +1,17 @@
-import { ICoordenadas } from "./coordenadas";
+import { z } from "zod";
+import { CoordenadasSchema } from "./coordenadas";
 
-export interface DireccionV2 {
-  calle?: string;
-  entreCalles?: string;
-  numero?: string;
-  piso?: string;
-  depto?: string;
-  barrio?: string;
-  localidad?: string;
-  partido?: string;
-  provincia?: string;
-  direccion?: string;
-  coordenadas?: ICoordenadas;
-}
+export const DireccionV2Schema = z.object({
+  calle: z.string().optional(),
+  entreCalles: z.string().optional(),
+  numero: z.string().optional(),
+  piso: z.string().optional(),
+  depto: z.string().optional(),
+  barrio: z.string().optional(),
+  localidad: z.string().optional(),
+  partido: z.string().optional(),
+  provincia: z.string().optional(),
+  direccion: z.string().optional(),
+  coordenadas: CoordenadasSchema.optional(),
+});
+export type DireccionV2 = z.infer<typeof DireccionV2Schema>;

--- a/src/auxiliares/downlink.ts
+++ b/src/auxiliares/downlink.ts
@@ -1,9 +1,15 @@
-export interface IDownlink {
-  deveui?: string;
-  puerto?: number;
-  payload?: string;
+import { z } from "zod";
+
+export const DownlinkSchema = z.object({
+  deveui: z.string().optional(),
+  puerto: z.number().optional(),
+  payload: z.string().optional(),
   // ===== Opciones Chirpstack =====
-  expiresAt?: string; // Expira en la cola de Chirpstack si el NS no entrega antes. Útil para evitar que cuando un device vuelve online reciba comandos viejos zombies.
-  flushQueue?: boolean; // Si es true, vacía la cola pendiente del device en Chirpstack antes de encolar este downlink. Usado en acciones de control inmediato (Encender, Apagar) donde solo importa el último.
-  confirmed?: boolean; // Class C confirmed downlink. Por defecto false.
-}
+  // Expira en la cola de Chirpstack si el NS no entrega antes. Útil para evitar que cuando un device vuelve online reciba comandos viejos zombies.
+  expiresAt: z.string().optional(),
+  // Si es true, vacía la cola pendiente del device en Chirpstack antes de encolar este downlink. Usado en acciones de control inmediato (Encender, Apagar) donde solo importa el último.
+  flushQueue: z.boolean().optional(),
+  // Class C confirmed downlink. Por defecto false.
+  confirmed: z.boolean().optional(),
+});
+export type IDownlink = z.infer<typeof DownlinkSchema>;

--- a/src/auxiliares/eventos/ack.ts
+++ b/src/auxiliares/eventos/ack.ts
@@ -1,13 +1,15 @@
-import { DeviceInfo } from "./uplink";
+import { z } from "zod";
+import { DeviceInfoSchema } from "./uplink";
 
-export interface IAck {
-  deduplicationId?: string;
-  time?: string;
-  deviceInfo?: DeviceInfo;
-  queueItemId?: string;
-  acknowledged?: boolean;
-  fCntDown?: number;
-}
+export const AckSchema = z.object({
+  deduplicationId: z.string().optional(),
+  time: z.string().optional(),
+  deviceInfo: DeviceInfoSchema.optional(),
+  queueItemId: z.string().optional(),
+  acknowledged: z.boolean().optional(),
+  fCntDown: z.number().optional(),
+});
+export type IAck = z.infer<typeof AckSchema>;
 
 export const EXAMPLE_ACK: IAck = {
   deduplicationId: "cd1a76ec-ece8-412e-8948-add1030c29c7",

--- a/src/auxiliares/eventos/join.ts
+++ b/src/auxiliares/eventos/join.ts
@@ -1,12 +1,14 @@
-import { DeviceInfo } from "./uplink";
+import { z } from "zod";
+import { DeviceInfoSchema } from "./uplink";
 
-export interface IJoin {
-  deduplicationId?: string;
-  time?: string;
-  deviceInfo?: DeviceInfo;
-  devAddr?: string;
-  regionConfigId?: string;
-}
+export const JoinSchema = z.object({
+  deduplicationId: z.string().optional(),
+  time: z.string().optional(),
+  deviceInfo: DeviceInfoSchema.optional(),
+  devAddr: z.string().optional(),
+  regionConfigId: z.string().optional(),
+});
+export type IJoin = z.infer<typeof JoinSchema>;
 
 export const EXAMPLE_JOIN: IJoin = {
   deduplicationId: "b09a7839-a7c5-44ed-82db-3b02c076813a",

--- a/src/auxiliares/eventos/log.ts
+++ b/src/auxiliares/eventos/log.ts
@@ -1,13 +1,15 @@
-import { DeviceInfo } from "./uplink";
+import { z } from "zod";
+import { DeviceInfoSchema } from "./uplink";
 
-export interface ILog {
-  time?: string;
-  deviceInfo?: DeviceInfo;
-  level?: string; // "ERROR", "WARNING", "INFO"
-  code?: string; // "DOWNLINK_GATEWAY", "UPLINK_F_CNT_RETRANSMISSION", etc.
-  description?: string;
-  context?: Record<string, any>;
-}
+export const LogSchema = z.object({
+  time: z.string().optional(),
+  deviceInfo: DeviceInfoSchema.optional(),
+  level: z.string().optional(), // "ERROR", "WARNING", "INFO"
+  code: z.string().optional(), // "DOWNLINK_GATEWAY", "UPLINK_F_CNT_RETRANSMISSION", etc.
+  description: z.string().optional(),
+  context: z.record(z.string(), z.any()).optional(),
+});
+export type ILog = z.infer<typeof LogSchema>;
 
 export const EXAMPLE_LOG_ERROR: ILog = {
   time: "2025-12-11T20:49:52.238228508+00:00",
@@ -45,7 +47,8 @@ export const EXAMPLE_LOG_WARNING: ILog = {
   },
   level: "WARNING",
   code: "UPLINK_F_CNT_RETRANSMISSION",
-  description: "Uplink was flagged as re-transmission / frame-counter did not increment",
+  description:
+    "Uplink was flagged as re-transmission / frame-counter did not increment",
   context: {
     deduplication_id: "8ec164e1-b5b3-4de6-94fa-9b5516347585",
   },

--- a/src/auxiliares/eventos/status.ts
+++ b/src/auxiliares/eventos/status.ts
@@ -1,14 +1,16 @@
-import { DeviceInfo } from "./uplink";
+import { z } from "zod";
+import { DeviceInfoSchema } from "./uplink";
 
-export interface IStatus {
-  deduplicationId?: string;
-  time?: string;
-  deviceInfo?: DeviceInfo;
-  margin?: number;
-  externalPowerSource?: boolean;
-  batteryLevelUnavailable?: boolean;
-  batteryLevel?: number;
-}
+export const StatusSchema = z.object({
+  deduplicationId: z.string().optional(),
+  time: z.string().optional(),
+  deviceInfo: DeviceInfoSchema.optional(),
+  margin: z.number().optional(),
+  externalPowerSource: z.boolean().optional(),
+  batteryLevelUnavailable: z.boolean().optional(),
+  batteryLevel: z.number().optional(),
+});
+export type IStatus = z.infer<typeof StatusSchema>;
 
 export const EXAMPLE_STATUS: IStatus = {
   deduplicationId: "7cf33400-9c76-4963-b6d5-cc61075ba585",

--- a/src/auxiliares/eventos/txack.ts
+++ b/src/auxiliares/eventos/txack.ts
@@ -1,40 +1,48 @@
-import { DeviceInfo } from "./uplink";
+import { z } from "zod";
+import { DeviceInfoSchema } from "./uplink";
 
-export interface ITxack {
-  downlinkId?: number;
-  time?: string;
-  deviceInfo?: DeviceInfo;
-  queueItemId?: string;
-  fCntDown?: number;
-  gatewayId?: string;
-  txInfo?: TxInfoTxack;
-}
+export const LoraTxackSchema = z.object({
+  bandwidth: z.number().optional(),
+  spreadingFactor: z.number().optional(),
+  codeRate: z.string().optional(),
+  polarizationInversion: z.boolean().optional(),
+});
+export type LoraTxack = z.infer<typeof LoraTxackSchema>;
 
-export interface TxInfoTxack {
-  frequency?: number;
-  power?: number;
-  modulation?: ModulationTxack;
-  timing?: Timing;
-  context?: string;
-}
+export const ModulationTxackSchema = z.object({
+  lora: LoraTxackSchema.optional(),
+});
+export type ModulationTxack = z.infer<typeof ModulationTxackSchema>;
 
-export interface ModulationTxack {
-  lora?: LoraTxack;
-}
+export const TimingSchema = z.object({
+  delay: z
+    .object({
+      delay: z.string().optional(),
+    })
+    .optional(),
+  immediately: z.object({}).optional(),
+});
+export type Timing = z.infer<typeof TimingSchema>;
 
-export interface LoraTxack {
-  bandwidth?: number;
-  spreadingFactor?: number;
-  codeRate?: string;
-  polarizationInversion?: boolean;
-}
+export const TxInfoTxackSchema = z.object({
+  frequency: z.number().optional(),
+  power: z.number().optional(),
+  modulation: ModulationTxackSchema.optional(),
+  timing: TimingSchema.optional(),
+  context: z.string().optional(),
+});
+export type TxInfoTxack = z.infer<typeof TxInfoTxackSchema>;
 
-export interface Timing {
-  delay?: {
-    delay?: string;
-  };
-  immediately?: {};
-}
+export const TxackSchema = z.object({
+  downlinkId: z.number().optional(),
+  time: z.string().optional(),
+  deviceInfo: DeviceInfoSchema.optional(),
+  queueItemId: z.string().optional(),
+  fCntDown: z.number().optional(),
+  gatewayId: z.string().optional(),
+  txInfo: TxInfoTxackSchema.optional(),
+});
+export type ITxack = z.infer<typeof TxackSchema>;
 
 export const EXAMPLE_TXACK: ITxack = {
   downlinkId: 259727475,

--- a/src/auxiliares/eventos/uplink.ts
+++ b/src/auxiliares/eventos/uplink.ts
@@ -1,97 +1,115 @@
-export interface IUplink {
-  deduplicationId?: string;
-  time?: string;
-  deviceInfo?: DeviceInfo;
-  devAddr?: string;
-  adr?: boolean;
-  dr?: number;
-  fCnt?: number;
-  fPort?: number;
-  confirmed?: boolean;
-  data?: string;
-  object?: IObjectUplink;
-  rxInfo?: RxInfo[];
-  txInfo?: TxInfo;
-  regionConfigId?: string;
-}
+import { z } from "zod";
 
-export interface DeviceInfo {
-  tenantId?: string;
-  tenantName?: string;
-  applicationId?: string;
-  applicationName?: string;
-  deviceProfileId?: string;
-  deviceProfileName?: string;
-  deviceName?: string;
-  devEui?: string;
-  deviceClassEnabled?: string;
-  tags?: Tags;
-}
+export const TagsSchema = z.record(z.string(), z.string());
+export type Tags = z.infer<typeof TagsSchema>;
 
-export interface Tags {
-  [key: string]: string;
-}
+export const DeviceInfoSchema = z.object({
+  tenantId: z.string().optional(),
+  tenantName: z.string().optional(),
+  applicationId: z.string().optional(),
+  applicationName: z.string().optional(),
+  deviceProfileId: z.string().optional(),
+  deviceProfileName: z.string().optional(),
+  deviceName: z.string().optional(),
+  devEui: z.string().optional(),
+  deviceClassEnabled: z.string().optional(),
+  tags: TagsSchema.optional(),
+});
+export type DeviceInfo = z.infer<typeof DeviceInfoSchema>;
 
-export interface IObjectUplink {
-  err?: number;
-  valid?: boolean;
-  payload?: string;
-  messages?: Array<IMessageUplink[]>;
-  errMessage?: string;
-}
+export const PositioningStatusSchema = z.object({
+  id: z.number().optional(),
+  statusName: z.string().optional(),
+});
+export type IPositioningStatus = z.infer<typeof PositioningStatusSchema>;
 
-export interface IMessageUplink {
-  measurementValue?:
-    | IMeasurementValueElementUplink[]
-    | IPositioningStatus
-    | number;
-  timestamp?: number;
-  measurementId?: string;
-  motionId?: number;
-  type?: string;
-}
+export const MeasurementValueElementUplinkSchema = z.object({
+  mac: z.string().optional(),
+  rssi: z.number().optional(),
+});
+export type IMeasurementValueElementUplink = z.infer<
+  typeof MeasurementValueElementUplinkSchema
+>;
 
-export interface IPositioningStatus {
-  id?: number;
-  statusName?: string;
-}
+export const MessageUplinkSchema = z.object({
+  measurementValue: z
+    .union([
+      z.array(MeasurementValueElementUplinkSchema),
+      PositioningStatusSchema,
+      z.number(),
+    ])
+    .optional(),
+  timestamp: z.number().optional(),
+  measurementId: z.string().optional(),
+  motionId: z.number().optional(),
+  type: z.string().optional(),
+});
+export type IMessageUplink = z.infer<typeof MessageUplinkSchema>;
 
-export interface IMeasurementValueElementUplink {
-  mac?: string;
-  rssi?: number;
-}
-export interface RxInfo {
-  gatewayId?: string;
-  uplinkId?: number;
-  gwTime?: string;
-  nsTime?: string;
-  timeSinceGpsEpoch?: string;
-  rssi?: number;
-  snr?: number;
-  location?: Location;
-  context?: string;
-  crcStatus?: string;
-}
+export const ObjectUplinkSchema = z.object({
+  err: z.number().optional(),
+  valid: z.boolean().optional(),
+  payload: z.string().optional(),
+  messages: z.array(z.array(MessageUplinkSchema)).optional(),
+  errMessage: z.string().optional(),
+});
+export type IObjectUplink = z.infer<typeof ObjectUplinkSchema>;
 
-export interface Location {
-  latitude?: number;
-  longitude?: number;
-}
+export const LocationSchema = z.object({
+  latitude: z.number().optional(),
+  longitude: z.number().optional(),
+});
+export type Location = z.infer<typeof LocationSchema>;
 
-export interface TxInfo {
-  frequency?: number;
-  modulation?: Modulation;
-}
+export const RxInfoSchema = z.object({
+  gatewayId: z.string().optional(),
+  uplinkId: z.number().optional(),
+  gwTime: z.string().optional(),
+  nsTime: z.string().optional(),
+  timeSinceGpsEpoch: z.string().optional(),
+  rssi: z.number().optional(),
+  snr: z.number().optional(),
+  location: LocationSchema.optional(),
+  context: z.string().optional(),
+  crcStatus: z.string().optional(),
+});
+export type RxInfo = z.infer<typeof RxInfoSchema>;
 
-export interface Modulation {
-  lora?: Lora;
-}
+export const LoraSchema = z.object({
+  bandwidth: z.number().optional(),
+  spreadingFactor: z.number().optional(),
+  codeRate: z.string().optional(),
+});
+export type Lora = z.infer<typeof LoraSchema>;
 
-export interface Lora {
-  bandwidth?: number;
-  spreadingFactor?: number;
-  codeRate?: string;
-}
+export const ModulationSchema = z.object({
+  lora: LoraSchema.optional(),
+});
+export type Modulation = z.infer<typeof ModulationSchema>;
+
+export const TxInfoSchema = z.object({
+  frequency: z.number().optional(),
+  modulation: ModulationSchema.optional(),
+});
+export type TxInfo = z.infer<typeof TxInfoSchema>;
+
+export const UplinkSchema = z.object({
+  deduplicationId: z.string().optional(),
+  time: z.string().optional(),
+  deviceInfo: DeviceInfoSchema.optional(),
+  devAddr: z.string().optional(),
+  adr: z.boolean().optional(),
+  dr: z.number().optional(),
+  fCnt: z.number().optional(),
+  fPort: z.number().optional(),
+  confirmed: z.boolean().optional(),
+  data: z.string().optional(),
+  object: ObjectUplinkSchema.optional(),
+  rxInfo: z.array(RxInfoSchema).optional(),
+  txInfo: TxInfoSchema.optional(),
+  regionConfigId: z.string().optional(),
+});
+export type IUplink = z.infer<typeof UplinkSchema>;
 
 export const EXAMPLE_UPLINK: IUplink = {
   deduplicationId: "8dc86175-520c-4b1e-9f12-1bd8fa2756c8",

--- a/src/auxiliares/exactly.ts
+++ b/src/auxiliares/exactly.ts
@@ -1,3 +1,4 @@
+// Helper de tipos genérico: queda TS puro, sin schema Zod (no tiene forma runtime).
 export type Exactly<T, U> = {
   [K in keyof U]: K extends keyof T ? T[K] : never;
 };

--- a/src/auxiliares/geojson.ts
+++ b/src/auxiliares/geojson.ts
@@ -10,8 +10,18 @@ import { z } from "zod";
 //  coordinates: [number, number];
 //
 
-/** [longitud, latitud] */
-const PuntoCoord = z.tuple([z.number(), z.number()]);
+/**
+ * [longitud, latitud]
+ *
+ * El output de `z.tuple` en Zod v4 se infiere como `[number?, number?, ...unknown[]]`
+ * (sobre todo en consumidores con `strictNullChecks: false`), lo que rompe la
+ * asignación a `[number, number]`. Forzamos el tipo de salida con un cast: el
+ * runtime sigue validando la tupla, pero el tipo público es estable.
+ */
+export const PuntoCoord = z.tuple([
+  z.number(),
+  z.number(),
+]) as unknown as z.ZodType<[number, number]>;
 
 /**
  * 🗺️
@@ -25,7 +35,7 @@ const PuntoCoord = z.tuple([z.number(), z.number()]);
  * --- coordinates[1] = latitud
  *
  */
-export const GeoJSONPointSchema = z.object({
+export const GeoJSONPointSchema: z.ZodType<IGeoJSONPoint> = z.object({
   type: z.literal("Point"),
   coordinates: PuntoCoord,
 });
@@ -44,7 +54,7 @@ export const GeoJSONPointSchema = z.object({
  * - radius: radio del círculo
  *
  */
-export const GeoJSONCircleSchema = z.object({
+export const GeoJSONCircleSchema: z.ZodType<IGeoJSONCircle> = z.object({
   type: z.literal("Point"),
   coordinates: PuntoCoord,
   radius: z.number(),
@@ -62,7 +72,7 @@ export const GeoJSONCircleSchema = z.object({
  * --- coordinates[n][1] = latitud del punto n
  *
  */
-export const GeoJSONLineStringSchema = z.object({
+export const GeoJSONLineStringSchema: z.ZodType<IGeoJSONLineString> = z.object({
   type: z.literal("LineString"),
   coordinates: z.array(PuntoCoord),
 });
@@ -81,9 +91,11 @@ export const GeoJSONLineStringSchema = z.object({
  * --- coordinates[0][n][1] = latitud del punto n del anillo
  *
  */
-export const GeoJSONPolygonSchema = z.object({
+export const GeoJSONPolygonSchema: z.ZodType<IGeoJSONPolygon> = z.object({
   type: z.literal("Polygon"),
-  coordinates: z.tuple([z.array(PuntoCoord)]),
+  coordinates: z.tuple([z.array(PuntoCoord)]) as unknown as z.ZodType<
+    [[number, number][]]
+  >,
 });
 
 /**
@@ -102,13 +114,13 @@ export const GeoJSONPolygonSchema = z.object({
  * --- coordinates[ i ][ j ][ k ][ 1 ] = latitud del punto k del anillo j del polígono i
  *
  */
-export const GeoJSONMultiPolygonSchema = z.object({
+export const GeoJSONMultiPolygonSchema: z.ZodType<IGeoJSONMultiPolygon> = z.object({
   type: z.literal("MultiPolygon"),
   coordinates: z.array(z.array(z.array(z.array(z.number())))),
 });
 
 // Point y Circle comparten type: "Point" → no puede ser discriminatedUnion
-export const GeoJSONSchema = z.union([
+export const GeoJSONSchema: z.ZodType<IGeoJSON> = z.union([
   GeoJSONPointSchema,
   GeoJSONCircleSchema,
   GeoJSONLineStringSchema,

--- a/src/auxiliares/geojson.ts
+++ b/src/auxiliares/geojson.ts
@@ -116,9 +116,33 @@ export const GeoJSONSchema = z.union([
   GeoJSONMultiPolygonSchema,
 ]);
 
-export type IGeoJSONPoint = z.infer<typeof GeoJSONPointSchema>;
-export type IGeoJSONCircle = z.infer<typeof GeoJSONCircleSchema>;
-export type IGeoJSONLineString = z.infer<typeof GeoJSONLineStringSchema>;
-export type IGeoJSONPolygon = z.infer<typeof GeoJSONPolygonSchema>;
-export type IGeoJSONMultiPolygon = z.infer<typeof GeoJSONMultiPolygonSchema>;
-export type IGeoJSON = z.infer<typeof GeoJSONSchema>;
+// Tipos hand-written (NO z.infer): los consumidores compilan este fuente con
+// strictNullChecks: false y la inferencia de Zod v4 se degrada sin strict
+// (ej: [number, number] → [number?, number?, ...unknown[]]).
+export interface IGeoJSONPoint {
+  type: 'Point';
+  coordinates: [number, number];
+}
+export interface IGeoJSONCircle {
+  type: 'Point';
+  coordinates: [number, number];
+  radius: number;
+}
+export interface IGeoJSONLineString {
+  type: 'LineString';
+  coordinates: [number, number][];
+}
+export interface IGeoJSONPolygon {
+  type: 'Polygon';
+  coordinates: [[number, number][]];
+}
+export interface IGeoJSONMultiPolygon {
+  type: 'MultiPolygon';
+  coordinates: number[][][][];
+}
+export type IGeoJSON =
+  | IGeoJSONPoint
+  | IGeoJSONCircle
+  | IGeoJSONLineString
+  | IGeoJSONPolygon
+  | IGeoJSONMultiPolygon;

--- a/src/auxiliares/geojson.ts
+++ b/src/auxiliares/geojson.ts
@@ -1,3 +1,5 @@
+import { z } from "zod";
+
 // GEOJSON
 // https://www.mongodb.com/docs/manual/reference/geojson/
 // type es el tipo de objeto a guardar
@@ -8,12 +10,8 @@
 //  coordinates: [number, number];
 //
 
-export type IGeoJSON =
-  | IGeoJSONPoint
-  | IGeoJSONCircle
-  | IGeoJSONLineString
-  | IGeoJSONPolygon
-  | IGeoJSONMultiPolygon;
+/** [longitud, latitud] */
+const PuntoCoord = z.tuple([z.number(), z.number()]);
 
 /**
  * 🗺️
@@ -27,10 +25,10 @@ export type IGeoJSON =
  * --- coordinates[1] = latitud
  *
  */
-export interface IGeoJSONPoint {
-  type: "Point";
-  coordinates: [number, number];
-}
+export const GeoJSONPointSchema = z.object({
+  type: z.literal("Point"),
+  coordinates: PuntoCoord,
+});
 
 /**
  * 🗺️
@@ -46,11 +44,11 @@ export interface IGeoJSONPoint {
  * - radius: radio del círculo
  *
  */
-export interface IGeoJSONCircle {
-  type: "Point";
-  coordinates: [number, number];
-  radius: number;
-}
+export const GeoJSONCircleSchema = z.object({
+  type: z.literal("Point"),
+  coordinates: PuntoCoord,
+  radius: z.number(),
+});
 
 /**
  * 🗺️
@@ -64,10 +62,10 @@ export interface IGeoJSONCircle {
  * --- coordinates[n][1] = latitud del punto n
  *
  */
-export interface IGeoJSONLineString {
-  type: "LineString";
-  coordinates: [number, number][];
-}
+export const GeoJSONLineStringSchema = z.object({
+  type: z.literal("LineString"),
+  coordinates: z.array(PuntoCoord),
+});
 
 /**
  * 🗺️
@@ -83,10 +81,10 @@ export interface IGeoJSONLineString {
  * --- coordinates[0][n][1] = latitud del punto n del anillo
  *
  */
-export interface IGeoJSONPolygon {
-  type: "Polygon";
-  coordinates: [[number, number][]];
-}
+export const GeoJSONPolygonSchema = z.object({
+  type: z.literal("Polygon"),
+  coordinates: z.tuple([z.array(PuntoCoord)]),
+});
 
 /**
  * 🗺️
@@ -104,7 +102,23 @@ export interface IGeoJSONPolygon {
  * --- coordinates[ i ][ j ][ k ][ 1 ] = latitud del punto k del anillo j del polígono i
  *
  */
-export interface IGeoJSONMultiPolygon {
-  type: "MultiPolygon";
-  coordinates: number[][][][];
-}
+export const GeoJSONMultiPolygonSchema = z.object({
+  type: z.literal("MultiPolygon"),
+  coordinates: z.array(z.array(z.array(z.array(z.number())))),
+});
+
+// Point y Circle comparten type: "Point" → no puede ser discriminatedUnion
+export const GeoJSONSchema = z.union([
+  GeoJSONPointSchema,
+  GeoJSONCircleSchema,
+  GeoJSONLineStringSchema,
+  GeoJSONPolygonSchema,
+  GeoJSONMultiPolygonSchema,
+]);
+
+export type IGeoJSONPoint = z.infer<typeof GeoJSONPointSchema>;
+export type IGeoJSONCircle = z.infer<typeof GeoJSONCircleSchema>;
+export type IGeoJSONLineString = z.infer<typeof GeoJSONLineStringSchema>;
+export type IGeoJSONPolygon = z.infer<typeof GeoJSONPolygonSchema>;
+export type IGeoJSONMultiPolygon = z.infer<typeof GeoJSONMultiPolygonSchema>;
+export type IGeoJSON = z.infer<typeof GeoJSONSchema>;

--- a/src/auxiliares/listado.ts
+++ b/src/auxiliares/listado.ts
@@ -1,6 +1,22 @@
+import { z } from "zod";
+
+// Interface genérica: se mantiene como tipo (la factory de abajo es el schema)
 export interface IListado<T> {
   totalCount?: number;
   datos: T[];
   duration?: number;
   executionStats?: object;
 }
+
+/**
+ * Factory de schema para listados paginados.
+ *
+ * @example ListadoSchema(ActivoSchema).safeParse(res)
+ */
+export const ListadoSchema = <T extends z.ZodTypeAny>(inner: T) =>
+  z.object({
+    totalCount: z.number().optional(),
+    datos: z.array(inner),
+    duration: z.number().optional(),
+    executionStats: z.record(z.string(), z.any()).optional(),
+  });

--- a/src/auxiliares/query-filter.ts
+++ b/src/auxiliares/query-filter.ts
@@ -1,3 +1,5 @@
+// Tipos estructurales genéricos de queries Mongo: quedan TS puro, sin schema Zod
+// (IFilter<T> es recursivo y genérico; no hay valor runtime que validar acá).
 export interface IQueryParam {
   page?: string | number;
   limit?: string | number;

--- a/src/auxiliares/socket-message.ts
+++ b/src/auxiliares/socket-message.ts
@@ -1,32 +1,35 @@
-export interface ISocketMessage {
+import { z } from "zod";
+
+export const SocketMessageSchema = z.object({
   /**
    * Las entidades modificadas (clientes, usuarios, etc)
    */
-  paths?: string[];
+  paths: z.array(z.string()).optional(),
   /**
    * Metodo HTTP ejecutado (post, put, delete)
    */
-  method?: string;
+  method: z.string().optional(),
   /**
    * El id del usuario que ejecutó la accion
    */
-  idUser?: string;
+  idUser: z.string().optional(),
   /**
    * El id del cliente del usuario que ejecutó la accion
    */
-  idCliente?: string;
+  idCliente: z.string().optional(),
   /**
    * El body que se devolvio al usuario
    * En caso de post o put, el body es el nuevo objeto
    * En caso de delete, el body es un objeto { _id: "id del objeto eliminado" }
    */
-  body?: Record<string, any>;
+  body: z.record(z.string(), z.any()).optional(),
   /**
    * Por que el usuario recibio el mensaje (para debug mas que nada)
    */
-  motivo?: string;
+  motivo: z.string().optional(),
   /**
    * La aplicacion que envio el mensaje
    */
-  aplicacion?: string;
-}
+  aplicacion: z.string().optional(),
+});
+export type ISocketMessage = z.infer<typeof SocketMessageSchema>;

--- a/src/externos/osrm.ts
+++ b/src/externos/osrm.ts
@@ -1,108 +1,122 @@
+import { z } from 'zod';
+
 /**
  * @todo Usar estas otras a través del sistema
  */
 
-export interface IRouteResponse {
-  code?: string;
-  routes?: Route[];
-  waypoints?: Waypoint[];
-  message?: string;
-}
+export const DrivingSideSchema = z.enum([
+  'left',
+  'right',
+  'slight left',
+  'straight',
+]);
+export type DrivingSide = z.infer<typeof DrivingSideSchema>;
 
-export interface IMatchResponse {
-  code?: string;
-  tracepoints?: Tracepoint[];
-  matchings?: Matchings[];
-}
+export const ModeSchema = z.enum(['driving']);
+export type Mode = z.infer<typeof ModeSchema>;
 
-export interface Route {
-  legs: Leg[];
-  distance: number;
-  duration: number;
-  weight_name: string;
-  weight: number;
-  geometry: {
-    type: string;
-    coordinates: number[][];
-  };
-}
+export const IntersectionSchema = z.object({
+  out: z.number().optional(),
+  entry: z.array(z.boolean()),
+  bearings: z.array(z.number()),
+  location: z.array(z.number()),
+  in: z.number().optional(),
+});
+export type Intersection = z.infer<typeof IntersectionSchema>;
 
-export interface Leg {
-  steps: Step[];
-  distance: number;
-  duration: number;
-  summary: string;
-  weight: number;
-}
+export const ManeuverSchema = z.object({
+  bearing_after: z.number(),
+  type: z.string(),
+  modifier: DrivingSideSchema.optional(),
+  bearing_before: z.number(),
+  location: z.array(z.number()),
+});
+export type Maneuver = z.infer<typeof ManeuverSchema>;
 
-export interface Step {
-  intersections: Intersection[];
-  driving_side: DrivingSide;
-  geometry: string;
-  mode: Mode;
-  duration: number;
-  maneuver: Maneuver;
-  weight: number;
-  distance: number;
-  name: string;
-}
+export const StepSchema = z.object({
+  intersections: z.array(IntersectionSchema),
+  driving_side: DrivingSideSchema,
+  geometry: z.string(),
+  mode: ModeSchema,
+  duration: z.number(),
+  maneuver: ManeuverSchema,
+  weight: z.number(),
+  distance: z.number(),
+  name: z.string(),
+});
+export type Step = z.infer<typeof StepSchema>;
 
-export enum DrivingSide {
-  Left = 'left',
-  Right = 'right',
-  SlightLeft = 'slight left',
-  Straight = 'straight',
-}
+export const LegSchema = z.object({
+  steps: z.array(StepSchema),
+  distance: z.number(),
+  duration: z.number(),
+  summary: z.string(),
+  weight: z.number(),
+});
+export type Leg = z.infer<typeof LegSchema>;
 
-export interface Intersection {
-  out?: number;
-  entry: boolean[];
-  bearings: number[];
-  location: number[];
-  in?: number;
-}
+export const RouteSchema = z.object({
+  legs: z.array(LegSchema),
+  distance: z.number(),
+  duration: z.number(),
+  weight_name: z.string(),
+  weight: z.number(),
+  geometry: z.object({
+    type: z.string(),
+    coordinates: z.array(z.array(z.number())),
+  }),
+});
+export type Route = z.infer<typeof RouteSchema>;
 
-export interface Maneuver {
-  bearing_after: number;
-  type: string;
-  modifier?: DrivingSide;
-  bearing_before: number;
-  location: number[];
-}
+export const WaypointSchema = z.object({
+  hint: z.string(),
+  distance: z.number(),
+  name: z.string(),
+  location: z.array(z.number()),
+});
+export type Waypoint = z.infer<typeof WaypointSchema>;
 
-export enum Mode {
-  Driving = 'driving',
-}
+export const RouteResponseSchema = z.object({
+  code: z.string().optional(),
+  routes: z.array(RouteSchema).optional(),
+  waypoints: z.array(WaypointSchema).optional(),
+  message: z.string().optional(),
+});
+export type IRouteResponse = z.infer<typeof RouteResponseSchema>;
 
-export interface Waypoint {
-  hint: string;
-  distance: number;
-  name: string;
-  location: number[];
-}
-
-export interface Tracepoint extends Waypoint {
+export const TracepointSchema = WaypointSchema.extend({
   //   matchings_index: Index to the Route object in matchings the sub-trace was matched to.
   // waypoint_index: Index of the waypoint inside the matched route.
   // alternatives_count: Number of probable alternative matchings for this trace point. A value of zero indicate that this point was matched unambiguously. Split the trace at these points for incremental map matching.
-  matchings_index?: number;
-  waypoint_index?: number;
-  alternatives_count?: number;
-}
+  matchings_index: z.number().optional(),
+  waypoint_index: z.number().optional(),
+  alternatives_count: z.number().optional(),
+});
+export type Tracepoint = z.infer<typeof TracepointSchema>;
 
-export interface Matchings extends Route {
+export const MatchingsSchema = RouteSchema.extend({
   // confidence: Confidence of the matching. float value between 0 and 1. 1 is very confident that the matching is correct.
-  confidence?: number;
-}
+  confidence: z.number().optional(),
+});
+export type Matchings = z.infer<typeof MatchingsSchema>;
 
-export interface INearest {
-  hint: string;
-  distance: number;
-  name: string;
-  location: number[];
-}
+export const MatchResponseSchema = z.object({
+  code: z.string().optional(),
+  tracepoints: z.array(TracepointSchema).optional(),
+  matchings: z.array(MatchingsSchema).optional(),
+});
+export type IMatchResponse = z.infer<typeof MatchResponseSchema>;
 
-export interface INearestResponse {
-  waypoints: INearest[];
-  code: string;
-}
+export const NearestSchema = z.object({
+  hint: z.string(),
+  distance: z.number(),
+  name: z.string(),
+  location: z.array(z.number()),
+});
+export type INearest = z.infer<typeof NearestSchema>;
+
+export const NearestResponseSchema = z.object({
+  waypoints: z.array(NearestSchema),
+  code: z.string(),
+});
+export type INearestResponse = z.infer<typeof NearestResponseSchema>;

--- a/src/externos/tripero.ts
+++ b/src/externos/tripero.ts
@@ -1,3 +1,5 @@
+import { z } from 'zod';
+
 /**
  * Interfaces para Tripero - Sistema de detección de viajes
  */
@@ -5,120 +7,132 @@
 /**
  * Viaje actual en progreso
  */
-export interface ICurrentTrip {
-  tripId: string;
-  startTime: string;
-  duration: number;
-  distance: number;
-  avgSpeed: number;
-  maxSpeed: number;
-  odometerAtStart: number;
-  startLat?: number;
-  startLon?: number;
-}
+export const CurrentTripSchema = z.object({
+  tripId: z.string(),
+  startTime: z.string(),
+  duration: z.number(),
+  distance: z.number(),
+  avgSpeed: z.number(),
+  maxSpeed: z.number(),
+  odometerAtStart: z.number(),
+  startLat: z.number().optional(),
+  startLon: z.number().optional(),
+});
+export type ICurrentTrip = z.infer<typeof CurrentTripSchema>;
 
 /**
  * Estado completo del tracker
  */
-export interface ITrackerStatus {
-  trackerId: string;
-  deviceId: string;
-  odometer: {
-    total: number;
-    totalKm: number;
-    currentTrip?: number;
-    currentTripKm?: number;
-  };
-  currentState: {
-    state: 'STOPPED' | 'IDLE' | 'MOVING' | 'UNKNOWN' | 'OFFLINE';
-    since: string;
-    duration: number;
-  };
-  lastPosition?: {
-    timestamp: string;
-    latitude: number;
-    longitude: number;
-    speed: number;
-    ignition: boolean;
-    heading: number;
-    altitude: number;
-    age: number;
-  };
-  currentTrip?: ICurrentTrip;
-  statistics: {
-    totalTrips: number;
-    totalDrivingTime: number;
-    totalDrivingHours: number;
-    totalIdleTime: number;
-    totalIdleHours: number;
-    totalStops: number;
-    firstSeen: string;
-    lastSeen: string;
-    daysActive: number;
-  };
-  health: {
-    status: 'online' | 'offline' | 'stale';
-    lastSeenAgo: number;
-  };
-  powerDiagnostic?: {
-    powerType: 'permanent' | 'switched' | 'unknown';
-    overnightGapCount: number;
-    lastOvernightGapAt?: string;
-    hasPowerIssue: boolean;
-    recommendation?: string;
-  };
-}
+export const TrackerStatusSchema = z.object({
+  trackerId: z.string(),
+  deviceId: z.string(),
+  odometer: z.object({
+    total: z.number(),
+    totalKm: z.number(),
+    currentTrip: z.number().optional(),
+    currentTripKm: z.number().optional(),
+  }),
+  currentState: z.object({
+    state: z.enum(['STOPPED', 'IDLE', 'MOVING', 'UNKNOWN', 'OFFLINE']),
+    since: z.string(),
+    duration: z.number(),
+  }),
+  lastPosition: z
+    .object({
+      timestamp: z.string(),
+      latitude: z.number(),
+      longitude: z.number(),
+      speed: z.number(),
+      ignition: z.boolean(),
+      heading: z.number(),
+      altitude: z.number(),
+      age: z.number(),
+    })
+    .optional(),
+  currentTrip: CurrentTripSchema.optional(),
+  statistics: z.object({
+    totalTrips: z.number(),
+    totalDrivingTime: z.number(),
+    totalDrivingHours: z.number(),
+    totalIdleTime: z.number(),
+    totalIdleHours: z.number(),
+    totalStops: z.number(),
+    firstSeen: z.string(),
+    lastSeen: z.string(),
+    daysActive: z.number(),
+  }),
+  health: z.object({
+    status: z.enum(['online', 'offline', 'stale']),
+    lastSeenAgo: z.number(),
+  }),
+  powerDiagnostic: z
+    .object({
+      powerType: z.enum(['permanent', 'switched', 'unknown']),
+      overnightGapCount: z.number(),
+      lastOvernightGapAt: z.string().optional(),
+      hasPowerIssue: z.boolean(),
+      recommendation: z.string().optional(),
+    })
+    .optional(),
+});
+export type ITrackerStatus = z.infer<typeof TrackerStatusSchema>;
 
 /**
  * Respuesta del endpoint /tripero/status/:id
  */
-export interface ITrackerStatusResponse {
-  success: boolean;
-  data: ITrackerStatus;
-}
+export const TrackerStatusResponseSchema = z.object({
+  success: z.boolean(),
+  data: TrackerStatusSchema,
+});
+export type ITrackerStatusResponse = z.infer<
+  typeof TrackerStatusResponseSchema
+>;
 
-export interface Trip {
-  deviceId?: number;
-  deviceName?: string;
-  maxSpeed?: number;
-  averageSpeed?: number;
-  distance?: number;
-  spentFuel?: number;
-  duration?: number;
-  startTime?: string;
-  startAddress?: string;
-  startLat?: number;
-  startLon?: number;
-  endTime?: string;
-  endAddress?: string;
-  endLat?: number;
-  endLon?: number;
-  driverUniqueId?: number;
-  driverName?: string;
-}
+export const TripSchema = z.object({
+  deviceId: z.number().optional(),
+  deviceName: z.string().optional(),
+  maxSpeed: z.number().optional(),
+  averageSpeed: z.number().optional(),
+  distance: z.number().optional(),
+  spentFuel: z.number().optional(),
+  duration: z.number().optional(),
+  startTime: z.string().optional(),
+  startAddress: z.string().optional(),
+  startLat: z.number().optional(),
+  startLon: z.number().optional(),
+  endTime: z.string().optional(),
+  endAddress: z.string().optional(),
+  endLat: z.number().optional(),
+  endLon: z.number().optional(),
+  driverUniqueId: z.number().optional(),
+  driverName: z.string().optional(),
+});
+export type Trip = z.infer<typeof TripSchema>;
 
-export interface Stop {
-  deviceId?: number;
-  deviceName?: string;
-  distance?: number;
-  averageSpeed?: number;
-  maxSpeed?: number;
-  spentFuel?: number;
-  startOdometer?: number;
-  endOdometer?: number;
-  startTime?: string;
-  endTime?: string;
-  positionId?: number;
-  latitude?: number;
-  longitude?: number;
-  address?: string;
-  duration?: number;
-  engineHours?: number;
-}
+export const StopSchema = z.object({
+  deviceId: z.number().optional(),
+  deviceName: z.string().optional(),
+  distance: z.number().optional(),
+  averageSpeed: z.number().optional(),
+  maxSpeed: z.number().optional(),
+  spentFuel: z.number().optional(),
+  startOdometer: z.number().optional(),
+  endOdometer: z.number().optional(),
+  startTime: z.string().optional(),
+  endTime: z.string().optional(),
+  positionId: z.number().optional(),
+  latitude: z.number().optional(),
+  longitude: z.number().optional(),
+  address: z.string().optional(),
+  duration: z.number().optional(),
+  engineHours: z.number().optional(),
+});
+export type Stop = z.infer<typeof StopSchema>;
 
-export interface IQueryTripero {
-  idVehiculo: string;
-  from: string;
-  to: string;
-  limit?: number;
-}
+export const QueryTriperoSchema = z.object({
+  idVehiculo: z.string(),
+  from: z.string(),
+  to: z.string(),
+  limit: z.number().optional(),
+});
+export type IQueryTripero = z.infer<typeof QueryTriperoSchema>;

--- a/src/interfaces/activo.ts
+++ b/src/interfaces/activo.ts
@@ -1,38 +1,86 @@
-import { ICliente, IConfigHorario } from './cliente';
-import { IModoDesactivado } from './dispositivo-alarma';
-import { estadoCuenta } from './estado-entidad';
-import { IGrupo } from './grupo';
-import { IRecorrido } from './recorrido';
-import { ITracker } from './tracker';
-import { IUsuario } from './usuario';
+import { z } from 'zod';
+import {
+  ClienteSchema,
+  ConfigHorarioSchema,
+  ICliente,
+  IConfigHorario,
+} from './cliente';
+import type { IModoDesactivado } from './dispositivo-alarma';
+import type { estadoCuenta } from './estado-entidad';
+import type { IGrupo } from './grupo';
+import type { IRecorrido } from './recorrido';
+import type { ITracker } from './tracker';
+import type { IUsuario } from './usuario';
 
-export type TipoVehiculo =
-  | 'Auto'
-  | 'Camion'
-  | 'Camioneta'
-  | 'Colectivo'
-  | 'Grua'
-  | 'Moto'
-  | 'Otro';
+export const TipoVehiculoSchema = z.enum([
+  'Auto',
+  'Camion',
+  'Camioneta',
+  'Colectivo',
+  'Grua',
+  'Moto',
+  'Otro',
+]);
+export type TipoVehiculo = z.infer<typeof TipoVehiculoSchema>;
 
-export type FuncionActivo =
-  | 'Ambulancia'
-  | 'Bomberos'
-  | 'Mantenimiento'
-  | 'Particular'
-  | 'Policia'
-  | 'Seguridad Privada'
-  | 'Servicio Técnico'
-  | 'Transporte'
-  | 'Otro';
+export const FuncionActivoSchema = z.enum([
+  'Ambulancia',
+  'Bomberos',
+  'Mantenimiento',
+  'Particular',
+  'Policia',
+  'Seguridad Privada',
+  'Servicio Técnico',
+  'Transporte',
+  'Otro',
+]);
+export type FuncionActivo = z.infer<typeof FuncionActivoSchema>;
 
-export type EstadoVehiculo =
-  | 'Operativo'
-  | 'En mantenimiento'
-  | 'Fuera de servicio';
+export const EstadoVehiculoSchema = z.enum([
+  'Operativo',
+  'En mantenimiento',
+  'Fuera de servicio',
+]);
+export type EstadoVehiculo = z.infer<typeof EstadoVehiculoSchema>;
 
-export type ICategoriaActivo = 'Normal' | 'Vehículo' | 'Colectivo';
+export const CategoriaActivoSchema = z.enum([
+  'Normal',
+  'Vehículo',
+  'Colectivo',
+]);
+export type ICategoriaActivo = z.infer<typeof CategoriaActivoSchema>;
 
+// Populates intra-SCC como z.custom (import type-only): un schema real acá
+// arrastra el shape completo del ciclo y revienta la serialización de
+// declarations (TS7056) acá y en los consumidores NestJS.
+export const VehiculoSchema = z.object({
+  tipo: TipoVehiculoSchema.optional(),
+  patente: z.string().optional(),
+  estado: EstadoVehiculoSchema.optional(),
+  modelo: z.string().optional(),
+  marca: z.string().optional(),
+  anio: z.string().optional(),
+  consumoRuta: z.number().optional(), // litros cada 100 km
+  consumoCiudad: z.number().optional(), // litros cada 100 km
+  capacidadCombustible: z.number().optional(), // litros
+  //
+  idChofer: z.string().optional(),
+  idRecorrido: z.string().optional(),
+  idsRecorridos: z.array(z.string()).optional(),
+  dentroDelRecorrido: z.boolean().optional(), // Para seguir el estado de los eventos
+  ignicion: z.boolean().optional(),
+  //
+  idExterno: z.string().optional(),
+  // Populate
+  chofer: z.custom<IUsuario>().optional(),
+  recorrido: z.custom<IRecorrido>().optional(),
+  recorridos: z.array(z.custom<IRecorrido>()).optional(),
+});
+
+/**
+ * Interface hand-written (misma forma que el schema): los tipos de entidad del
+ * SCC no usan z.infer para no arrastrar el ciclo en el declaration emit.
+ */
 export interface IVehiculo {
   tipo?: TipoVehiculo;
   patente?: string;
@@ -57,11 +105,51 @@ export interface IVehiculo {
   recorridos?: IRecorrido[];
 }
 
+export const VehiculoCacheSchema = VehiculoSchema.omit({
+  chofer: true,
+  recorrido: true,
+  recorridos: true,
+});
 export interface IVehiculoCache extends Omit<
   IVehiculo,
   'chofer' | 'recorrido' | 'recorridos'
 > {}
 
+export const ActivoSchema = z.object({
+  _id: z.string().optional(),
+  //
+  idCliente: z.string().optional(),
+  idsAncestros: z.array(z.string()).optional(),
+  idGrupo: z.string().optional(),
+  idTracker: z.string().optional(),
+  ///alta de activo
+  fechaAlta: z.string().optional(),
+  imagenes: z.array(z.string()).optional(),
+  // es la imagen en la posición 0 de imagenes, pero reducida para usarla en el mapa
+  imagenMiniatura: z.string().optional(),
+  identificacion: z.string().optional(),
+  categoria: CategoriaActivoSchema.optional(),
+  funcion: FuncionActivoSchema.optional(),
+  vehiculo: VehiculoSchema.optional(),
+  idsClientesQuePuedenAtender: z.array(z.string()).optional(),
+  idsClientesQuePuedenAtenderEventosTecnicos: z.array(z.string()).optional(),
+  puedeSolicitarServicioTecnico: z.boolean().optional(),
+  configHorariosAtencion: z.array(ConfigHorarioSchema).optional(),
+  configHorariosAtencionTecnica: z.array(ConfigHorarioSchema).optional(),
+  modoDesactivado: z.custom<IModoDesactivado>().optional(),
+
+  estadoCuenta: z.custom<estadoCuenta>().optional(),
+  // Populate
+  cliente: ClienteSchema.optional(),
+  ancestros: z.array(ClienteSchema).optional(),
+  tracker: z.custom<ITracker>().optional(),
+  grupo: z.custom<IGrupo>().optional(),
+});
+
+/**
+ * Interface hand-written (misma forma que el schema): los tipos de entidad del
+ * SCC no usan z.infer para no arrastrar el ciclo en el declaration emit.
+ */
 export interface IActivo {
   _id?: string;
   //
@@ -95,12 +183,31 @@ export interface IActivo {
 
 type OmitirCreate = '_id' | 'cliente' | 'tracker';
 
+export const CreateActivoSchema = ActivoSchema.omit({
+  _id: true,
+  cliente: true,
+  tracker: true,
+});
 export interface ICreateActivo extends Omit<Partial<IActivo>, OmitirCreate> {}
 
 type OmitirUpdate = '_id' | 'cliente' | 'tracker';
 
+export const UpdateActivoSchema = ActivoSchema.omit({
+  _id: true,
+  cliente: true,
+  tracker: true,
+});
 export interface IUpdateActivo extends Omit<Partial<IActivo>, OmitirUpdate> {}
 
+export const ActivoCacheSchema = ActivoSchema.omit({
+  cliente: true,
+  ancestros: true,
+  tracker: true,
+  grupo: true,
+  vehiculo: true,
+}).extend({
+  vehiculo: VehiculoCacheSchema.optional(),
+});
 export interface IActivoCache extends Omit<
   IActivo,
   'cliente' | 'ancestros' | 'tracker' | 'grupo' | 'vehiculo'

--- a/src/interfaces/alerta-boton-ble.ts
+++ b/src/interfaces/alerta-boton-ble.ts
@@ -1,29 +1,34 @@
-import { ICliente } from "./cliente";
-import { IDispositivoLorawan } from "./dispositivo-lorawan";
-import { ILuminaria } from "./luminaria";
+import { z } from "zod";
+import { ClienteSchema } from "./cliente";
+import { DispositivoLorawanSchema } from "./dispositivo-lorawan";
+import { LuminariaSchema } from "./luminaria";
 
-export interface IAlertaBotonBLE {
-  _id?: string;
-  idCliente?: string;
-  idsAncestros?: string[];
-  fechaCreacion?: string;
-  idDispositivoLorawan?: string;
-  idLuminaria?: string;
-  mac?: string;
+export const AlertaBotonBLESchema = z.object({
+  _id: z.string().optional(),
+  idCliente: z.string().optional(),
+  idsAncestros: z.array(z.string()).optional(),
+  fechaCreacion: z.string().optional(),
+  idDispositivoLorawan: z.string().optional(),
+  idLuminaria: z.string().optional(),
+  mac: z.string().optional(),
 
   //Populate
-  dispositivoLorawan?: IDispositivoLorawan;
-  luminaria?: ILuminaria;
-  cliente?: ICliente;
-  ancestros?: ICliente[];
-}
+  dispositivoLorawan: DispositivoLorawanSchema.optional(),
+  luminaria: LuminariaSchema.optional(),
+  cliente: ClienteSchema.optional(),
+  ancestros: z.array(ClienteSchema).optional(),
+});
+export type IAlertaBotonBLE = z.infer<typeof AlertaBotonBLESchema>;
 
-type OmitirCreate = "_id" | "fechaCreacion";
+export const CreateAlertaBotonBLESchema = AlertaBotonBLESchema.omit({
+  _id: true,
+  fechaCreacion: true,
+});
+export type ICreateAlertaBotonBLE = z.infer<typeof CreateAlertaBotonBLESchema>;
 
-export interface ICreateAlertaBotonBLE
-  extends Omit<Partial<IAlertaBotonBLE>, OmitirCreate> {}
-
-type OmitirUpdate = "_id" | "fechaCreacion" | "cliente";
-
-export interface IUpdateAlertaBotonBLE
-  extends Omit<Partial<IAlertaBotonBLE>, OmitirUpdate> {}
+export const UpdateAlertaBotonBLESchema = AlertaBotonBLESchema.omit({
+  _id: true,
+  fechaCreacion: true,
+  cliente: true,
+});
+export type IUpdateAlertaBotonBLE = z.infer<typeof UpdateAlertaBotonBLESchema>;

--- a/src/interfaces/apikey.ts
+++ b/src/interfaces/apikey.ts
@@ -1,28 +1,35 @@
-import { ICliente } from './cliente';
+import { z } from 'zod';
+import { ClienteSchema } from './cliente';
 
-export interface IApikey {
-  _id?: string;
+export const ModuloSchema = z.enum(['flotas', 'alarmas']);
+export type Modulo = z.infer<typeof ModuloSchema>;
+
+export const ApikeySchema = z.object({
+  _id: z.string().optional(),
   //
-  identificacion?: string;
-  key?: string;
+  identificacion: z.string().optional(),
+  key: z.string().optional(),
   // Permisos
-  global?: boolean; // Si es global, no se le asignan clientes
-  idCreador?: string; // Si es global. Es lo que puede ver ese cliente.
-  idClientes?: string[]; // Si no es global, se le asignan clientes
-  modulos?: Modulo[]; // Flotas - Alarmas - etc
+  global: z.boolean().optional(), // Si es global, no se le asignan clientes
+  idCreador: z.string().optional(), // Si es global. Es lo que puede ver ese cliente.
+  idClientes: z.array(z.string()).optional(), // Si no es global, se le asignan clientes
+  modulos: z.array(ModuloSchema).optional(), // Flotas - Alarmas - etc
 
   // Populate
-  cliente?: ICliente;
-  ancestros?: ICliente[]; // Este sería el creador
-  clientes?: ICliente[]; // Estos son los elegidos para ver
-}
+  cliente: ClienteSchema.optional(),
+  ancestros: z.array(ClienteSchema).optional(), // Este sería el creador
+  clientes: z.array(ClienteSchema).optional(), // Estos son los elegidos para ver
+});
+export type IApikey = z.infer<typeof ApikeySchema>;
 
-type OmitirCreate = '_id' | 'clientes';
+export const CreateApikeySchema = ApikeySchema.omit({
+  _id: true,
+  clientes: true,
+});
+export type ICreateApikey = z.infer<typeof CreateApikeySchema>;
 
-export interface ICreateApikey extends Omit<Partial<IApikey>, OmitirCreate> {}
-
-type OmitirUpdate = '_id' | 'clientes';
-
-export interface IUpdateApikey extends Omit<Partial<IApikey>, OmitirUpdate> {}
-
-export type Modulo = 'flotas' | 'alarmas';
+export const UpdateApikeySchema = ApikeySchema.omit({
+  _id: true,
+  clientes: true,
+});
+export type IUpdateApikey = z.infer<typeof UpdateApikeySchema>;

--- a/src/interfaces/asignacion.ts
+++ b/src/interfaces/asignacion.ts
@@ -1,79 +1,77 @@
-import { ICliente } from './cliente';
-import { IActivo } from './activo';
-import { ITracker } from './tracker';
-import { IUsuario } from './usuario';
+import { z } from 'zod';
+import { ClienteSchema } from './cliente';
+import { ActivoSchema } from './activo';
+import { TrackerSchema } from './tracker';
+import { UsuarioSchema } from './usuario';
 
-export type IEntidades =
-  | 'Chofer'
-  | 'Activo'
-  | 'Tracker'
-  | 'Luminaria'
-  | 'Cliente'
-  | 'Alarma'
-  | 'Vehículo'
-  | 'Colectivo'
-  | 'Dispositivo Lorawan'
-  | 'Puesta'
-  | 'Grupo'
-  | 'Configuración de Perfil';
+export const EntidadesSchema = z.enum([
+  'Chofer',
+  'Activo',
+  'Tracker',
+  'Luminaria',
+  'Cliente',
+  'Alarma',
+  'Vehículo',
+  'Colectivo',
+  'Dispositivo Lorawan',
+  'Puesta',
+  'Grupo',
+  'Configuración de Perfil',
+]);
+export type IEntidades = z.infer<typeof EntidadesSchema>;
 
-export interface IAsignacion {
-  _id?: string;
+export const AsignacionSchema = z.object({
+  _id: z.string().optional(),
   //
-  fechaAsignacion?: string;
-  fechaDesasignacion?: string;
-  idCliente?: string;
-  idsAncestros?: string[];
-  idUsuario?: string;
+  fechaAsignacion: z.string().optional(),
+  fechaDesasignacion: z.string().optional(),
+  idCliente: z.string().optional(),
+  idsAncestros: z.array(z.string()).optional(),
+  idUsuario: z.string().optional(),
 
   // Id de la entidad a la que se le asigna algo
-  idEntidadModificada?: string;
-  tipoEntidadModificada?: IEntidades;
-  nombreEntidadModificada?: string;
+  idEntidadModificada: z.string().optional(),
+  tipoEntidadModificada: EntidadesSchema.optional(),
+  nombreEntidadModificada: z.string().optional(),
   // Id de la entidad que se asigna a la otra
-  idEntidadAsignada?: string;
-  tipoEntidadAsignada?: IEntidades;
-  nombreEntidadAsignada?: string;
+  idEntidadAsignada: z.string().optional(),
+  tipoEntidadAsignada: EntidadesSchema.optional(),
+  nombreEntidadAsignada: z.string().optional(),
 
   // Populate
-  cliente?: ICliente;
-  usuario?: IUsuario;
-  choferModificado?: IUsuario;
-  activoModificado?: IActivo;
-  trackerModificado?: ITracker;
-  choferAsignado?: IUsuario;
-  activoAsignado?: IActivo;
-  trackerAsignado?: ITracker;
-}
+  cliente: ClienteSchema.optional(),
+  usuario: UsuarioSchema.optional(),
+  choferModificado: UsuarioSchema.optional(),
+  activoModificado: ActivoSchema.optional(),
+  trackerModificado: TrackerSchema.optional(),
+  choferAsignado: UsuarioSchema.optional(),
+  activoAsignado: ActivoSchema.optional(),
+  trackerAsignado: TrackerSchema.optional(),
+});
+export type IAsignacion = z.infer<typeof AsignacionSchema>;
 
-type OmitirCreate =
-  | '_id'
-  | 'cliente'
-  | 'usuario'
-  | 'choferModificado'
-  | 'activoModificado'
-  | 'trackerModificado'
-  | 'choferAsignado'
-  | 'activoAsignado'
-  | 'trackerAsignado';
+export const CreateAsignacionSchema = AsignacionSchema.omit({
+  _id: true,
+  cliente: true,
+  usuario: true,
+  choferModificado: true,
+  activoModificado: true,
+  trackerModificado: true,
+  choferAsignado: true,
+  activoAsignado: true,
+  trackerAsignado: true,
+});
+export type ICreateAsignacion = z.infer<typeof CreateAsignacionSchema>;
 
-export interface ICreateAsignacion extends Omit<
-  Partial<IAsignacion>,
-  OmitirCreate
-> {}
-
-type OmitirUpdate =
-  | '_id'
-  | 'cliente'
-  | 'usuario'
-  | 'choferModificado'
-  | 'activoModificado'
-  | 'trackerModificado'
-  | 'choferAsignado'
-  | 'activoAsignado'
-  | 'trackerAsignado';
-
-export interface IUpdateAsignacion extends Omit<
-  Partial<IAsignacion>,
-  OmitirUpdate
-> {}
+export const UpdateAsignacionSchema = AsignacionSchema.omit({
+  _id: true,
+  cliente: true,
+  usuario: true,
+  choferModificado: true,
+  activoModificado: true,
+  trackerModificado: true,
+  choferAsignado: true,
+  activoAsignado: true,
+  trackerAsignado: true,
+});
+export type IUpdateAsignacion = z.infer<typeof UpdateAsignacionSchema>;

--- a/src/interfaces/auditoria.ts
+++ b/src/interfaces/auditoria.ts
@@ -1,33 +1,36 @@
-import { ICliente } from './cliente';
-import { IUsuario } from './usuario';
+import { z } from 'zod';
+import { ClienteSchema } from './cliente';
+import { UsuarioSchema } from './usuario';
 
-export type AccionAuditoria = 'Crear' | 'Editar' | 'Eliminar';
+export const AccionAuditoriaSchema = z.enum(['Crear', 'Editar', 'Eliminar']);
+export type AccionAuditoria = z.infer<typeof AccionAuditoriaSchema>;
 
-export interface IAuditoria {
-  _id?: string;
-  idCliente?: string;
-  idsAncestros?: string[];
-  fechaCreacion?: string;
-  idUsuario?: string;
-  nombreUsuario?: string; // se persiste por si se borra el usuario
-  entidad?: string; // 'activos', 'usuarios', 'clientes', etc.
-  subPath?: string; // Lo que sigue en la ruta despues de la entidad
-  idEntidad?: string; // ID del documento afectado
-  accion?: AccionAuditoria;
-  cambios?: Record<string, unknown>; // { campo: valorNuevo }
-  valoresAnteriores?: Record<string, unknown>; // { campo: valorAntes } — solo para Editar
-  camposModificados?: string[]; // ['nombre', 'descripcion'] — indexable
+export const AuditoriaSchema = z.object({
+  _id: z.string().optional(),
+  idCliente: z.string().optional(),
+  idsAncestros: z.array(z.string()).optional(),
+  fechaCreacion: z.string().optional(),
+  idUsuario: z.string().optional(),
+  nombreUsuario: z.string().optional(), // se persiste por si se borra el usuario
+  entidad: z.string().optional(), // 'activos', 'usuarios', 'clientes', etc.
+  subPath: z.string().optional(), // Lo que sigue en la ruta despues de la entidad
+  idEntidad: z.string().optional(), // ID del documento afectado
+  accion: AccionAuditoriaSchema.optional(),
+  cambios: z.record(z.string(), z.unknown()).optional(), // { campo: valorNuevo }
+  valoresAnteriores: z.record(z.string(), z.unknown()).optional(), // { campo: valorAntes } — solo para Editar
+  camposModificados: z.array(z.string()).optional(), // ['nombre', 'descripcion'] — indexable
 
   // Populate
-  usuario?: IUsuario;
-  cliente?: ICliente;
-  ancestros?: ICliente[];
-}
+  usuario: UsuarioSchema.optional(),
+  cliente: ClienteSchema.optional(),
+  ancestros: z.array(ClienteSchema).optional(),
+});
+export type IAuditoria = z.infer<typeof AuditoriaSchema>;
 
-type OmitirCreate = '_id' | 'fechaCreacion';
-export interface ICreateAuditoria extends Omit<
-  Partial<IAuditoria>,
-  OmitirCreate
-> {}
+export const CreateAuditoriaSchema = AuditoriaSchema.omit({
+  _id: true,
+  fechaCreacion: true,
+});
+export type ICreateAuditoria = z.infer<typeof CreateAuditoriaSchema>;
 
 /// LAS AUDITORIAS SON INMUTABLES, FER.

--- a/src/interfaces/boton-bluetooth.ts
+++ b/src/interfaces/boton-bluetooth.ts
@@ -1,28 +1,32 @@
-import { ICliente } from './cliente';
-import { IModeloDispositivo } from './modelo-dispositivo';
+import { z } from 'zod';
+import { ClienteSchema } from './cliente';
+import { ModeloDispositivoSchema } from './modelo-dispositivo';
 
-export interface IBotonBluetooth {
-  _id?: string;
-  idModeloDispositivo?: string;
+export const BotonBluetoothSchema = z.object({
+  _id: z.string().optional(),
+  idModeloDispositivo: z.string().optional(),
 
-  fechaCreacion?: string;
-  idCliente?: string;
-  idsAncestros?: string[];
-  mac?: string;
-  serialNumber?: string;
+  fechaCreacion: z.string().optional(),
+  idCliente: z.string().optional(),
+  idsAncestros: z.array(z.string()).optional(),
+  mac: z.string().optional(),
+  serialNumber: z.string().optional(),
 
   //Populate
-  cliente?: ICliente;
-  ancestros?: ICliente[];
-  modeloDispositivo?: IModeloDispositivo;
-}
+  cliente: ClienteSchema.optional(),
+  ancestros: z.array(ClienteSchema).optional(),
+  modeloDispositivo: ModeloDispositivoSchema.optional(),
+});
+export type IBotonBluetooth = z.infer<typeof BotonBluetoothSchema>;
 
-type OmitirCreate = '_id' | 'cliente';
+export const CreateBotonBluetoothSchema = BotonBluetoothSchema.omit({
+  _id: true,
+  cliente: true,
+});
+export type ICreateBotonBluetooth = z.infer<typeof CreateBotonBluetoothSchema>;
 
-export interface ICreateBotonBluetooth
-  extends Omit<Partial<IBotonBluetooth>, OmitirCreate> {}
-
-type OmitirUpdate = '_id' | 'cliente';
-
-export interface IUpdateBotonBluetooth
-  extends Omit<Partial<IBotonBluetooth>, OmitirUpdate> {}
+export const UpdateBotonBluetoothSchema = BotonBluetoothSchema.omit({
+  _id: true,
+  cliente: true,
+});
+export type IUpdateBotonBluetooth = z.infer<typeof UpdateBotonBluetoothSchema>;

--- a/src/interfaces/camara.ts
+++ b/src/interfaces/camara.ts
@@ -1,58 +1,78 @@
-import { ICliente } from './cliente';
-import { IModeloDispositivo } from './modelo-dispositivo';
+import { z } from 'zod';
+import { ClienteSchema } from './cliente';
+import { ModeloDispositivoSchema } from './modelo-dispositivo';
 
-export type TipoHabilitacion = 'Siempre' | 'Con Evento';
-export type TipoCamara = 'Hikvision' | 'Dahua' | 'Hikvision P2P' | 'Dahua P2P';
+export const TipoHabilitacionSchema = z.enum(['Siempre', 'Con Evento']);
+export type TipoHabilitacion = z.infer<typeof TipoHabilitacionSchema>;
 
-export interface ICanalesCamara {
-  numero: string; // 1
-  ids: {
-    id: string;
-    width: number;
-    height: number;
-  }[];
-  idModeloDispositivo?: string;
-  nombre?: string;
-  descripcion?: string;
-  tipoHabilitacion?: TipoHabilitacion;
+export const TipoCamaraSchema = z.enum([
+  'Hikvision',
+  'Dahua',
+  'Hikvision P2P',
+  'Dahua P2P',
+]);
+export type TipoCamara = z.infer<typeof TipoCamaraSchema>;
+
+export const CanalesCamaraSchema = z.object({
+  numero: z.string(), // 1
+  ids: z.array(
+    z.object({
+      id: z.string(),
+      width: z.number(),
+      height: z.number(),
+    }),
+  ),
+  idModeloDispositivo: z.string().optional(),
+  nombre: z.string().optional(),
+  descripcion: z.string().optional(),
+  tipoHabilitacion: TipoHabilitacionSchema.optional(),
 
   // populate
-  modeloDispositivo?: IModeloDispositivo;
-}
+  modeloDispositivo: ModeloDispositivoSchema.optional(),
+});
+export type ICanalesCamara = z.infer<typeof CanalesCamaraSchema>;
 
-export interface ICredencialesDahua {
-  acceskeyDahua?: string;
-  secretKeyDahua?: string;
-  productID?: string;
-}
+export const CredencialesDahuaSchema = z.object({
+  acceskeyDahua: z.string().optional(),
+  secretKeyDahua: z.string().optional(),
+  productID: z.string().optional(),
+});
+export type ICredencialesDahua = z.infer<typeof CredencialesDahuaSchema>;
 
-export interface ICamara {
-  _id?: string;
-  idCliente?: string;
-  idsAncestros?: string[];
-  fechaCreacion?: string;
-  identificacion?: string;
-  canales?: ICanalesCamara[];
-  idModeloDispositivo?: string;
-  tipo?: TipoCamara;
-  numeroSerie?: string;
-  host?: string;
-  puertoRTSP?: number;
-  puertoHTTP?: number;
-  usuario?: string;
-  password?: string;
-  claveDeEncriptacion?: string;
-  credencialesDahua?: ICredencialesDahua;
+export const CamaraSchema = z.object({
+  _id: z.string().optional(),
+  idCliente: z.string().optional(),
+  idsAncestros: z.array(z.string()).optional(),
+  fechaCreacion: z.string().optional(),
+  identificacion: z.string().optional(),
+  canales: z.array(CanalesCamaraSchema).optional(),
+  idModeloDispositivo: z.string().optional(),
+  tipo: TipoCamaraSchema.optional(),
+  numeroSerie: z.string().optional(),
+  host: z.string().optional(),
+  puertoRTSP: z.number().optional(),
+  puertoHTTP: z.number().optional(),
+  usuario: z.string().optional(),
+  password: z.string().optional(),
+  claveDeEncriptacion: z.string().optional(),
+  credencialesDahua: CredencialesDahuaSchema.optional(),
   // Populate
-  cliente?: ICliente;
-  ancestros?: ICliente[];
-  modeloDispositivo?: IModeloDispositivo;
-}
+  cliente: ClienteSchema.optional(),
+  ancestros: z.array(ClienteSchema).optional(),
+  modeloDispositivo: ModeloDispositivoSchema.optional(),
+});
+export type ICamara = z.infer<typeof CamaraSchema>;
 
-type OmitirCreate = '_id' | 'cliente' | 'modeloDispositivo';
+export const CreateCamaraSchema = CamaraSchema.omit({
+  _id: true,
+  cliente: true,
+  modeloDispositivo: true,
+});
+export type ICreateCamara = z.infer<typeof CreateCamaraSchema>;
 
-export interface ICreateCamara extends Omit<Partial<ICamara>, OmitirCreate> {}
-
-type OmitirUpdate = '_id' | 'cliente' | 'modeloDispositivo';
-
-export interface IUpdateCamara extends Omit<Partial<ICamara>, OmitirUpdate> {}
+export const UpdateCamaraSchema = CamaraSchema.omit({
+  _id: true,
+  cliente: true,
+  modeloDispositivo: true,
+});
+export type IUpdateCamara = z.infer<typeof UpdateCamaraSchema>;

--- a/src/interfaces/categoria-evento.ts
+++ b/src/interfaces/categoria-evento.ts
@@ -1,43 +1,58 @@
-import { ICliente } from "./cliente";
+import { z } from "zod";
+import { ClienteSchema } from "./cliente";
 
-export type SonidoEvento = "Silencio" | "Campana" | "Sirena";
-export type TipoCategoria =
-  | "Activo"
-  | "Vehiculo"
-  | "Alarma"
-  | "Luminaria"
-  | "Sistema"
-  | "Otro";
+export const SonidoEventoSchema = z.enum(["Silencio", "Campana", "Sirena"]);
+export type SonidoEvento = z.infer<typeof SonidoEventoSchema>;
 
-export interface ICategoriaEvento {
-  _id?: string;
+export const TipoCategoriaSchema = z.enum([
+  "Activo",
+  "Vehiculo",
+  "Alarma",
+  "Luminaria",
+  "Sistema",
+  "Otro",
+]);
+export type TipoCategoria = z.infer<typeof TipoCategoriaSchema>;
+
+export const CategoriaEventoSchema = z.object({
+  _id: z.string().optional(),
   //
-  nombre?: string; // BUR
-  prioridad?: number; // 100
-  color?: string;
-  notificar?: boolean;
-  atender?: boolean;
-  noDerivar?: boolean;
-  sonido?: SonidoEvento;
-  modulo?: TipoCategoria;
-  idCliente?: string;
-  idsAncestros?: string[];
-  default?: boolean;
-  global?: boolean;
+  nombre: z.string().optional(), // BUR
+  prioridad: z.number().optional(), // 100
+  color: z.string().optional(),
+  notificar: z.boolean().optional(),
+  atender: z.boolean().optional(),
+  noDerivar: z.boolean().optional(),
+  sonido: SonidoEventoSchema.optional(),
+  modulo: TipoCategoriaSchema.optional(),
+  idCliente: z.string().optional(),
+  idsAncestros: z.array(z.string()).optional(),
+  default: z.boolean().optional(),
+  global: z.boolean().optional(),
   //Populate
-  cliente?: ICliente;
-  ancestros?: ICliente[];
-}
+  cliente: ClienteSchema.optional(),
+  ancestros: z.array(ClienteSchema).optional(),
+});
+export type ICategoriaEvento = z.infer<typeof CategoriaEventoSchema>;
 
-type OmitirCreate = "_id" | "cliente";
+export const CreateCategoriaEventoSchema = CategoriaEventoSchema.omit({
+  _id: true,
+  cliente: true,
+});
+export type ICreateCategoriaEvento = z.infer<
+  typeof CreateCategoriaEventoSchema
+>;
 
-export interface ICreateCategoriaEvento
-  extends Omit<Partial<ICategoriaEvento>, OmitirCreate> {}
+export const UpdateCategoriaEventoSchema = CategoriaEventoSchema.omit({
+  _id: true,
+  cliente: true,
+});
+export type IUpdateCategoriaEvento = z.infer<
+  typeof UpdateCategoriaEventoSchema
+>;
 
-type OmitirUpdate = "_id" | "cliente";
-
-export interface IUpdateCategoriaEvento
-  extends Omit<Partial<ICategoriaEvento>, OmitirUpdate> {}
-
-export interface ICategoriaEventoCache
-  extends Omit<ICategoriaEvento, "cliente" | "ancestros"> {}
+export const CategoriaEventoCacheSchema = CategoriaEventoSchema.omit({
+  cliente: true,
+  ancestros: true,
+});
+export type ICategoriaEventoCache = z.infer<typeof CategoriaEventoCacheSchema>;

--- a/src/interfaces/certificado-entidad.ts
+++ b/src/interfaces/certificado-entidad.ts
@@ -1,34 +1,48 @@
-import { IActivo } from './activo';
-import { ICliente } from './cliente';
-import { ICodigoDispositivo } from './codigos-dispositivo';
-import { IDispositivoAlarma } from './dispositivo-alarma';
-import { IEventoGenerico } from './evento-generico';
-import { ITracker } from './tracker';
+import { z } from 'zod';
+import { ActivoSchema } from './activo';
+import { ClienteSchema } from './cliente';
+import { CodigoDispositivoSchema } from './codigos-dispositivo';
+import { DispositivoAlarmaSchema } from './dispositivo-alarma';
+import type { IEventoGenerico } from './evento-generico';
+import { TrackerSchema } from './tracker';
 
-export interface ICertificadoEntidad {
-  _id?: string;
+export const CertificadoEntidadSchema = z.object({
+  _id: z.string().optional(),
   //
-  idCliente?: string;
-  idsAncestros?: string[];
+  idCliente: z.string().optional(),
+  idsAncestros: z.array(z.string()).optional(),
   //
-  idEntidad?: string;
-  fechaComienzo?: string;
-  fechaEmision?: string;
-  eventosRegistrados?: IEventoGenerico[];
-  codigosEsperados?: ICodigoDispositivo[];
+  idEntidad: z.string().optional(),
+  fechaComienzo: z.string().optional(),
+  fechaEmision: z.string().optional(),
+  eventosRegistrados: z.array(z.custom<IEventoGenerico>()).optional(),
+  codigosEsperados: z.array(CodigoDispositivoSchema).optional(),
   // Populate
-  tracker?: ITracker;
-  activo?: IActivo;
-  alarma?: IDispositivoAlarma;
-  cliente?: ICliente;
-}
+  tracker: TrackerSchema.optional(),
+  activo: ActivoSchema.optional(),
+  alarma: DispositivoAlarmaSchema.optional(),
+  cliente: ClienteSchema.optional(),
+});
+export type ICertificadoEntidad = z.infer<typeof CertificadoEntidadSchema>;
 
-type OmitirCreate = '_id' | 'cliente' | 'tracker' | 'alarma' | 'activo';
+export const CreateCertificadoEntidadSchema = CertificadoEntidadSchema.omit({
+  _id: true,
+  cliente: true,
+  tracker: true,
+  alarma: true,
+  activo: true,
+});
+export type ICreateCertificadoEntidad = z.infer<
+  typeof CreateCertificadoEntidadSchema
+>;
 
-export interface ICreateCertificadoEntidad
-  extends Omit<Partial<ICertificadoEntidad>, OmitirCreate> {}
-
-type OmitirUpdate = '_id' | 'cliente' | 'tracker' | 'alarma' | 'activo';
-
-export interface IUpdateCertificadoEntidad
-  extends Omit<Partial<ICertificadoEntidad>, OmitirUpdate> {}
+export const UpdateCertificadoEntidadSchema = CertificadoEntidadSchema.omit({
+  _id: true,
+  cliente: true,
+  tracker: true,
+  alarma: true,
+  activo: true,
+});
+export type IUpdateCertificadoEntidad = z.infer<
+  typeof UpdateCertificadoEntidadSchema
+>;

--- a/src/interfaces/chirpstack/device-profile.ts
+++ b/src/interfaces/chirpstack/device-profile.ts
@@ -1,74 +1,89 @@
-export interface IGetDeviceProfileChirpstack {
-  id?: string;
-  createdAt?: string;
-  updatedAt?: string;
-  name?: string;
-  region?: string;
-  macVersion?: string;
-  regParamsRevision?: string;
-  supportsOtaa?: boolean;
-  supportsClassB?: boolean;
-  supportsClassC?: boolean;
-}
+import { z } from 'zod';
 
-export interface ICreateUpdateDeviceProfileChirpstack {
-  deviceProfile?: {
-    abpRx1Delay?: number;
-    abpRx1DrOffset?: number;
-    abpRx2Dr?: number;
-    abpRx2Freq?: number;
-    adrAlgorithmID?: string;
-    allowRoaming?: boolean;
-    autoDetectMeasurements?: boolean;
-    classBPingSlotDr?: number;
-    classBPingSlotFreq?: number;
-    classBPingSlotNbK?: number;
-    classBTimeout?: number;
-    classCTimeout?: number;
-    description?: string;
-    deviceStatusReqInterval?: number;
-    flushQueueOnActivate?: boolean;
-    id?: string;
-    isRelay?: boolean;
-    isRelayEd?: boolean;
-    macVersion?: string;
-    measurements?: { [key: string]: { kind: string; name: string } };
-    name?: string;
-    payloadCodecRuntime?: string;
-    payloadCodecScript?: string;
-    regParamsRevision?: string;
-    region?: string;
-    regionConfigId?: string;
-    relayCadPeriodicity?: string;
-    relayDefaultChannelIndex?: number;
-    relayEdActivationMode?: string;
-    relayEdBackOff?: number;
-    relayEdRelayOnly?: boolean;
-    relayEdSmartEnableLevel?: number;
-    relayEdUplinkLimitBucketSize?: number;
-    relayEdUplinkLimitReloadRate?: number;
-    relayEnabled?: boolean;
-    relayGlobalUplinkLimitBucketSize?: number;
-    relayGlobalUplinkLimitReloadRate?: number;
-    relayJoinReqLimitBucketSize?: number;
-    relayJoinReqLimitReloadRate?: number;
-    relayNotifyLimitBucketSize?: number;
-    relayNotifyLimitReloadRate?: number;
-    relayOverallLimitBucketSize?: number;
-    relayOverallLimitReloadRate?: number;
-    relaySecondChannelAckOffset?: string;
-    relaySecondChannelDr?: number;
-    relaySecondChannelFreq?: number;
-    rx1Delay?: number;
-    supportsClassB?: boolean;
-    supportsClassC?: boolean;
+export const GetDeviceProfileChirpstackSchema = z.object({
+  id: z.string().optional(),
+  createdAt: z.string().optional(),
+  updatedAt: z.string().optional(),
+  name: z.string().optional(),
+  region: z.string().optional(),
+  macVersion: z.string().optional(),
+  regParamsRevision: z.string().optional(),
+  supportsOtaa: z.boolean().optional(),
+  supportsClassB: z.boolean().optional(),
+  supportsClassC: z.boolean().optional(),
+});
+export type IGetDeviceProfileChirpstack = z.infer<
+  typeof GetDeviceProfileChirpstackSchema
+>;
 
-    //////////////////////////////////////////////////////////
-    supportsOtaa?: boolean;
-    /////////////////////////////////////////////////////////
+export const CreateUpdateDeviceProfileChirpstackSchema = z.object({
+  deviceProfile: z
+    .object({
+      abpRx1Delay: z.number().optional(),
+      abpRx1DrOffset: z.number().optional(),
+      abpRx2Dr: z.number().optional(),
+      abpRx2Freq: z.number().optional(),
+      adrAlgorithmID: z.string().optional(),
+      allowRoaming: z.boolean().optional(),
+      autoDetectMeasurements: z.boolean().optional(),
+      classBPingSlotDr: z.number().optional(),
+      classBPingSlotFreq: z.number().optional(),
+      classBPingSlotNbK: z.number().optional(),
+      classBTimeout: z.number().optional(),
+      classCTimeout: z.number().optional(),
+      description: z.string().optional(),
+      deviceStatusReqInterval: z.number().optional(),
+      flushQueueOnActivate: z.boolean().optional(),
+      id: z.string().optional(),
+      isRelay: z.boolean().optional(),
+      isRelayEd: z.boolean().optional(),
+      macVersion: z.string().optional(),
+      measurements: z
+        .record(
+          z.string(),
+          z.object({ kind: z.string(), name: z.string() }),
+        )
+        .optional(),
+      name: z.string().optional(),
+      payloadCodecRuntime: z.string().optional(),
+      payloadCodecScript: z.string().optional(),
+      regParamsRevision: z.string().optional(),
+      region: z.string().optional(),
+      regionConfigId: z.string().optional(),
+      relayCadPeriodicity: z.string().optional(),
+      relayDefaultChannelIndex: z.number().optional(),
+      relayEdActivationMode: z.string().optional(),
+      relayEdBackOff: z.number().optional(),
+      relayEdRelayOnly: z.boolean().optional(),
+      relayEdSmartEnableLevel: z.number().optional(),
+      relayEdUplinkLimitBucketSize: z.number().optional(),
+      relayEdUplinkLimitReloadRate: z.number().optional(),
+      relayEnabled: z.boolean().optional(),
+      relayGlobalUplinkLimitBucketSize: z.number().optional(),
+      relayGlobalUplinkLimitReloadRate: z.number().optional(),
+      relayJoinReqLimitBucketSize: z.number().optional(),
+      relayJoinReqLimitReloadRate: z.number().optional(),
+      relayNotifyLimitBucketSize: z.number().optional(),
+      relayNotifyLimitReloadRate: z.number().optional(),
+      relayOverallLimitBucketSize: z.number().optional(),
+      relayOverallLimitReloadRate: z.number().optional(),
+      relaySecondChannelAckOffset: z.string().optional(),
+      relaySecondChannelDr: z.number().optional(),
+      relaySecondChannelFreq: z.number().optional(),
+      rx1Delay: z.number().optional(),
+      supportsClassB: z.boolean().optional(),
+      supportsClassC: z.boolean().optional(),
 
-    tags?: Record<string, string>;
-    tenantId?: string;
-    uplinkInterval?: number;
-  };
-}
+      //////////////////////////////////////////////////////////
+      supportsOtaa: z.boolean().optional(),
+      /////////////////////////////////////////////////////////
+
+      tags: z.record(z.string(), z.string()).optional(),
+      tenantId: z.string().optional(),
+      uplinkInterval: z.number().optional(),
+    })
+    .optional(),
+});
+export type ICreateUpdateDeviceProfileChirpstack = z.infer<
+  typeof CreateUpdateDeviceProfileChirpstackSchema
+>;

--- a/src/interfaces/chirpstack/dispositivo-chirpstack.ts
+++ b/src/interfaces/chirpstack/dispositivo-chirpstack.ts
@@ -1,31 +1,39 @@
-export interface ICreateUpdateDeviceChirpstack {
-  device?: IDeviceInfo;
-}
+import { z } from 'zod';
 
-export interface IDeviceInfo {
-  applicationId?: string;
-  description?: string;
-  devEui?: string;
-  deviceProfileId?: string;
-  isDisabled?: boolean;
-  joinEui?: string;
-  name?: string;
-  skipFcntCheck?: boolean;
-  tags?: Record<string, string>;
-  variables?: Record<string, string>;
-}
+export const DeviceInfoChirpstackSchema = z.object({
+  applicationId: z.string().optional(),
+  description: z.string().optional(),
+  devEui: z.string().optional(),
+  deviceProfileId: z.string().optional(),
+  isDisabled: z.boolean().optional(),
+  joinEui: z.string().optional(),
+  name: z.string().optional(),
+  skipFcntCheck: z.boolean().optional(),
+  tags: z.record(z.string(), z.string()).optional(),
+  variables: z.record(z.string(), z.string()).optional(),
+});
+export type IDeviceInfo = z.infer<typeof DeviceInfoChirpstackSchema>;
 
-export interface IDeviceStatus {
-  batteryLevel?: number;
-  externalPowerSource?: boolean;
-  margin?: number;
-}
+export const CreateUpdateDeviceChirpstackSchema = z.object({
+  device: DeviceInfoChirpstackSchema.optional(),
+});
+export type ICreateUpdateDeviceChirpstack = z.infer<
+  typeof CreateUpdateDeviceChirpstackSchema
+>;
 
-export interface IDeviceChirpstack {
-  classEnabled?: string;
-  createdAt?: string;
-  lastSeenAt?: string;
-  updatedAt?: string;
-  device?: IDeviceInfo;
-  deviceStatus?: IDeviceStatus;
-}
+export const DeviceStatusSchema = z.object({
+  batteryLevel: z.number().optional(),
+  externalPowerSource: z.boolean().optional(),
+  margin: z.number().optional(),
+});
+export type IDeviceStatus = z.infer<typeof DeviceStatusSchema>;
+
+export const DeviceChirpstackSchema = z.object({
+  classEnabled: z.string().optional(),
+  createdAt: z.string().optional(),
+  lastSeenAt: z.string().optional(),
+  updatedAt: z.string().optional(),
+  device: DeviceInfoChirpstackSchema.optional(),
+  deviceStatus: DeviceStatusSchema.optional(),
+});
+export type IDeviceChirpstack = z.infer<typeof DeviceChirpstackSchema>;

--- a/src/interfaces/chirpstack/dispositivos-activation.ts
+++ b/src/interfaces/chirpstack/dispositivos-activation.ts
@@ -1,13 +1,20 @@
-export interface ICreateUpdateDeviceActivation {
-  deviceActivation?: {
-    description?: string;
-    aFCntDown?: number;
-    appSKey?: string;
-    devAddr?: string;
-    fCntUp?: number;
-    fNwkSIntKey?: string;
-    nFCntDown?: number;
-    nwkSEncKey?: string;
-    sNwkSIntKey?: string;
-  };
-}
+import { z } from 'zod';
+
+export const CreateUpdateDeviceActivationSchema = z.object({
+  deviceActivation: z
+    .object({
+      description: z.string().optional(),
+      aFCntDown: z.number().optional(),
+      appSKey: z.string().optional(),
+      devAddr: z.string().optional(),
+      fCntUp: z.number().optional(),
+      fNwkSIntKey: z.string().optional(),
+      nFCntDown: z.number().optional(),
+      nwkSEncKey: z.string().optional(),
+      sNwkSIntKey: z.string().optional(),
+    })
+    .optional(),
+});
+export type ICreateUpdateDeviceActivation = z.infer<
+  typeof CreateUpdateDeviceActivationSchema
+>;

--- a/src/interfaces/chirpstack/dispositivos-keys.ts
+++ b/src/interfaces/chirpstack/dispositivos-keys.ts
@@ -1,6 +1,13 @@
-export interface ICreateUpdateDeviceKeysChirpstack {
-  deviceKeys?: {
-    appKey?: string;
-    nwkKey?: string; //Ambas Keys son lo mismo, pero cambian el nombre según la versión del dispositivo Lorawan
-  };
-}
+import { z } from 'zod';
+
+export const CreateUpdateDeviceKeysChirpstackSchema = z.object({
+  deviceKeys: z
+    .object({
+      appKey: z.string().optional(),
+      nwkKey: z.string().optional(), //Ambas Keys son lo mismo, pero cambian el nombre según la versión del dispositivo Lorawan
+    })
+    .optional(),
+});
+export type ICreateUpdateDeviceKeysChirpstack = z.infer<
+  typeof CreateUpdateDeviceKeysChirpstackSchema
+>;

--- a/src/interfaces/chirpstack/gateway-chirpstack.ts
+++ b/src/interfaces/chirpstack/gateway-chirpstack.ts
@@ -1,31 +1,42 @@
-export interface ICreateUpdateGatewayChirpstack {
-  gateway?: IGatewayInfo;
-}
+import { z } from 'zod';
 
-export interface IGatewayInfo {
-  description?: string;
-  gatewayId?: string; //Este es el gatewayEui
-  location?: ILocationGateway;
-  metadata?: Record<string, string>;
-  name?: string;
-  statsInterval?: number;
-  tags?: Record<string, string>;
-  tenantId?: string;
-}
+export const LocationGatewaySchema = z.object({
+  accuracy: z.number().optional(),
+  altitude: z.number().optional(),
+  latitude: z.number().optional(),
+  longitude: z.number().optional(),
+  source: z.string().optional(),
+});
+export type ILocationGateway = z.infer<typeof LocationGatewaySchema>;
 
-export interface ILocationGateway {
-  accuracy?: number;
-  altitude?: number;
-  latitude?: number;
-  longitude?: number;
-  source?: string;
-}
+export const GatewayInfoSchema = z.object({
+  description: z.string().optional(),
+  gatewayId: z.string().optional(), //Este es el gatewayEui
+  location: LocationGatewaySchema.optional(),
+  metadata: z.record(z.string(), z.string()).optional(),
+  name: z.string().optional(),
+  statsInterval: z.number().optional(),
+  tags: z.record(z.string(), z.string()).optional(),
+  tenantId: z.string().optional(),
+});
+export type IGatewayInfo = z.infer<typeof GatewayInfoSchema>;
 
-export interface IGatewayChirpstack
-  extends Omit<IGatewayInfo, 'metadata' | 'tags' | 'statsInterval'> {
-  createdAt?: string;
-  lastSeenAt?: string;
-  updatedAt?: string;
-  properties?: Record<string, string>;
-  state: string;
-}
+export const CreateUpdateGatewayChirpstackSchema = z.object({
+  gateway: GatewayInfoSchema.optional(),
+});
+export type ICreateUpdateGatewayChirpstack = z.infer<
+  typeof CreateUpdateGatewayChirpstackSchema
+>;
+
+export const GatewayChirpstackSchema = GatewayInfoSchema.omit({
+  metadata: true,
+  tags: true,
+  statsInterval: true,
+}).extend({
+  createdAt: z.string().optional(),
+  lastSeenAt: z.string().optional(),
+  updatedAt: z.string().optional(),
+  properties: z.record(z.string(), z.string()).optional(),
+  state: z.string(),
+});
+export type IGatewayChirpstack = z.infer<typeof GatewayChirpstackSchema>;

--- a/src/interfaces/chirpstack/metricas-gateways.ts
+++ b/src/interfaces/chirpstack/metricas-gateways.ts
@@ -1,23 +1,36 @@
-export interface IMetricasGateways {
-  rxPackets: IMetricaItem; //Paquetes recibidos
-  rxPacketsPerDr: IMetricaItem; //Paquetes recibidos por data rate
-  rxPacketsPerFreq: IMetricaItem; //Paquetes recibidos por frecuencia
-  txPackets: IMetricaItem; //Paquetes transmitidos
-  txPacketsPerDr: IMetricaItem; //Paquetes transmitidos por data rate
-  txPacketsPerFreq: IMetricaItem; //Paquetes transmitidos por frecuencia
-  txPacketsPerStatus: IMetricaItem; //Paquetes transmitidos por estado
-}
+import { z } from 'zod';
 
-export interface IMetricaItem {
-  datasets: IMetricaDataset[];
-  kind: string;
-  name: string;
-  timestamps: string[];
-}
+export const MetricaDatasetSchema = z.object({
+  data: z.array(z.number()),
+  label: z.string(),
+});
+export type IMetricaDataset = z.infer<typeof MetricaDatasetSchema>;
 
-export interface IMetricaDataset {
-  data: number[];
-  label: string;
-}
+export const MetricaItemSchema = z.object({
+  datasets: z.array(MetricaDatasetSchema),
+  kind: z.string(),
+  name: z.string(),
+  timestamps: z.array(z.string()),
+});
+export type IMetricaItem = z.infer<typeof MetricaItemSchema>;
 
-export type aggregationGatewaysMetrics = 'HOUR' | 'DAY' | 'MONTH' | 'MINUTE';
+export const MetricasGatewaysSchema = z.object({
+  rxPackets: MetricaItemSchema, //Paquetes recibidos
+  rxPacketsPerDr: MetricaItemSchema, //Paquetes recibidos por data rate
+  rxPacketsPerFreq: MetricaItemSchema, //Paquetes recibidos por frecuencia
+  txPackets: MetricaItemSchema, //Paquetes transmitidos
+  txPacketsPerDr: MetricaItemSchema, //Paquetes transmitidos por data rate
+  txPacketsPerFreq: MetricaItemSchema, //Paquetes transmitidos por frecuencia
+  txPacketsPerStatus: MetricaItemSchema, //Paquetes transmitidos por estado
+});
+export type IMetricasGateways = z.infer<typeof MetricasGatewaysSchema>;
+
+export const AggregationGatewaysMetricsSchema = z.enum([
+  'HOUR',
+  'DAY',
+  'MONTH',
+  'MINUTE',
+]);
+export type aggregationGatewaysMetrics = z.infer<
+  typeof AggregationGatewaysMetricsSchema
+>;

--- a/src/interfaces/client.ts
+++ b/src/interfaces/client.ts
@@ -1,17 +1,18 @@
-export interface IClient {
-  _id?: string;
-  id?: string;
-  clientSecret?: string;
-  grants?: string[];
-  redirectUris?: string[];
-  accessTokenLifetime?: number;
-  refreshTokenLifetime?: number;
-}
+import { z } from 'zod';
 
-type OmitirCreate = '_id';
+export const ClientSchema = z.object({
+  _id: z.string().optional(),
+  id: z.string().optional(),
+  clientSecret: z.string().optional(),
+  grants: z.array(z.string()).optional(),
+  redirectUris: z.array(z.string()).optional(),
+  accessTokenLifetime: z.number().optional(),
+  refreshTokenLifetime: z.number().optional(),
+});
+export type IClient = z.infer<typeof ClientSchema>;
 
-export interface ICreateClient extends Omit<Partial<IClient>, OmitirCreate> {}
+export const CreateClientSchema = ClientSchema.omit({ _id: true });
+export type ICreateClient = z.infer<typeof CreateClientSchema>;
 
-type OmitirUpdate = '_id';
-
-export interface IUpdateClient extends Omit<Partial<IClient>, OmitirUpdate> {}
+export const UpdateClientSchema = ClientSchema.omit({ _id: true });
+export type IUpdateClient = z.infer<typeof UpdateClientSchema>;

--- a/src/interfaces/cliente.ts
+++ b/src/interfaces/cliente.ts
@@ -1,302 +1,362 @@
-export interface IConfigHorario {
-  idCliente?: string; // undefined = default del cliente
-  dias?: number[]; // 0-6 (Dom-Sáb), undefined = todos los días
-  horaInicio?: string; // "HH:mm"
-  horaFin?: string; // "HH:mm"
-}
+import { z } from 'zod';
 
-export interface IImagenesCliente {
-  icono?: string;
-  banner?: string;
-  bannerModoOscuro?: string;
-}
+export const ConfigHorarioSchema = z.object({
+  idCliente: z.string().optional(), // undefined = default del cliente
+  dias: z.array(z.number()).optional(), // 0-6 (Dom-Sáb), undefined = todos los días
+  horaInicio: z.string().optional(), // "HH:mm"
+  horaFin: z.string().optional(), // "HH:mm"
+});
+export type IConfigHorario = z.infer<typeof ConfigHorarioSchema>;
 
-export interface ITemaCliente {
-  primaryColor?: string;
-  accentColor?: string;
-  warnColor?: string;
-  backgroundColor?: string;
-  typography?: string;
-}
+export const ImagenesClienteSchema = z.object({
+  icono: z.string().optional(),
+  banner: z.string().optional(),
+  bannerModoOscuro: z.string().optional(),
+});
+export type IImagenesCliente = z.infer<typeof ImagenesClienteSchema>;
 
-export interface ICredencialesAlarma {
-  tipo?: 'Garnet Titanium' | 'Garnet' | 'Hikvision';
-  usuario?: string;
-  password?: string;
-  apikey?: string;
-  apisecret?: string;
-}
+export const TemaClienteSchema = z.object({
+  primaryColor: z.string().optional(),
+  accentColor: z.string().optional(),
+  warnColor: z.string().optional(),
+  backgroundColor: z.string().optional(),
+  typography: z.string().optional(),
+});
+export type ITemaCliente = z.infer<typeof TemaClienteSchema>;
 
-export interface IIntegracionSoflex {
+export const CredencialesAlarmaSchema = z.object({
+  tipo: z.enum(['Garnet Titanium', 'Garnet', 'Hikvision']).optional(),
+  usuario: z.string().optional(),
+  password: z.string().optional(),
+  apikey: z.string().optional(),
+  apisecret: z.string().optional(),
+});
+export type ICredencialesAlarma = z.infer<typeof CredencialesAlarmaSchema>;
+
+export const IntegracionSoflexSchema = z.object({
   // Hace que se creen los trackers en Soflex (se llaman fleet)
-  activo?: boolean;
-  fleetId?: string;
-  parentFleetId?: string;
-}
+  activo: z.boolean().optional(),
+  fleetId: z.string().optional(),
+  parentFleetId: z.string().optional(),
+});
+export type IIntegracionSoflex = z.infer<typeof IntegracionSoflexSchema>;
 
 /** Control de inactividad de operadores (popup de confirmación de actividad
  *  en gestion-web-cliente). Aplica a usuarios con rol Operador. */
-export interface IControlInactividad {
+export const ControlInactividadSchema = z.object({
   /** Minutos sin actividad hasta mostrar el cartel de confirmación */
-  limTiempoInactividad?: number;
+  limTiempoInactividad: z.number().optional(),
   /** Segundos que tiene el operador para confirmar que está activo */
-  limTiempoConfirm?: number;
-}
-
-export interface IConfigCliente {
-  imagenes?: IImagenesCliente;
-  tema?: ITemaCliente;
-  moduloColectivos?: IModuloColectivos;
-  moduloAlarmasDomiciliarias?: IModuloAlarmasDomiciliarias;
-  moduloCamaras?: IModuloCamaras;
-  moduloDispositivosLorawan?: IModuloDispositivosLorawan;
-  moduloActivos?: IModuloActivos;
-  moduloAdministracion?: IModuloAdministracion;
-  moduloEventosTecnicos?: IModuloEventosTecnicos;
-  moduloVehiculos?: IModuloVehiculos;
-  moduloLuminarias?: IModuloLuminarias;
-  moduloEmergencias?: IModuloEmergencias;
-  moduloBotonBLE?: IModuloBotonBLE;
-  modulosIntegraciones?: IModulosIntegraciones;
-  moduloLogs?: IModuloLogs;
-  moduloTwilio?: IModuloTwilio;
-  moduloSendgrid?: IModuloSendgrid;
-  moduloSirenas?: IModuloSirenas;
-  moduloAlertasSeguridad?: IModuloAlertasSeguridad;
-  idsClientesQuePuedenAtenderEventos?: string[];
-  idsClientesQuePuedenAtenderEventosTecnicos?: string[];
-  configHorarioAtencion?: IConfigHorario;
-  /** Si es true, los operadores de este cliente pueden sumarse a atender
-   *  eventos que ya están siendo atendidos por otro operador.
-   *  Default false: solo un operador atiende a la vez (lock). */
-  atencionMultipleEventos?: boolean;
-  solicitantesEmergencias?: string[];
-  solicitantePredeterminado?: string;
-  credencialesAlarmas?: ICredencialesAlarma[];
-  integracionSoflex?: IIntegracionSoflex;
-  verTrafico?: boolean;
-  controlInactividad?: IControlInactividad;
-}
+  limTiempoConfirm: z.number().optional(),
+});
+export type IControlInactividad = z.infer<typeof ControlInactividadSchema>;
 
 // Informes
 // Configuración para envío de informes por mail
-export interface IConfigInformes {
+export const ConfigInformesSchema = z.object({
   // Lo podemos poner en cualqjhier módulo
-  activo?: boolean;
-  frecuencia?: 'Diaria' | 'Semanal' | 'Mensual'; // Para el cron/worker
-  smtpHost?: string;
-  smtpPort?: number;
-  smtpUser?: string;
-  smtpPass?: string;
-  destinatariosInformes?: string[]; /// Mails
-}
+  activo: z.boolean().optional(),
+  frecuencia: z.enum(['Diaria', 'Semanal', 'Mensual']).optional(), // Para el cron/worker
+  smtpHost: z.string().optional(),
+  smtpPort: z.number().optional(),
+  smtpUser: z.string().optional(),
+  smtpPass: z.string().optional(),
+  destinatariosInformes: z.array(z.string()).optional(), /// Mails
+});
+export type IConfigInformes = z.infer<typeof ConfigInformesSchema>;
 
 /// Twilio
 
-export type TemplatesWhatsapp =
-  | 'Error de comunicación de alarma'
-  | 'Equipos fuera de línea'
-  | 'Batería baja';
+export const TemplatesWhatsappSchema = z.enum([
+  'Error de comunicación de alarma',
+  'Equipos fuera de línea',
+  'Batería baja',
+]);
+export type TemplatesWhatsapp = z.infer<typeof TemplatesWhatsappSchema>;
 
-export type TemplatesMail =
-  | TemplatesWhatsapp
-  | 'Nuevo usuario'
-  | 'Reset de contraseña'
-  | 'Cambio de contraseña';
+export const TemplatesMailSchema = z.enum([
+  ...TemplatesWhatsappSchema.options,
+  'Nuevo usuario',
+  'Reset de contraseña',
+  'Cambio de contraseña',
+]);
+export type TemplatesMail = z.infer<typeof TemplatesMailSchema>;
 
-export interface IModuloTwilio {
-  activo?: boolean;
-  accSid?: string;
-  authToken?: string;
-  msgServiceSid?: string;
-  statusCallback?: string;
-  phoneSms?: string;
-  phoneWhatsapp?: string;
-  phoneLlamada?: string;
-  templatesWhatsapp?: {
-    [K in TemplatesWhatsapp]?: string;
-  };
-}
+export const ModuloTwilioSchema = z.object({
+  activo: z.boolean().optional(),
+  accSid: z.string().optional(),
+  authToken: z.string().optional(),
+  msgServiceSid: z.string().optional(),
+  statusCallback: z.string().optional(),
+  phoneSms: z.string().optional(),
+  phoneWhatsapp: z.string().optional(),
+  phoneLlamada: z.string().optional(),
+  templatesWhatsapp: z
+    .partialRecord(TemplatesWhatsappSchema, z.string())
+    .optional(),
+});
+export type IModuloTwilio = z.infer<typeof ModuloTwilioSchema>;
 
-export interface IModuloSendgrid {
-  activo?: boolean;
-  senderEmail?: string;
-  senderName?: string;
-  senderAddress?: string;
-  senderCity?: string;
-  senderState?: string;
-  senderZip?: number;
-  sendGridApiKey?: string;
-  templatesMail?: {
-    [K in TemplatesMail]?: string;
-  };
-}
+export const ModuloSendgridSchema = z.object({
+  activo: z.boolean().optional(),
+  senderEmail: z.string().optional(),
+  senderName: z.string().optional(),
+  senderAddress: z.string().optional(),
+  senderCity: z.string().optional(),
+  senderState: z.string().optional(),
+  senderZip: z.number().optional(),
+  sendGridApiKey: z.string().optional(),
+  templatesMail: z.partialRecord(TemplatesMailSchema, z.string()).optional(),
+});
+export type IModuloSendgrid = z.infer<typeof ModuloSendgridSchema>;
 
-export type ITipoCliente = 'Mayorista' | 'Minorista' | 'Final';
+export const TipoClienteSchema = z.enum(['Mayorista', 'Minorista', 'Final']);
+export type ITipoCliente = z.infer<typeof TipoClienteSchema>;
 
-export type EstadoCuenta = 'Activo' | 'Suspendido' | 'Moroso';
-export interface IModulosIntegraciones {
-  activo?: boolean;
-  moduloBotonDePanico?: IModuloBotonDePanico;
-}
+export const EstadoCuentaSchema = z.enum(['Activo', 'Suspendido', 'Moroso']);
+export type EstadoCuenta = z.infer<typeof EstadoCuentaSchema>;
 
-export interface IModuloBotonDePanico {
-  appkey?: string;
-  activo?: boolean;
-}
+export const ModuloBotonDePanicoSchema = z.object({
+  appkey: z.string().optional(),
+  activo: z.boolean().optional(),
+});
+export type IModuloBotonDePanico = z.infer<typeof ModuloBotonDePanicoSchema>;
 
-export interface IModuloBotonBLE {
-  activo?: boolean;
-}
+export const ModulosIntegracionesSchema = z.object({
+  activo: z.boolean().optional(),
+  moduloBotonDePanico: ModuloBotonDePanicoSchema.optional(),
+});
+export type IModulosIntegraciones = z.infer<typeof ModulosIntegracionesSchema>;
 
-export interface IModuloSirenas {
-  activo?: boolean;
-  crearSirenas?: boolean;
-  derivarEventos?: boolean;
-  derivarEventosTecnicos?: boolean;
-  compartirSirenas?: boolean;
-  informe?: IConfigInformes;
-}
+export const ModuloBotonBLESchema = z.object({
+  activo: z.boolean().optional(),
+});
+export type IModuloBotonBLE = z.infer<typeof ModuloBotonBLESchema>;
 
-export interface IModuloLuminarias {
-  activo?: boolean;
-  crearDispositivos?: boolean;
-  derivarEventos?: boolean;
-  derivarEventosTecnicos?: boolean;
-  compartirLuminarias?: boolean;
-  usaPuestas?: boolean; // Habilita la creación de puestas y la relación puesta-luminaria
-  informe?: IConfigInformes;
-}
+export const ModuloSirenasSchema = z.object({
+  activo: z.boolean().optional(),
+  crearSirenas: z.boolean().optional(),
+  derivarEventos: z.boolean().optional(),
+  derivarEventosTecnicos: z.boolean().optional(),
+  compartirSirenas: z.boolean().optional(),
+  informe: ConfigInformesSchema.optional(),
+});
+export type IModuloSirenas = z.infer<typeof ModuloSirenasSchema>;
 
-export interface IModuloEmergencias {
-  activoEmergenciasMedicas?: boolean;
-  crearEmergenciasMedicas?: boolean;
-  activoEmergenciasBomberos?: boolean;
-  crearEmergenciasBomberos?: boolean;
+export const ModuloLuminariasSchema = z.object({
+  activo: z.boolean().optional(),
+  crearDispositivos: z.boolean().optional(),
+  derivarEventos: z.boolean().optional(),
+  derivarEventosTecnicos: z.boolean().optional(),
+  compartirLuminarias: z.boolean().optional(),
+  usaPuestas: z.boolean().optional(), // Habilita la creación de puestas y la relación puesta-luminaria
+  informe: ConfigInformesSchema.optional(),
+});
+export type IModuloLuminarias = z.infer<typeof ModuloLuminariasSchema>;
+
+export const ModuloEmergenciasSchema = z.object({
+  activoEmergenciasMedicas: z.boolean().optional(),
+  crearEmergenciasMedicas: z.boolean().optional(),
+  activoEmergenciasBomberos: z.boolean().optional(),
+  crearEmergenciasBomberos: z.boolean().optional(),
   //Acá pueden ir otros tipos de emergencias...
-}
+});
+export type IModuloEmergencias = z.infer<typeof ModuloEmergenciasSchema>;
 
-export interface IModuloAlertasSeguridad {
-  activo?: boolean;
-  crearAlertas?: boolean;
-}
+export const ModuloAlertasSeguridadSchema = z.object({
+  activo: z.boolean().optional(),
+  crearAlertas: z.boolean().optional(),
+});
+export type IModuloAlertasSeguridad = z.infer<
+  typeof ModuloAlertasSeguridadSchema
+>;
 
-export interface IModuloColectivos {
-  activo?: boolean;
-  crearDispositivos?: boolean;
-  derivarEventos?: boolean;
-  derivarEventosTecnicos?: boolean;
-  compartirFlota?: boolean;
-}
+export const ModuloColectivosSchema = z.object({
+  activo: z.boolean().optional(),
+  crearDispositivos: z.boolean().optional(),
+  derivarEventos: z.boolean().optional(),
+  derivarEventosTecnicos: z.boolean().optional(),
+  compartirFlota: z.boolean().optional(),
+});
+export type IModuloColectivos = z.infer<typeof ModuloColectivosSchema>;
 
-export interface IModuloAlarmasDomiciliarias {
-  activo?: boolean;
-  crearDispositivos?: boolean;
-  derivarEventos?: boolean;
-  derivarEventosTecnicos?: boolean;
-  compartirAlarmas?: boolean;
-}
+export const ModuloAlarmasDomiciliariasSchema = z.object({
+  activo: z.boolean().optional(),
+  crearDispositivos: z.boolean().optional(),
+  derivarEventos: z.boolean().optional(),
+  derivarEventosTecnicos: z.boolean().optional(),
+  compartirAlarmas: z.boolean().optional(),
+});
+export type IModuloAlarmasDomiciliarias = z.infer<
+  typeof ModuloAlarmasDomiciliariasSchema
+>;
 
-export interface IModuloCamaras {
-  activo?: boolean;
-  crear?: boolean;
-  compartir?: boolean;
-}
+export const ModuloCamarasSchema = z.object({
+  activo: z.boolean().optional(),
+  crear: z.boolean().optional(),
+  compartir: z.boolean().optional(),
+});
+export type IModuloCamaras = z.infer<typeof ModuloCamarasSchema>;
 
-export interface IModuloDispositivosLorawan {
-  activo?: boolean;
-  crearDispositivos?: boolean;
-  derivarEventos?: boolean;
-  derivarEventosTecnicos?: boolean;
-  compartirDispositivosLorawan?: boolean;
-}
+export const ModuloDispositivosLorawanSchema = z.object({
+  activo: z.boolean().optional(),
+  crearDispositivos: z.boolean().optional(),
+  derivarEventos: z.boolean().optional(),
+  derivarEventosTecnicos: z.boolean().optional(),
+  compartirDispositivosLorawan: z.boolean().optional(),
+});
+export type IModuloDispositivosLorawan = z.infer<
+  typeof ModuloDispositivosLorawanSchema
+>;
 
-export interface IModuloActivos {
-  activo?: boolean;
-  crearDispositivos?: boolean;
-  derivarEventos?: boolean;
-  derivarEventosTecnicos?: boolean;
-  compartirActivos?: boolean;
-}
+export const ModuloActivosSchema = z.object({
+  activo: z.boolean().optional(),
+  crearDispositivos: z.boolean().optional(),
+  derivarEventos: z.boolean().optional(),
+  derivarEventosTecnicos: z.boolean().optional(),
+  compartirActivos: z.boolean().optional(),
+});
+export type IModuloActivos = z.infer<typeof ModuloActivosSchema>;
 
-export interface IModuloAdministracion {
-  activo?: boolean;
-  crearUsuarios?: boolean;
-  crearServicios?: boolean;
-  verApikeys?: boolean;
-  crearApikeys?: boolean;
+export const ModuloAdministracionSchema = z.object({
+  activo: z.boolean().optional(),
+  crearUsuarios: z.boolean().optional(),
+  crearServicios: z.boolean().optional(),
+  verApikeys: z.boolean().optional(),
+  crearApikeys: z.boolean().optional(),
 
   //Eventos Personalizados
-  verCategoriasEventos?: boolean;
-  verTiposEventos?: boolean;
-  verEventosPersonalizados?: boolean;
+  verCategoriasEventos: z.boolean().optional(),
+  verTiposEventos: z.boolean().optional(),
+  verEventosPersonalizados: z.boolean().optional(),
 
   //Trackers
-  activoTrackers?: boolean;
-  crearTrackers?: boolean;
+  activoTrackers: z.boolean().optional(),
+  crearTrackers: z.boolean().optional(),
   //Botones BLE
-  activoBotonesBLE?: boolean;
-  crearBotonesBLE?: boolean;
+  activoBotonesBLE: z.boolean().optional(),
+  crearBotonesBLE: z.boolean().optional(),
   //Dispositivos Lorawam
-  activoDispositivosLorawan?: boolean;
-  crearDispositivosLorawan?: boolean;
-  compartirDispositivosLorawan?: boolean; //Posiblemente esto no se use más
+  activoDispositivosLorawan: z.boolean().optional(),
+  crearDispositivosLorawan: z.boolean().optional(),
+  compartirDispositivosLorawan: z.boolean().optional(), //Posiblemente esto no se use más
 
   //Gateways
-  activoGateways?: boolean;
-  crearGateways?: boolean;
-}
+  activoGateways: z.boolean().optional(),
+  crearGateways: z.boolean().optional(),
+});
+export type IModuloAdministracion = z.infer<typeof ModuloAdministracionSchema>;
 
-export interface IModuloVehiculos {
-  activo?: boolean;
-  crearVehiculos?: boolean;
-  derivarEventos?: boolean;
-  derivarEventosTecnicos?: boolean;
-  compartirVehiculos?: boolean;
-}
+export const ModuloVehiculosSchema = z.object({
+  activo: z.boolean().optional(),
+  crearVehiculos: z.boolean().optional(),
+  derivarEventos: z.boolean().optional(),
+  derivarEventosTecnicos: z.boolean().optional(),
+  compartirVehiculos: z.boolean().optional(),
+});
+export type IModuloVehiculos = z.infer<typeof ModuloVehiculosSchema>;
 
-export interface IModuloEventosTecnicos {
-  activo?: boolean;
-}
+export const ModuloEventosTecnicosSchema = z.object({
+  activo: z.boolean().optional(),
+});
+export type IModuloEventosTecnicos = z.infer<
+  typeof ModuloEventosTecnicosSchema
+>;
 
-export interface IModuloLogs {
-  activo?: boolean;
-}
+export const ModuloLogsSchema = z.object({
+  activo: z.boolean().optional(),
+});
+export type IModuloLogs = z.infer<typeof ModuloLogsSchema>;
 
-export interface ILayerMapaPersonalizado {
-  nombre?: string;
-  url?: string;
-  icono?: string;
-}
+export const LayerMapaPersonalizadoSchema = z.object({
+  nombre: z.string().optional(),
+  url: z.string().optional(),
+  icono: z.string().optional(),
+});
+export type ILayerMapaPersonalizado = z.infer<
+  typeof LayerMapaPersonalizadoSchema
+>;
 
-export interface ICliente {
-  _id?: string;
-  idsAncestros?: string[];
-  idPadre?: string;
-  activo?: boolean;
-  nombre?: string;
-  fechaCreacion?: string;
-  nivel?: number;
-  config?: IConfigCliente;
-  tipoCliente?: ITipoCliente;
-  estadoDeCuenta?: EstadoCuenta;
-  numeroCliente?: string;
-  habilitado?: boolean;
-  apikeyBotonBLE?: string;
-  poligono?: {
-    type: 'MultiPolygon';
-    coordinates: [number, number][][][];
-  };
-  mapLayers?: ILayerMapaPersonalizado[]; //Capas de mapa personalizadas
+export const ConfigClienteSchema = z.object({
+  imagenes: ImagenesClienteSchema.optional(),
+  tema: TemaClienteSchema.optional(),
+  moduloColectivos: ModuloColectivosSchema.optional(),
+  moduloAlarmasDomiciliarias: ModuloAlarmasDomiciliariasSchema.optional(),
+  moduloCamaras: ModuloCamarasSchema.optional(),
+  moduloDispositivosLorawan: ModuloDispositivosLorawanSchema.optional(),
+  moduloActivos: ModuloActivosSchema.optional(),
+  moduloAdministracion: ModuloAdministracionSchema.optional(),
+  moduloEventosTecnicos: ModuloEventosTecnicosSchema.optional(),
+  moduloVehiculos: ModuloVehiculosSchema.optional(),
+  moduloLuminarias: ModuloLuminariasSchema.optional(),
+  moduloEmergencias: ModuloEmergenciasSchema.optional(),
+  moduloBotonBLE: ModuloBotonBLESchema.optional(),
+  modulosIntegraciones: ModulosIntegracionesSchema.optional(),
+  moduloLogs: ModuloLogsSchema.optional(),
+  moduloTwilio: ModuloTwilioSchema.optional(),
+  moduloSendgrid: ModuloSendgridSchema.optional(),
+  moduloSirenas: ModuloSirenasSchema.optional(),
+  moduloAlertasSeguridad: ModuloAlertasSeguridadSchema.optional(),
+  idsClientesQuePuedenAtenderEventos: z.array(z.string()).optional(),
+  idsClientesQuePuedenAtenderEventosTecnicos: z.array(z.string()).optional(),
+  configHorarioAtencion: ConfigHorarioSchema.optional(),
+  /** Si es true, los operadores de este cliente pueden sumarse a atender
+   *  eventos que ya están siendo atendidos por otro operador.
+   *  Default false: solo un operador atiende a la vez (lock). */
+  atencionMultipleEventos: z.boolean().optional(),
+  solicitantesEmergencias: z.array(z.string()).optional(),
+  solicitantePredeterminado: z.string().optional(),
+  credencialesAlarmas: z.array(CredencialesAlarmaSchema).optional(),
+  integracionSoflex: IntegracionSoflexSchema.optional(),
+  verTrafico: z.boolean().optional(),
+  controlInactividad: ControlInactividadSchema.optional(),
+});
+export type IConfigCliente = z.infer<typeof ConfigClienteSchema>;
+
+export const ClienteSchema = z.object({
+  _id: z.string().optional(),
+  idsAncestros: z.array(z.string()).optional(),
+  idPadre: z.string().optional(),
+  activo: z.boolean().optional(),
+  nombre: z.string().optional(),
+  fechaCreacion: z.string().optional(),
+  nivel: z.number().optional(),
+  config: ConfigClienteSchema.optional(),
+  tipoCliente: TipoClienteSchema.optional(),
+  estadoDeCuenta: EstadoCuentaSchema.optional(),
+  numeroCliente: z.string().optional(),
+  habilitado: z.boolean().optional(),
+  apikeyBotonBLE: z.string().optional(),
+  poligono: z
+    .object({
+      type: z.literal('MultiPolygon'),
+      coordinates: z.array(
+        z.array(z.array(z.tuple([z.number(), z.number()]))),
+      ),
+    })
+    .optional(),
+  mapLayers: z.array(LayerMapaPersonalizadoSchema).optional(), //Capas de mapa personalizadas
   // Populate
-  padre?: ICliente;
-  ancestros?: ICliente[];
-}
+  get padre() {
+    return ClienteSchema.optional();
+  },
+  get ancestros() {
+    return z.array(ClienteSchema).optional();
+  },
+});
+export type ICliente = z.infer<typeof ClienteSchema>;
 
-type OmitirCreate = '_id' | 'padre';
+export const CreateClienteSchema = ClienteSchema.omit({
+  _id: true,
+  padre: true,
+});
+export type ICreateCliente = z.infer<typeof CreateClienteSchema>;
 
-export interface ICreateCliente extends Omit<Partial<ICliente>, OmitirCreate> {}
-
-type OmitirUpdate = '_id' | 'nivel' | 'tipoCliente' | 'fechaCreacion' | 'padre';
-
-export interface IUpdateCliente extends Omit<Partial<ICliente>, OmitirUpdate> {}
+export const UpdateClienteSchema = ClienteSchema.omit({
+  _id: true,
+  nivel: true,
+  tipoCliente: true,
+  fechaCreacion: true,
+  padre: true,
+});
+export type IUpdateCliente = z.infer<typeof UpdateClienteSchema>;

--- a/src/interfaces/cliente.ts
+++ b/src/interfaces/cliente.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod';
+import { PuntoCoord } from '../auxiliares/geojson';
 
 export const ConfigHorarioSchema = z.object({
   idCliente: z.string().optional(), // undefined = default del cliente
@@ -330,9 +331,7 @@ export const ClienteSchema = z.object({
   poligono: z
     .object({
       type: z.literal('MultiPolygon'),
-      coordinates: z.array(
-        z.array(z.array(z.tuple([z.number(), z.number()]))),
-      ),
+      coordinates: z.array(z.array(z.array(PuntoCoord))),
     })
     .optional(),
   mapLayers: z.array(LayerMapaPersonalizadoSchema).optional(), //Capas de mapa personalizadas

--- a/src/interfaces/codigos-dispositivo.ts
+++ b/src/interfaces/codigos-dispositivo.ts
@@ -1,89 +1,117 @@
-import { ICliente } from './cliente';
-import { ICategoriaEvento } from './categoria-evento';
+import { z } from 'zod';
+import { ClienteSchema } from './cliente';
+import { CategoriaEventoSchema } from './categoria-evento';
 
-export interface ICodigoDispositivoEntrada {
-  codigo?: string;
-  descripcion?: string;
-  idCategoriaEvento?: string;
+export const CodigoDispositivoEntradaSchema = z.object({
+  codigo: z.string().optional(),
+  descripcion: z.string().optional(),
+  idCategoriaEvento: z.string().optional(),
   // Populate
-  categoriaEvento?: ICategoriaEvento;
-}
+  categoriaEvento: CategoriaEventoSchema.optional(),
+});
+export type ICodigoDispositivoEntrada = z.infer<
+  typeof CodigoDispositivoEntradaSchema
+>;
 
-export type FlagsTrackers = 'Posicion' | 'Ignición' | 'Emergencia' | 'Batería';
+export const FlagsTrackersSchema = z.enum([
+  'Posicion',
+  'Ignición',
+  'Emergencia',
+  'Batería',
+]);
+export type FlagsTrackers = z.infer<typeof FlagsTrackersSchema>;
 
-export interface ICodigoDispositivoEntradaCache extends Omit<
-  ICodigoDispositivoEntrada,
-  'categoriaEvento'
-> {}
+export const CodigoDispositivoEntradaCacheSchema =
+  CodigoDispositivoEntradaSchema.omit({
+    categoriaEvento: true,
+  });
+export type ICodigoDispositivoEntradaCache = z.infer<
+  typeof CodigoDispositivoEntradaCacheSchema
+>;
 
-export interface ICodigoDispositivo {
-  codigo?: string;
-  descripcion?: string;
-  idCategoriaEvento?: string;
-  mostrarZona?: boolean;
-  mostrarUsuario?: boolean;
-  armado?: boolean;
-  desarmado?: boolean;
-  detonacion?: boolean;
-  test?: boolean;
-  notificar?: boolean;
-  minutosEsperaAutomatica?: number; // Los eventos generados se ponen en espera automaticamente por este tiempo
-  cierraCodigosEventos?: string[]; // Si se genera un evento con este codigo, se cierran los eventos con estos codigos del array
+export const CodigoDispositivoSchema = z.object({
+  codigo: z.string().optional(),
+  descripcion: z.string().optional(),
+  idCategoriaEvento: z.string().optional(),
+  mostrarZona: z.boolean().optional(),
+  mostrarUsuario: z.boolean().optional(),
+  armado: z.boolean().optional(),
+  desarmado: z.boolean().optional(),
+  detonacion: z.boolean().optional(),
+  test: z.boolean().optional(),
+  notificar: z.boolean().optional(),
+  minutosEsperaAutomatica: z.number().optional(), // Los eventos generados se ponen en espera automaticamente por este tiempo
+  cierraCodigosEventos: z.array(z.string()).optional(), // Si se genera un evento con este codigo, se cierran los eventos con estos codigos del array
 
-  flagsTrackers?: FlagsTrackers[];
+  flagsTrackers: z.array(FlagsTrackersSchema).optional(),
   // Populate
-  categoriaEvento?: ICategoriaEvento;
-}
+  categoriaEvento: CategoriaEventoSchema.optional(),
+});
+export type ICodigoDispositivo = z.infer<typeof CodigoDispositivoSchema>;
 
-export interface ICodigoDispositivoCache extends Omit<
-  ICodigoDispositivo,
-  'categoriaEvento'
-> {}
+export const CodigoDispositivoCacheSchema = CodigoDispositivoSchema.omit({
+  categoriaEvento: true,
+});
+export type ICodigoDispositivoCache = z.infer<
+  typeof CodigoDispositivoCacheSchema
+>;
 
-export type TipoDispositivo =
-  | 'Tracker'
-  | 'Alarma'
-  | 'Comunicador'
-  | 'NVR'
-  | 'Cámara'
-  | 'Luminaria'
-  | 'DispositivoLorawan'
-  | 'BotonBLE'
-  | 'Sirena';
+export const TipoDispositivoSchema = z.enum([
+  'Tracker',
+  'Alarma',
+  'Comunicador',
+  'NVR',
+  'Cámara',
+  'Luminaria',
+  'DispositivoLorawan',
+  'BotonBLE',
+  'Sirena',
+]);
+export type TipoDispositivo = z.infer<typeof TipoDispositivoSchema>;
 
-export interface ICodigosDispositivo {
-  _id?: string;
+export const CodigosDispositivoSchema = z.object({
+  _id: z.string().optional(),
   //
-  nombre?: string;
-  tipo?: TipoDispositivo;
-  codigos?: ICodigoDispositivo[];
-  codigosEntrada?: ICodigoDispositivoEntrada[];
-  idCliente?: string;
-  idsAncestros?: string[];
-  global?: boolean;
+  nombre: z.string().optional(),
+  tipo: TipoDispositivoSchema.optional(),
+  codigos: z.array(CodigoDispositivoSchema).optional(),
+  codigosEntrada: z.array(CodigoDispositivoEntradaSchema).optional(),
+  idCliente: z.string().optional(),
+  idsAncestros: z.array(z.string()).optional(),
+  global: z.boolean().optional(),
   // Populate
-  cliente?: ICliente;
-  ancestros?: ICliente[];
-}
+  cliente: ClienteSchema.optional(),
+  ancestros: z.array(ClienteSchema).optional(),
+});
+export type ICodigosDispositivo = z.infer<typeof CodigosDispositivoSchema>;
 
-export interface ICodigosDispositivoCache extends Omit<
-  ICodigosDispositivo,
-  'cliente' | 'ancestros' | 'codigos' | 'codigosEntrada'
-> {
-  codigos?: ICodigoDispositivoCache[];
-  codigosEntrada?: ICodigoDispositivoEntradaCache[];
-}
+export const CodigosDispositivoCacheSchema = CodigosDispositivoSchema.omit({
+  cliente: true,
+  ancestros: true,
+  codigos: true,
+  codigosEntrada: true,
+}).extend({
+  codigos: z.array(CodigoDispositivoCacheSchema).optional(),
+  codigosEntrada: z.array(CodigoDispositivoEntradaCacheSchema).optional(),
+});
+export type ICodigosDispositivoCache = z.infer<
+  typeof CodigosDispositivoCacheSchema
+>;
 
-type OmitirCreate = '_id' | 'cliente' | 'ancestros';
+export const CreateCodigosDispositivoSchema = CodigosDispositivoSchema.omit({
+  _id: true,
+  cliente: true,
+  ancestros: true,
+});
+export type ICreateCodigosDispositivo = z.infer<
+  typeof CreateCodigosDispositivoSchema
+>;
 
-export interface ICreateCodigosDispositivo extends Omit<
-  Partial<ICodigosDispositivo>,
-  OmitirCreate
-> {}
-
-type OmitirUpdate = '_id' | 'cliente' | 'ancestros';
-
-export interface IUpdateCodigosDispositivo extends Omit<
-  Partial<ICodigosDispositivo>,
-  OmitirUpdate
-> {}
+export const UpdateCodigosDispositivoSchema = CodigosDispositivoSchema.omit({
+  _id: true,
+  cliente: true,
+  ancestros: true,
+});
+export type IUpdateCodigosDispositivo = z.infer<
+  typeof UpdateCodigosDispositivoSchema
+>;

--- a/src/interfaces/comando.ts
+++ b/src/interfaces/comando.ts
@@ -1,16 +1,19 @@
-import { ICliente } from './cliente';
-import { IDispositivoLorawan } from './dispositivo-lorawan';
-import { ITracker } from './tracker';
-import { IUsuario } from './usuario';
+import { z } from 'zod';
+import { ClienteSchema, ICliente } from './cliente';
+import type { IDispositivoLorawan } from './dispositivo-lorawan';
+import type { ITracker } from './tracker';
+import type { IUsuario } from './usuario';
 
-export type IEstadoComando =
-  | 'Enviado'
-  | 'Recibido'
-  | 'No Recibido'
-  | 'Ejecutado'
-  | 'En Cola'
-  | 'No Ejecutado'
-  | 'Descartado';
+export const EstadoComandoSchema = z.enum([
+  'Enviado',
+  'Recibido',
+  'No Recibido',
+  'Ejecutado',
+  'En Cola',
+  'No Ejecutado',
+  'Descartado',
+]);
+export type IEstadoComando = z.infer<typeof EstadoComandoSchema>;
 
 /**
  * Nivel/objetivo desde el que se origina un comando o downlink.
@@ -18,14 +21,61 @@ export type IEstadoComando =
  * Eje de PROCEDENCIA (qué entidad/acción originó el comando), ortogonal al `origen` (`OrigenDownlinkJob`, que es el eje de POLÍTICA: cómo se trata el
  * downlink).
  */
-export type NivelObjetivo = 'luminaria' | 'grupo' | 'puesta' | 'grupoPuesta';
+export const NivelObjetivoSchema = z.enum([
+  'luminaria',
+  'grupo',
+  'puesta',
+  'grupoPuesta',
+]);
+export type NivelObjetivo = z.infer<typeof NivelObjetivoSchema>;
 
-export interface IObjetivoComando {
-  nivel: NivelObjetivo;
-  id: string; // _id del objetivo (luminaria / grupo de luminarias/ puesta / grupo de puestas)
-  nombre?: string; // Denormalizado para que la UI muestre sin populate
-}
+export const ObjetivoComandoSchema = z.object({
+  nivel: NivelObjetivoSchema,
+  id: z.string(), // _id del objetivo (luminaria / grupo de luminarias/ puesta / grupo de puestas)
+  nombre: z.string().optional(), // Denormalizado para que la UI muestre sin populate
+});
+export type IObjetivoComando = z.infer<typeof ObjetivoComandoSchema>;
 
+// Populates intra-SCC como z.custom (import type-only): un schema real acá
+// arrastra el shape completo del ciclo y revienta la serialización de
+// declarations (TS7056) acá y en los consumidores NestJS.
+export const ComandoSchema = z.object({
+  _id: z.string().optional(),
+  idCliente: z.string().optional(),
+  idsAncestros: z.array(z.string()).optional(),
+  idUsuario: z.string().optional(),
+  nombre: z.string().optional(),
+  descripcion: z.string().optional(),
+  fechaCreacion: z.string().optional(),
+  payload: z.string().optional(),
+  datosExtra: z.record(z.string(), z.any()).optional(),
+  // Tracker
+  idTracker: z.string().optional(),
+  respuesta: z.string().optional(),
+  // lorawan
+  // Downlink
+  deveui: z.string().optional(),
+  puerto: z.number().optional(),
+  //
+  fechaActualizacion: z.string().optional(),
+  estado: EstadoComandoSchema.optional(), // Default: Enviado
+  fallos: z.number().optional(),
+  fCnt: z.string().optional(),
+  idChirpstack: z.string().optional(),
+  objetivo: ObjetivoComandoSchema.optional(), // Procedencia: desde qué nivel/entidad se originó (luminaria/grupo/puesta/punto-alim)
+
+  // Virtuals
+  tracker: z.custom<ITracker>().optional(),
+  cliente: ClienteSchema.optional(),
+  ancestros: z.array(ClienteSchema).optional(),
+  usuario: z.custom<IUsuario>().optional(),
+  dispositivo: z.custom<IDispositivoLorawan>().optional(),
+});
+
+/**
+ * Interface hand-written (misma forma que el schema): los tipos de entidad del
+ * SCC no usan z.infer porque los ciclos de aliases mutuos disparan TS2589.
+ */
 export interface IComando {
   _id?: string;
   idCliente?: string;
@@ -59,6 +109,16 @@ export interface IComando {
   dispositivo?: IDispositivoLorawan;
 }
 
+export const CreateComandoSchema = ComandoSchema.omit({
+  _id: true,
+  fechaCreacion: true,
+  cliente: true,
+  ancestros: true,
+  usuario: true,
+  tracker: true,
+  dispositivo: true,
+});
+
 type OmitirCreate =
   | '_id'
   | 'fechaCreacion'
@@ -68,6 +128,16 @@ type OmitirCreate =
   | 'tracker'
   | 'dispositivo';
 export interface ICreateComando extends Omit<Partial<IComando>, OmitirCreate> {}
+
+export const UpdateComandoSchema = ComandoSchema.omit({
+  _id: true,
+  fechaCreacion: true,
+  cliente: true,
+  usuario: true,
+  ancestros: true,
+  tracker: true,
+  dispositivo: true,
+});
 
 type OmitirUpdate =
   | '_id'

--- a/src/interfaces/config-deseada.ts
+++ b/src/interfaces/config-deseada.ts
@@ -1,16 +1,18 @@
-import { IGeoJSONPoint } from '../auxiliares';
-import { ICliente } from './cliente';
+import { z } from 'zod';
+import { ClienteSchema, ICliente } from './cliente';
 import {
+  DispositivoLuminariaACTISSchema,
+  DispositivoLuminariaGPESchema,
+  DispositivoLuminariaWellnessSchema,
   IDispositivoLorawan,
   IDispositivoLuminariaACTIS,
   IDispositivoLuminariaGPE,
   IDispositivoLuminariaWellness,
-  IModosACTIS,
-  IPerfilesDimmingACTIS,
 } from './dispositivo-lorawan';
 
 // 'Pendiente' indica creada/modificada pero aún no comparada por el reconciliador.
-export type Estado = 'Coincide' | 'No coincide' | 'Pendiente';
+export const EstadoSchema = z.enum(['Coincide', 'No coincide', 'Pendiente']);
+export type Estado = z.infer<typeof EstadoSchema>;
 
 /* ────────────────────────────────────────────────
  *  CONFIGS DESEADAS POR TIPO (Tienen correlación con las configuraciones REALES de los dispositivos para hacer comparaciones)
@@ -19,16 +21,32 @@ export type Estado = 'Coincide' | 'No coincide' | 'Pendiente';
  *   reactivePowerTotal, turnOnOffStatus, versiones de firmware, etc. — son campos no configurables)
  * ────────────────────────────────────────────────*/
 
+export const ConfigDeseadaLuminariaGPESchema =
+  DispositivoLuminariaGPESchema.omit({ alarma: true });
 export type IConfigDeseadaLuminariaGPE = Omit<
   IDispositivoLuminariaGPE,
   'alarma'
 >;
 
+export const ConfigDeseadaLuminariaWellnessSchema =
+  DispositivoLuminariaWellnessSchema.omit({
+    alarma: true,
+    activePowerTotal: true,
+    reactivePowerTotal: true,
+    turnOnOffStatus: true,
+  });
 export type IConfigDeseadaLuminariaWellness = Omit<
   IDispositivoLuminariaWellness,
   'alarma' | 'activePowerTotal' | 'reactivePowerTotal' | 'turnOnOffStatus'
 >;
 
+export const ConfigDeseadaLuminariaACTISSchema =
+  DispositivoLuminariaACTISSchema.omit({
+    alarma: true,
+    reporteFechaHora: true,
+    versionFirmware: true,
+    versionModuloLoRa: true,
+  });
 export type IConfigDeseadaLuminariaACTIS = Omit<
   IDispositivoLuminariaACTIS,
   'alarma' | 'reporteFechaHora' | 'versionFirmware' | 'versionModuloLoRa'
@@ -51,18 +69,21 @@ export type MapaConfigDeseada = {
 // Cada diff identifica un campo que no coincide entre la config deseada y la
 // real del dispositivo. El reconciliador lo usa para resolver qué downlink
 // disparar y qué get encadenar para refrescar dispositivo.config tras el set.
-export interface IDiffConfig {
-  campo: string; // dot path (ej: "fotocelula.umbralSuperior")
-  esperado: unknown;
-  real: unknown;
-  puertoDownlink: number; // puerto del set corrector
-  puertoGet?: number; // puerto del get que refresca dispositivo.config (ACTIS)
-}
+export const DiffConfigSchema = z.object({
+  campo: z.string(), // dot path (ej: "fotocelula.umbralSuperior")
+  esperado: z.unknown(),
+  real: z.unknown(),
+  puertoDownlink: z.number(), // puerto del set corrector
+  puertoGet: z.number().optional(), // puerto del get que refresca dispositivo.config (ACTIS)
+});
+export type IDiffConfig = z.infer<typeof DiffConfigSchema>;
 
 /* ────────────────────────────────────────────────
  *  BASE CONFIG DESEADA (GENÉRICO)
  * ────────────────────────────────────────────────*/
 
+// Interface genérica hand-written (no hay z.infer genérico): los schemas se
+// construyen por variante más abajo y se unen con z.union.
 export interface IConfigDeseadaBase<T extends keyof MapaConfigDeseada> {
   // Info autogenerada
   _id?: string;
@@ -93,9 +114,59 @@ export interface IConfigDeseadaBase<T extends keyof MapaConfigDeseada> {
   ancestros?: ICliente[];
 }
 
+const ConfigDeseadaCamposSchema = z.object({
+  // Info autogenerada
+  _id: z.string().optional(),
+  idCliente: z.string().optional(),
+  idsAncestros: z.array(z.string()).optional(),
+
+  // Info de carga
+  fechaCreacion: z.string().optional(), // Default: Date.now
+  fechaActualizacion: z.string().optional(), // Última vez que cambió el contenido de la configuración deseada
+  fechaAplicacion: z.string().optional(),
+  idEntidad: z.string().optional(),
+  estado: EstadoSchema.optional(),
+
+  // Reconciliación (escritos por el cron reconciliador)
+  diffs: z.array(DiffConfigSchema).optional(), // campos en discrepancia tras la última comparación
+  ultimaComparacion: z.string().optional(), // ISO timestamp de la última comparación realizada por el reconciliador
+  ultimaReconciliacion: z.string().optional(), // ISO timestamp del último set disparado
+  reintentosReconciliacion: z.number().optional(), // counter para back-off
+  bloqueadoHasta: z.string().optional(), // ISO. Si > now no se reintenta (circuit breaker)
+
+  // Virtuals
+  // z.custom para no arrastrar el shape completo del dispositivo al
+  // declaration emit (TS7056 en ConfigDeseadaSchema).
+  dispositivo: z.custom<IDispositivoLorawan>().optional(),
+  cliente: ClienteSchema.optional(),
+  ancestros: z.array(ClienteSchema).optional(),
+});
+
+const VarianteConfigDeseadaGPE = ConfigDeseadaCamposSchema.extend({
+  // Discriminante
+  tipo: z.literal('Luminaria GPE').optional(),
+  config: ConfigDeseadaLuminariaGPESchema.optional(),
+});
+const VarianteConfigDeseadaWellness = ConfigDeseadaCamposSchema.extend({
+  // Discriminante
+  tipo: z.literal('Luminaria Wellness').optional(),
+  config: ConfigDeseadaLuminariaWellnessSchema.optional(),
+});
+const VarianteConfigDeseadaACTIS = ConfigDeseadaCamposSchema.extend({
+  // Discriminante
+  tipo: z.literal('Luminaria ACTIS FING').optional(),
+  config: ConfigDeseadaLuminariaACTISSchema.optional(),
+});
+
 /* ────────────────────────────────────────────────
  *  TIPO DISCRIMINADO (TYPE-SAFE) - READ
  * ────────────────────────────────────────────────*/
+
+export const ConfigDeseadaSchema = z.union([
+  VarianteConfigDeseadaGPE,
+  VarianteConfigDeseadaWellness,
+  VarianteConfigDeseadaACTIS,
+]);
 
 export type IConfigDeseada =
   | IConfigDeseadaBase<'Luminaria GPE'>
@@ -115,9 +186,33 @@ type Omitir =
   | 'cliente'
   | 'ancestros';
 
+const camposOmitidos: {
+  _id: true;
+  idsAncestros: true;
+  fechaCreacion: true;
+  fechaActualizacion: true;
+  dispositivo: true;
+  cliente: true;
+  ancestros: true;
+} = {
+  _id: true,
+  idsAncestros: true,
+  fechaCreacion: true,
+  fechaActualizacion: true,
+  dispositivo: true,
+  cliente: true,
+  ancestros: true,
+};
+
 /** Create: no incluimos virtuales/ids manejados por backend.
  *  Mantiene `tipo` como discriminante.
  */
+export const CreateConfigDispositivoSchema = z.union([
+  VarianteConfigDeseadaGPE.omit(camposOmitidos),
+  VarianteConfigDeseadaWellness.omit(camposOmitidos),
+  VarianteConfigDeseadaACTIS.omit(camposOmitidos),
+]);
+
 export type ICreateConfigDispositivo =
   | Omit<IConfigDeseadaBase<'Luminaria GPE'>, Omitir>
   | Omit<IConfigDeseadaBase<'Luminaria Wellness'>, Omitir>
@@ -126,6 +221,18 @@ export type ICreateConfigDispositivo =
 /** Update: campos parciales pero `tipo` se mantiene para discriminar.
  *  TS valida que `config` corresponda al `tipo`.
  */
+export const UpdateConfigDispositivoSchema = z.union([
+  VarianteConfigDeseadaGPE.omit(camposOmitidos).extend({
+    tipo: z.literal('Luminaria GPE'),
+  }),
+  VarianteConfigDeseadaWellness.omit(camposOmitidos).extend({
+    tipo: z.literal('Luminaria Wellness'),
+  }),
+  VarianteConfigDeseadaACTIS.omit(camposOmitidos).extend({
+    tipo: z.literal('Luminaria ACTIS FING'),
+  }),
+]);
+
 export type IUpdateConfigDispositivo =
   | ({ tipo: 'Luminaria GPE' } & Partial<
       Omit<IConfigDeseadaBase<'Luminaria GPE'>, Omitir | 'tipo'>

--- a/src/interfaces/config-evento-usuario.ts
+++ b/src/interfaces/config-evento-usuario.ts
@@ -1,38 +1,148 @@
-import { IActivo } from './activo';
-import { ICliente, IConfigHorario } from './cliente';
-import { ICategoriaEvento } from './categoria-evento';
-import { IGrupo } from './grupo';
-import { IUbicacion } from './ubicacion';
-import { IUsuario } from './usuario';
-import { IDispositivoAlarma } from './dispositivo-alarma';
-import { ITracker } from './tracker';
-import { IListadoCategoria } from './listado-categoria';
-import { IGeoJSONPoint } from '../auxiliares';
-import { ILuminaria } from './luminaria';
+import { z } from 'zod';
+import type { IActivo } from './activo';
+import {
+  ClienteSchema,
+  ConfigHorarioSchema,
+  ICliente,
+  IConfigHorario,
+} from './cliente';
+import { CategoriaEventoSchema, ICategoriaEvento } from './categoria-evento';
+import type { IGrupo } from './grupo';
+import type { IUbicacion } from './ubicacion';
+import type { IUsuario } from './usuario';
+import type { IDispositivoAlarma } from './dispositivo-alarma';
+import type { ITracker } from './tracker';
+import { IListadoCategoria, ListadoCategoriaSchema } from './listado-categoria';
+import { GeoJSONPointSchema, IGeoJSONPoint } from '../auxiliares';
+import type { ILuminaria } from './luminaria';
 
-export interface IConfigZona {
-  particion?: number;
-  zona?: number;
-}
+export const ConfigZonaSchema = z.object({
+  particion: z.number().optional(),
+  zona: z.number().optional(),
+});
+export type IConfigZona = z.infer<typeof ConfigZonaSchema>;
 
-export type TipoEnvio = 'SMS' | 'WhatsApp' | 'Llamada' | 'Notificacion Push';
+export const TipoEnvioSchema = z.enum([
+  'SMS',
+  'WhatsApp',
+  'Llamada',
+  'Notificacion Push',
+]);
+export type TipoEnvio = z.infer<typeof TipoEnvioSchema>;
 
-export type Agrupacion = 'Grupo' | 'Entidad' | 'Global';
+export const AgrupacionSchema = z.enum(['Grupo', 'Entidad', 'Global']);
+export type Agrupacion = z.infer<typeof AgrupacionSchema>;
 
-export type TipoEntidad =
-  | 'Activo'
-  | 'Vehiculo'
-  | 'Alarma'
-  | 'Usuario'
-  | 'Luminaria';
+export const TipoEntidadSchema = z.enum([
+  'Activo',
+  'Vehiculo',
+  'Alarma',
+  'Usuario',
+  'Luminaria',
+]);
+export type TipoEntidad = z.infer<typeof TipoEntidadSchema>;
 
-export type Frecuencia =
-  | 'Unica'
-  | 'Continua'
-  | 'Unica en un periodo'
-  | 'Continua en un periodo'
-  | 'Cronograma';
+export const FrecuenciaSchema = z.enum([
+  'Unica',
+  'Continua',
+  'Unica en un periodo',
+  'Continua en un periodo',
+  'Cronograma',
+]);
+export type Frecuencia = z.infer<typeof FrecuenciaSchema>;
 
+// Populates intra-SCC como z.custom (import type-only): un schema real acá
+// arrastra el shape completo del ciclo y revienta la serialización de
+// declarations (TS7056) acá y en los consumidores NestJS.
+export const CondicionNotificacionSchema = z.object({
+  activo: z
+    .object({
+      velocidad: z
+        .object({
+          'superior a': z.number(),
+        })
+        .optional(),
+      // Exceso de velocidad según el límite legal de la calle/ruta (no un umbral fijo).
+      // El límite se resuelve por backend (TomTom/OSM, ver feature exceso de velocidad).
+      excesoVelocidadCalle: z
+        .object({
+          tolerancia: z.number().optional(), // ej. 0.1 (+10%) sobre el límite antes de generar; default 0.1
+          umbralFallback: z.number().optional(), // km/h a usar si la vía no tiene dato de límite
+        })
+        .optional(),
+      estacionado: z
+        .object({
+          ubicacionEstacionado: GeoJSONPointSchema.optional(),
+          distanciaDeAviso: z.number().optional(),
+        })
+        .optional(),
+      ubicacion: z
+        .object({
+          idUbicacion: z.string(),
+          dentro: z.boolean().optional(),
+          fuera: z.boolean().optional(),
+          /**
+           * Comprueba que el activo esté asignado a una emergencia medica para generar el evento
+           */
+          soloEnEmergencias: z.boolean().optional(),
+          // Virtual
+          ubicacion: z.custom<IUbicacion>().optional(),
+        })
+        .optional(),
+      detenido: z
+        .object({
+          'mas de': z.number(),
+        })
+        .optional(),
+      recorridos: z
+        .object({
+          distancia: z.number().optional(), // METROS
+          dentro: z.boolean().optional(),
+          fuera: z.boolean().optional(),
+        })
+        .optional(),
+      divergenciaGPS: z.boolean().optional(),
+    })
+    .optional(),
+
+  alarma: z
+    .object({
+      // se le asigna el codigo reportado, y notifica si llega ese evento dentro del periodo o cronograma
+      'llega evento': z.array(z.string()).optional(),
+      // se le asigna el codigo reportado, y notifica si no llega ese evento dentro del periodo o cronograma
+      'no llega evento': z.array(z.string()).optional(),
+    })
+    .optional(),
+  luminaria: z
+    .object({
+      potencia: z
+        .object({
+          'superior a': z.number().optional(),
+          'inferior a': z.number().optional(),
+        })
+        .optional(),
+      voltaje: z
+        .object({
+          'superior a': z.number().optional(),
+          'inferior a': z.number().optional(),
+        })
+        .optional(),
+    })
+    .optional(),
+  usuario: z
+    .object({
+      llegoEn: z.object({
+        idUsuario: z.string(),
+        tiempo: z.number(),
+      }),
+    })
+    .optional(),
+});
+
+/**
+ * Interface hand-written (misma forma que el schema): referencia IUbicacion
+ * (entidad del SCC), así que no usa z.infer para no disparar TS2589/TS7056.
+ */
 export interface CondicionNotificacion {
   activo?: {
     velocidad?: {
@@ -94,6 +204,83 @@ export interface CondicionNotificacion {
   };
 }
 
+export const CondicionNotificacionCacheSchema = z.object({
+  activo: z
+    .object({
+      velocidad: z
+        .object({
+          'superior a': z.number(),
+        })
+        .optional(),
+      excesoVelocidadCalle: z
+        .object({
+          tolerancia: z.number().optional(),
+          umbralFallback: z.number().optional(),
+        })
+        .optional(),
+      estacionado: z
+        .object({
+          ubicacionEstacionado: GeoJSONPointSchema.optional(),
+          distanciaDeAviso: z.number().optional(),
+        })
+        .optional(),
+      ubicacion: z
+        .object({
+          idUbicacion: z.string(),
+          dentro: z.boolean().optional(),
+          fuera: z.boolean().optional(),
+        })
+        .optional(),
+      detenido: z
+        .object({
+          'mas de': z.number(),
+        })
+        .optional(),
+      recorridos: z
+        .object({
+          distancia: z.number().optional(), // METROS
+          dentro: z.boolean().optional(),
+          fuera: z.boolean().optional(),
+        })
+        .optional(),
+      divergenciaGPS: z.boolean().optional(),
+    })
+    .optional(),
+
+  alarma: z
+    .object({
+      // se le asigna el codigo reportado, y notifica si llega ese evento dentro del periodo o cronograma
+      'llega evento': z.array(z.string()).optional(),
+      // se le asigna el codigo reportado, y notifica si no llega ese evento dentro del periodo o cronograma
+      'no llega evento': z.array(z.string()).optional(),
+    })
+    .optional(),
+  luminaria: z
+    .object({
+      potencia: z
+        .object({
+          'superior a': z.number().optional(),
+          'inferior a': z.number().optional(),
+        })
+        .optional(),
+      voltaje: z
+        .object({
+          'superior a': z.number().optional(),
+          'inferior a': z.number().optional(),
+        })
+        .optional(),
+    })
+    .optional(),
+  usuario: z
+    .object({
+      llegoEn: z.object({
+        idUsuario: z.string(),
+        tiempo: z.number(),
+      }),
+    })
+    .optional(),
+});
+
 export interface CondicionNotificacionCache {
   activo?: {
     velocidad?: {
@@ -147,15 +334,88 @@ export interface CondicionNotificacionCache {
   };
 }
 
-export type Dia =
-  | 'Lunes'
-  | 'Martes'
-  | 'Miercoles'
-  | 'Jueves'
-  | 'Viernes'
-  | 'Sabado'
-  | 'Domingo';
+export const DiaSchema = z.enum([
+  'Lunes',
+  'Martes',
+  'Miercoles',
+  'Jueves',
+  'Viernes',
+  'Sabado',
+  'Domingo',
+]);
+export type Dia = z.infer<typeof DiaSchema>;
 
+export const ConfigEventoUsuarioSchema = z.object({
+  _id: z.string().optional(),
+  fechaCreacion: z.string().optional(),
+  // Para eventos de una sola vez, al cumplirse se desactiva
+  activa: z.boolean().optional(),
+  // Agrupaciones temporales
+  frecuencia: FrecuenciaSchema.optional(),
+  // Fechas de vigencia para generar los eventos
+  validaDesde: z.string().optional(),
+  validaHasta: z.string().optional(),
+  // Frecuencia de generacion de eventos
+  generarSoloUnaVez: z.boolean().optional(),
+  // Si pasa el periodo y sigue activa se genera el evento
+  generarSiNoSeCumple: z.boolean().optional(),
+  // Dentro del cronograma
+  dias: z.array(DiaSchema).optional(),
+  horaInicio: z.string().optional(),
+  horaFin: z.string().optional(),
+  // Minutos que se agregan a los periodos de vigencia
+  minutosDeGracia: z.number().optional(),
+
+  // Notificar al usuario
+  notificar: z.boolean().optional(),
+  // Atender el evento
+  atender: z.boolean().optional(),
+  // Si es true solo el propio cliente lo puede ver/atender
+  noDerivar: z.boolean().optional(),
+  // Marca configs autogeneradas por el sistema (p.ej. "Seguimiento ambulancia").
+  // Backend la setea al autocrear. Cliente filtra esDelSistema: { $ne: true } para ocultarlas del usuario.
+  esDelSistema: z.boolean().optional(),
+  // Tipo de envio de la notificacion
+  tipoEnvio: TipoEnvioSchema.optional(),
+  // Tipo de dispositivo
+  tipoEntidad: TipoEntidadSchema.optional(),
+  // Configuracion de la condicion para enviar la notificacion
+  condicion: CondicionNotificacionSchema.optional(),
+  // Agrupacion para buscar las entidades
+  agrupacion: AgrupacionSchema.optional(),
+  // Sobre que entidades se reciben las notificaciones
+  idCliente: z.string().optional(),
+  idsAncestros: z.array(z.string()).optional(),
+  idGrupo: z.string().optional(),
+  idEntidad: z.string().optional(),
+  // Los usuarios que van a recibir las notificaciones
+  idsUsuarios: z.array(z.string()).optional(),
+  // Los clientes que pueden atender el evento
+  idsClientesQuePuedenAtender: z.array(z.string()).optional(),
+  configHorariosAtencion: z.array(ConfigHorarioSchema).optional(),
+  idCategoriaEvento: z.string().optional(),
+  codigoReportado: z.string().optional(),
+  idListadoCategoria: z.string().optional(),
+  configZona: ConfigZonaSchema.optional(),
+
+  // Virtual
+  usuarios: z.array(z.custom<IUsuario>()).optional(),
+  cliente: ClienteSchema.optional(),
+  ancestros: z.array(ClienteSchema).optional(),
+  grupo: z.custom<IGrupo>().optional(),
+  activo: z.custom<IActivo>().optional(),
+  luminaria: z.custom<ILuminaria>().optional(),
+  alarma: z.custom<IDispositivoAlarma>().optional(),
+  clientesQuePuedenAtender: z.array(ClienteSchema).optional(),
+  categoriaEvento: CategoriaEventoSchema.optional(),
+  tracker: z.custom<ITracker>().optional(),
+  listadoCategoria: ListadoCategoriaSchema.optional(),
+});
+
+/**
+ * Interface hand-written (misma forma que el schema): los tipos de entidad del
+ * SCC no usan z.infer porque los ciclos de aliases mutuos disparan TS2589.
+ */
 export interface IConfigEventoUsuario {
   _id?: string;
   fechaCreacion?: string;
@@ -223,6 +483,20 @@ export interface IConfigEventoUsuario {
   listadoCategoria?: IListadoCategoria;
 }
 
+export const CreateConfigEventoUsuarioSchema = ConfigEventoUsuarioSchema.omit({
+  _id: true,
+  usuarios: true,
+  cliente: true,
+  grupo: true,
+  activo: true,
+  luminaria: true,
+  alarma: true,
+  clientesQuePuedenAtender: true,
+  categoriaEvento: true,
+  tracker: true,
+  listadoCategoria: true,
+});
+
 type OmitirCreate =
   | '_id'
   | 'usuarios'
@@ -235,10 +509,22 @@ type OmitirCreate =
   | 'categoriaEvento'
   | 'tracker'
   | 'listadoCategoria';
-export interface ICreateConfigEventoUsuario extends Omit<
-  Partial<IConfigEventoUsuario>,
-  OmitirCreate
-> {}
+export interface ICreateConfigEventoUsuario
+  extends Omit<Partial<IConfigEventoUsuario>, OmitirCreate> {}
+
+export const UpdateConfigEventoUsuarioSchema = ConfigEventoUsuarioSchema.omit({
+  _id: true,
+  usuarios: true,
+  cliente: true,
+  grupo: true,
+  activo: true,
+  luminaria: true,
+  alarma: true,
+  clientesQuePuedenAtender: true,
+  categoriaEvento: true,
+  tracker: true,
+  listadoCategoria: true,
+});
 
 type OmitirUpdate =
   | '_id'
@@ -252,25 +538,41 @@ type OmitirUpdate =
   | 'categoriaEvento'
   | 'tracker'
   | 'listadoCategoria';
-export interface IUpdateConfigEventoUsuario extends Omit<
-  Partial<IConfigEventoUsuario>,
-  OmitirUpdate
-> {}
+export interface IUpdateConfigEventoUsuario
+  extends Omit<Partial<IConfigEventoUsuario>, OmitirUpdate> {}
 
-export interface IConfigEventoUsuarioCache extends Omit<
-  IConfigEventoUsuario,
-  | 'usuarios'
-  | 'cliente'
-  | 'ancestros'
-  | 'grupo'
-  | 'activo'
-  | 'luminaria'
-  | 'alarma'
-  | 'clientesQuePuedenAtender'
-  | 'categoriaEvento'
-  | 'tracker'
-  | 'listadoCategoria'
-  | 'condicion'
-> {
+export const ConfigEventoUsuarioCacheSchema = ConfigEventoUsuarioSchema.omit({
+  usuarios: true,
+  cliente: true,
+  ancestros: true,
+  grupo: true,
+  activo: true,
+  luminaria: true,
+  alarma: true,
+  clientesQuePuedenAtender: true,
+  categoriaEvento: true,
+  tracker: true,
+  listadoCategoria: true,
+  condicion: true,
+}).extend({
+  condicion: CondicionNotificacionCacheSchema.optional(),
+});
+
+export interface IConfigEventoUsuarioCache
+  extends Omit<
+    IConfigEventoUsuario,
+    | 'usuarios'
+    | 'cliente'
+    | 'ancestros'
+    | 'grupo'
+    | 'activo'
+    | 'luminaria'
+    | 'alarma'
+    | 'clientesQuePuedenAtender'
+    | 'categoriaEvento'
+    | 'tracker'
+    | 'listadoCategoria'
+    | 'condicion'
+  > {
   condicion?: CondicionNotificacionCache;
 }

--- a/src/interfaces/config-marker.ts
+++ b/src/interfaces/config-marker.ts
@@ -1,67 +1,78 @@
-import { FuncionActivo, TipoVehiculo } from './activo';
-import { ICliente } from './cliente';
+import { z } from 'zod';
+import { FuncionActivoSchema, TipoVehiculoSchema } from './activo';
+import { ClienteSchema } from './cliente';
 
-export interface IVistaMarker {
-  tipoVehiculo?: TipoVehiculo;
-  funcionVehiculo?: FuncionActivo;
+export const VistaMarkerSchema = z.object({
+  tipoVehiculo: TipoVehiculoSchema.optional(),
+  funcionVehiculo: FuncionActivoSchema.optional(),
 
   // Icono para el marker - En el front el usuario elige si ver por tipo o funcion
   //
-  vehicleTypeIcon?: string; // url imagen PNG - Idealemnente con fondo transparente para ver el color de la flota
-  vehiculeTypeIconColor?: string; // color HEX para el icono por tipo
-  vehicleFunctionIcon?: string; // url imagen PNG - Idealemnente con fondo transparente para ver el color de la flota
-  vehicleFunctionIconColor?: string; // color HEX para el icono por funcion
+  vehicleTypeIcon: z.string().optional(), // url imagen PNG - Idealemnente con fondo transparente para ver el color de la flota
+  vehiculeTypeIconColor: z.string().optional(), // color HEX para el icono por tipo
+  vehicleFunctionIcon: z.string().optional(), // url imagen PNG - Idealemnente con fondo transparente para ver el color de la flota
+  vehicleFunctionIconColor: z.string().optional(), // color HEX para el icono por funcion
 
   // Color icon
-  useOriginalIconColor?: boolean; // Si es true, usa el color original del icono, no aplica vehicleFunctionIcon vehicleFunctionIconColor groupColorIcon groupColorBackground
+  useOriginalIconColor: z.boolean().optional(), // Si es true, usa el color original del icono, no aplica vehicleFunctionIcon vehicleFunctionIconColor groupColorIcon groupColorBackground
 
   // Color segun el grupo
   //
-  groupColorIcon?: boolean; // Si es true, el icono toma el color del grupo
-  groupColorBackground?: boolean; // Si es true, el fondo del marker toma el color del grupo
+  groupColorIcon: z.boolean().optional(), // Si es true, el icono toma el color del grupo
+  groupColorBackground: z.boolean().optional(), // Si es true, el fondo del marker toma el color del grupo
 
   // Estado | Aro al rededor del icono
   //
-  offColor?: string; // color HEX / Color cuando el vehiculo esta apagado
-  stopColor?: string; // color HEX / Color cuando el vehiculo esta encendido y detenido
-  movingColor?: string; // color HEX / Color cuando el vehiculo esta encendido y en movimiento
-  movingDegraded?: boolean; // Si es true, el color moving se cambia de acuerdo a la velocidad de verde a rojo
-}
+  offColor: z.string().optional(), // color HEX / Color cuando el vehiculo esta apagado
+  stopColor: z.string().optional(), // color HEX / Color cuando el vehiculo esta encendido y detenido
+  movingColor: z.string().optional(), // color HEX / Color cuando el vehiculo esta encendido y en movimiento
+  movingDegraded: z.boolean().optional(), // Si es true, el color moving se cambia de acuerdo a la velocidad de verde a rojo
+});
+export type IVistaMarker = z.infer<typeof VistaMarkerSchema>;
 
-export interface IConfigMarker {
-  _id?: string;
+export const ConfigMarkerSchema = z.object({
+  _id: z.string().optional(),
   //
-  fechaCreacion?: string;
+  fechaCreacion: z.string().optional(),
 
   // Define quien puede usar este marker
   //
-  global?: boolean; // Si es global, puede ser usado por cualquiera
-  idCliente?: string; // IdCliente que lo creó
-  idsAncestros?: string[]; // IdsAncestros del cliente que lo creó
-  idUsuario?: string; // Si tiene idUsuario, solo lo puede usar ese usuario
+  global: z.boolean().optional(), // Si es global, puede ser usado por cualquiera
+  idCliente: z.string().optional(), // IdCliente que lo creó
+  idsAncestros: z.array(z.string()).optional(), // IdsAncestros del cliente que lo creó
+  idUsuario: z.string().optional(), // Si tiene idUsuario, solo lo puede usar ese usuario
 
   // Sobre que aplica este marker
   //
-  idClienteVer?: string; // idCliente del grupo o activo a ver; o repetido el idRef si scope es cliente ya que idRef es idCliente
-  scope: 'cliente' | 'grupo' | 'activo';
-  idRef: string; // idCliente, idGrupo o idActivo
+  idClienteVer: z.string().optional(), // idCliente del grupo o activo a ver; o repetido el idRef si scope es cliente ya que idRef es idCliente
+  scope: z.enum(['cliente', 'grupo', 'activo']),
+  idRef: z.string(), // idCliente, idGrupo o idActivo
 
-  vistas?: IVistaMarker[];
+  vistas: z.array(VistaMarkerSchema).optional(),
 
   // Populate
-  cliente?: ICliente;
-  clienteVer?: ICliente;
-  ancestros?: ICliente[];
-}
+  cliente: ClienteSchema.optional(),
+  clienteVer: ClienteSchema.optional(),
+  ancestros: z.array(ClienteSchema).optional(),
+});
+export type IConfigMarker = z.infer<typeof ConfigMarkerSchema>;
 
-type Omitir =
-  | '_id'
-  | 'idsAncestros'
+// El original era Omit<Partial<IConfigMarker>, Omitir>: acá el Partial NO era
+// no-op (scope e idRef son requeridos en la base), por eso se agrega .partial().
+export const CreateConfigMarkerSchema = ConfigMarkerSchema.omit({
+  _id: true,
+  idsAncestros: true,
   // Virtuals
-  | 'cliente'
-  | 'ancestros';
+  cliente: true,
+  ancestros: true,
+}).partial();
+export type ICreateConfigMarker = z.infer<typeof CreateConfigMarkerSchema>;
 
-export interface ICreateConfigMarker
-  extends Omit<Partial<IConfigMarker>, Omitir> {}
-export interface IUpdateConfigMarker
-  extends Omit<Partial<IConfigMarker>, Omitir> {}
+export const UpdateConfigMarkerSchema = ConfigMarkerSchema.omit({
+  _id: true,
+  idsAncestros: true,
+  // Virtuals
+  cliente: true,
+  ancestros: true,
+}).partial();
+export type IUpdateConfigMarker = z.infer<typeof UpdateConfigMarkerSchema>;

--- a/src/interfaces/config-perfil.ts
+++ b/src/interfaces/config-perfil.ts
@@ -1,17 +1,22 @@
-import { ICliente } from './cliente';
-import {
+import { z } from 'zod';
+import { ClienteSchema, ICliente } from './cliente';
+import type {
   IDispositivoLuminariaACTIS,
   IDispositivoLuminariaGPE,
   IDispositivoLuminariaWellness,
   IPerfilesDimmingACTIS,
 } from './dispositivo-lorawan';
 
-export type TipoEntidadConfigPerfil =
-  | 'Luminaria'
-  | 'Colectivo'
-  | 'Activo'
-  | 'Tracker'
-  | 'Vehiculo';
+export const TipoEntidadConfigPerfilSchema = z.enum([
+  'Luminaria',
+  'Colectivo',
+  'Activo',
+  'Tracker',
+  'Vehiculo',
+]);
+export type TipoEntidadConfigPerfil = z.infer<
+  typeof TipoEntidadConfigPerfilSchema
+>;
 
 //Estos perfiles definen valores por defecto de configuraciones que tienen que tener ciertas entidades.
 //Ej: en luminarias, definen configuraciones que se envían mediante comandos.
@@ -77,9 +82,57 @@ export interface IConfigPerfilBase<T extends keyof MapaConfigPerfil> {
   ancestros?: ICliente[];
 }
 
+// Campos comunes a todas las variantes (sin tipoConfig/valores, que discriminan)
+const ConfigPerfilCamposSchema = z.object({
+  _id: z.string().optional(),
+  fechaCreacion: z.string().optional(),
+  nombre: z.string().optional(),
+  global: z.boolean().optional(), // Si es global, puede ser usado por cualquier cliente.
+
+  // Tenant
+  idCliente: z.string().optional(),
+  idsAncestros: z.array(z.string()).optional(),
+
+  // Tipo y datos
+  tipoEntidad: TipoEntidadConfigPerfilSchema.optional(),
+
+  // Populate
+  cliente: ClienteSchema.optional(),
+  ancestros: z.array(ClienteSchema).optional(),
+});
+
+// Populates intra-SCC como z.custom (import type-only): un schema real acá
+// arrastra el shape completo del ciclo y revienta la serialización de
+// declarations (TS7056) acá y en los consumidores NestJS.
+const VarianteConfigPerfilLuminariaGPE = ConfigPerfilCamposSchema.extend({
+  tipoConfig: z.literal('Luminaria GPE').optional(),
+  valores: z.custom<IConfigPerfilLuminariaGPE>().optional(),
+});
+const VarianteConfigPerfilLuminariaWellness = ConfigPerfilCamposSchema.extend({
+  tipoConfig: z.literal('Luminaria Wellness').optional(),
+  valores: z.custom<IConfigPerfilLuminariaWellness>().optional(),
+});
+const VarianteConfigPerfilLuminariaACTISGeneral =
+  ConfigPerfilCamposSchema.extend({
+    tipoConfig: z.literal('Luminaria ACTIS FING General').optional(),
+    valores: z.custom<IConfigPerfilLuminariaACTISGeneral>().optional(),
+  });
+const VarianteConfigPerfilLuminariaACTISDimming =
+  ConfigPerfilCamposSchema.extend({
+    tipoConfig: z.literal('Luminaria ACTIS FING Dimming').optional(),
+    valores: z.custom<IConfigPerfilLuminariaACTISDimming>().optional(),
+  });
+
 /* ────────────────────────────────────────────────
  *  TIPO DISCRIMINADO (TYPE-SAFE) - READ
  * ────────────────────────────────────────────────*/
+
+export const ConfigPerfilSchema = z.union([
+  VarianteConfigPerfilLuminariaGPE,
+  VarianteConfigPerfilLuminariaWellness,
+  VarianteConfigPerfilLuminariaACTISGeneral,
+  VarianteConfigPerfilLuminariaACTISDimming,
+]);
 
 export type IConfigPerfil =
   | IConfigPerfilBase<'Luminaria GPE'>
@@ -91,11 +144,29 @@ export type IConfigPerfil =
  *  CREATE / UPDATE - UNIONES DISCRIMINADAS
  * ────────────────────────────────────────────────*/
 
+const camposOmitidos: {
+  _id: true;
+  idsAncestros: true;
+  cliente: true;
+  ancestros: true;
+} = {
+  _id: true,
+  idsAncestros: true,
+  cliente: true,
+  ancestros: true,
+};
+
 type Omitir = '_id' | 'idsAncestros' | 'cliente' | 'ancestros';
 
 /** Create: no incluimos virtuales/ids manejados por backend.
  *  Mantiene `tipoConfig` como discriminante.
  */
+export const CreateConfigPerfilSchema = z.union([
+  VarianteConfigPerfilLuminariaGPE.omit(camposOmitidos),
+  VarianteConfigPerfilLuminariaWellness.omit(camposOmitidos),
+  VarianteConfigPerfilLuminariaACTISGeneral.omit(camposOmitidos),
+  VarianteConfigPerfilLuminariaACTISDimming.omit(camposOmitidos),
+]);
 export type ICreateConfigPerfil =
   | Omit<IConfigPerfilBase<'Luminaria GPE'>, Omitir>
   | Omit<IConfigPerfilBase<'Luminaria Wellness'>, Omitir>
@@ -105,6 +176,20 @@ export type ICreateConfigPerfil =
 /** Update: campos parciales pero `tipoConfig` se mantiene para discriminar.
  *  TS valida que `valores` corresponda al `tipoConfig`.
  */
+export const UpdateConfigPerfilSchema = z.union([
+  VarianteConfigPerfilLuminariaGPE.omit(camposOmitidos).required({
+    tipoConfig: true,
+  }),
+  VarianteConfigPerfilLuminariaWellness.omit(camposOmitidos).required({
+    tipoConfig: true,
+  }),
+  VarianteConfigPerfilLuminariaACTISGeneral.omit(camposOmitidos).required({
+    tipoConfig: true,
+  }),
+  VarianteConfigPerfilLuminariaACTISDimming.omit(camposOmitidos).required({
+    tipoConfig: true,
+  }),
+]);
 export type IUpdateConfigPerfil =
   | ({ tipoConfig: 'Luminaria GPE' } & Partial<
       Omit<IConfigPerfilBase<'Luminaria GPE'>, Omitir | 'tipoConfig'>

--- a/src/interfaces/config-reenvios.ts
+++ b/src/interfaces/config-reenvios.ts
@@ -1,81 +1,103 @@
-import { ICliente } from './cliente';
-import { IDispositivoAlarma } from './dispositivo-alarma';
-import { ITracker } from './tracker';
+import { z } from 'zod';
+import { ClienteSchema } from './cliente';
+import { DispositivoAlarmaSchema } from './dispositivo-alarma';
+import { TrackerSchema } from './tracker';
 
-export type MetodoReenvio =
-  | 'Básico'
-  | 'Seguridad Evento Externo'
-  | 'Soflex'
-  | 'Caessat'
-  | 'Cersat'
-  | 'Iron Tracking'
-  | 'Logictracker';
-export type Protocolo = 'UDP' | 'TCP';
-export type IAgrupacionReenvio =
-  | 'Todos los trackers del cliente'
-  | 'Todas las alarmas del cliente'
-  | 'Entidad';
-export interface IOpcionesReenvio {
-  metodo?: MetodoReenvio;
-  host?: string;
-  puerto?: number;
-  apikey?: string;
-  usuario?: string;
-  protocolo?: Protocolo;
-  contrasena?: string;
-  usaReglaReenvio?: boolean;
-  reglasReenvio?: IReglaReenvio[]; //Especifica condiciones de cómo reenviar, dependiendo de cómo llegó la data recibida
-  opcionesSoflex?: ISoflexConfig;
-}
+export const MetodoReenvioSchema = z.enum([
+  'Básico',
+  'Seguridad Evento Externo',
+  'Soflex',
+  'Caessat',
+  'Cersat',
+  'Iron Tracking',
+  'Logictracker',
+]);
+export type MetodoReenvio = z.infer<typeof MetodoReenvioSchema>;
 
-export interface IReglaReenvio {
-  puertoEntrada?: number; // Puerto por el cual llegó la data recibida. Para Trackers: TRAX (5031), GTO6 (5023), GPS103 (5001)
-  protocoloEntrada?: Protocolo;
-  puertoSalida?: number; // Puerto al cual se reenviará la data (definido por el usuario)
-  protocoloSalida?: Protocolo;
-  hostSalida?: string; // Host al cual se reenviará la data (definido por el usuario)
-}
-export interface ISoflexConfig {
-  providerid?: string;
-  version?: string; // v.X.X dice la documentación
-}
+export const ProtocoloSchema = z.enum(['UDP', 'TCP']);
+export type Protocolo = z.infer<typeof ProtocoloSchema>;
 
-export interface IConfigReenvio {
-  _id?: string;
-  activo?: boolean;
-  idCliente?: string;
-  idsAncestros?: string[];
-  fechaCreacion?: string;
+export const AgrupacionReenvioSchema = z.enum([
+  'Todos los trackers del cliente',
+  'Todas las alarmas del cliente',
+  'Entidad',
+]);
+export type IAgrupacionReenvio = z.infer<typeof AgrupacionReenvioSchema>;
+
+export const ReglaReenvioSchema = z.object({
+  puertoEntrada: z.number().optional(), // Puerto por el cual llegó la data recibida. Para Trackers: TRAX (5031), GTO6 (5023), GPS103 (5001)
+  protocoloEntrada: ProtocoloSchema.optional(),
+  puertoSalida: z.number().optional(), // Puerto al cual se reenviará la data (definido por el usuario)
+  protocoloSalida: ProtocoloSchema.optional(),
+  hostSalida: z.string().optional(), // Host al cual se reenviará la data (definido por el usuario)
+});
+export type IReglaReenvio = z.infer<typeof ReglaReenvioSchema>;
+
+export const SoflexConfigSchema = z.object({
+  providerid: z.string().optional(),
+  version: z.string().optional(), // v.X.X dice la documentación
+});
+export type ISoflexConfig = z.infer<typeof SoflexConfigSchema>;
+
+export const OpcionesReenvioSchema = z.object({
+  metodo: MetodoReenvioSchema.optional(),
+  host: z.string().optional(),
+  puerto: z.number().optional(),
+  apikey: z.string().optional(),
+  usuario: z.string().optional(),
+  protocolo: ProtocoloSchema.optional(),
+  contrasena: z.string().optional(),
+  usaReglaReenvio: z.boolean().optional(),
+  reglasReenvio: z.array(ReglaReenvioSchema).optional(), //Especifica condiciones de cómo reenviar, dependiendo de cómo llegó la data recibida
+  opcionesSoflex: SoflexConfigSchema.optional(),
+});
+export type IOpcionesReenvio = z.infer<typeof OpcionesReenvioSchema>;
+
+export const ConfigReenvioSchema = z.object({
+  _id: z.string().optional(),
+  activo: z.boolean().optional(),
+  idCliente: z.string().optional(),
+  idsAncestros: z.array(z.string()).optional(),
+  fechaCreacion: z.string().optional(),
   // Configuracion
-  agrupacionReenvio?: IAgrupacionReenvio;
-  idClienteReenvio?: string;
-  idEntidadReenvio?: string;
-  opcionesReenvio?: IOpcionesReenvio;
-  reenviarHijos?: boolean; /// solo para trackers o alarmas de clientes hijos del cliente reenvio -- tambien se reenvian los propios
-  periodoInicio?: string; // Fecha desde la cual se comenzará a reenviar la data (si no se especifica, se asume que es desde la fecha de creación del reenvío)
-  periodoFin?: string; // Fecha hasta la cual se reenviará la data (si no se especifica, se asume que es indefinido)
+  agrupacionReenvio: AgrupacionReenvioSchema.optional(),
+  idClienteReenvio: z.string().optional(),
+  idEntidadReenvio: z.string().optional(),
+  opcionesReenvio: OpcionesReenvioSchema.optional(),
+  reenviarHijos: z.boolean().optional(), /// solo para trackers o alarmas de clientes hijos del cliente reenvio -- tambien se reenvian los propios
+  periodoInicio: z.string().optional(), // Fecha desde la cual se comenzará a reenviar la data (si no se especifica, se asume que es desde la fecha de creación del reenvío)
+  periodoFin: z.string().optional(), // Fecha hasta la cual se reenviará la data (si no se especifica, se asume que es indefinido)
 
   // Virtual
-  cliente?: ICliente;
-  ancestros?: ICliente[];
-  clienteReenvio?: ICliente;
-  dispositivoAlarma?: IDispositivoAlarma;
-  tracker?: ITracker;
-}
+  cliente: ClienteSchema.optional(),
+  ancestros: z.array(ClienteSchema).optional(),
+  clienteReenvio: ClienteSchema.optional(),
+  dispositivoAlarma: DispositivoAlarmaSchema.optional(),
+  tracker: TrackerSchema.optional(),
+});
+export type IConfigReenvio = z.infer<typeof ConfigReenvioSchema>;
 
-type OmitirCreate = '_id' | 'cliente' | 'dispositivoAlarma' | 'tracker';
-export interface ICreateConfigReenvio extends Omit<
-  Partial<IConfigReenvio>,
-  OmitirCreate
-> {}
+export const CreateConfigReenvioSchema = ConfigReenvioSchema.omit({
+  _id: true,
+  cliente: true,
+  dispositivoAlarma: true,
+  tracker: true,
+});
+export type ICreateConfigReenvio = z.infer<typeof CreateConfigReenvioSchema>;
 
-type OmitirUpdate = '_id' | 'cliente' | 'dispositivoAlarma' | 'tracker';
-export interface IUpdateConfigReenvio extends Omit<
-  Partial<IConfigReenvio>,
-  OmitirUpdate
-> {}
+export const UpdateConfigReenvioSchema = ConfigReenvioSchema.omit({
+  _id: true,
+  cliente: true,
+  dispositivoAlarma: true,
+  tracker: true,
+});
+export type IUpdateConfigReenvio = z.infer<typeof UpdateConfigReenvioSchema>;
 
-export interface IConfigReenvioCache extends Omit<
-  IConfigReenvio,
-  'cliente' | 'ancestros' | 'clienteReenvio' | 'dispositivoAlarma' | 'tracker'
-> {}
+export const ConfigReenvioCacheSchema = ConfigReenvioSchema.omit({
+  cliente: true,
+  ancestros: true,
+  clienteReenvio: true,
+  dispositivoAlarma: true,
+  tracker: true,
+});
+export type IConfigReenvioCache = z.infer<typeof ConfigReenvioCacheSchema>;

--- a/src/interfaces/cronograma.ts
+++ b/src/interfaces/cronograma.ts
@@ -1,7 +1,7 @@
 import { z } from 'zod';
 import { ClienteSchema } from './cliente';
 import { DiaSchema } from './config-evento-usuario';
-import { UbicacionSchema } from './ubicacion';
+import type { IUbicacion } from './ubicacion';
 
 export const TipoDeCronogramaSchema = z.enum(['despacho', 'turnos']);
 export type TipoDeCronograma = z.infer<typeof TipoDeCronogramaSchema>;
@@ -38,7 +38,10 @@ export const CronogramaSchema = z.object({
   // Populate
   cliente: ClienteSchema.optional(),
   ancestros: z.array(ClienteSchema).optional(),
-  ubicacion: UbicacionSchema.optional(),
+  // Populate hacia una union discriminada (IUbicacion): z.custom con el tipo
+  // hand-written, NO UbicacionSchema. z.infer del schema union rompe el
+  // narrowing por categoria al asignar un doc Mongoose en consumidores.
+  ubicacion: z.custom<IUbicacion>().optional(),
 });
 export type ICronograma = z.infer<typeof CronogramaSchema>;
 

--- a/src/interfaces/cronograma.ts
+++ b/src/interfaces/cronograma.ts
@@ -1,48 +1,57 @@
-import { ICliente } from './cliente';
-import { Dia } from './config-evento-usuario';
-import { IUbicacion } from './ubicacion';
+import { z } from 'zod';
+import { ClienteSchema } from './cliente';
+import { DiaSchema } from './config-evento-usuario';
+import { UbicacionSchema } from './ubicacion';
 
-export interface ICronograma {
-  _id?: string;
+export const TipoDeCronogramaSchema = z.enum(['despacho', 'turnos']);
+export type TipoDeCronograma = z.infer<typeof TipoDeCronogramaSchema>;
+
+export const PeriodoSchema = z.object({
+  desde: z.string().optional(), // Sale
+  hasta: z.string().optional(), // Llega
+  datos: z.record(z.string(), z.any()).optional(), // Datos extras para el periodo, como el chofer, el vehículo, el usuario, etc
+});
+export type Periodo = z.infer<typeof PeriodoSchema>;
+
+export const ConfigCronogramaSchema = z.object({
+  color: z.string().optional(),
+  nombreParaMostrar: z.string().optional(),
+});
+export type ConfigCronograma = z.infer<typeof ConfigCronogramaSchema>;
+
+export const CronogramaSchema = z.object({
+  _id: z.string().optional(),
   //
-  idCliente?: string;
-  idsAncestros?: string[];
-  idUbicacion?: string;
+  idCliente: z.string().optional(),
+  idsAncestros: z.array(z.string()).optional(),
+  idUbicacion: z.string().optional(),
   //
-  fechaCreacion?: string;
-  automatico?: boolean;
-  dias?: Dia[];
-  nombre?: string;
-  descripcion?: string;
-  tipo?: TipoDeCronograma;
-  periodos?: Periodo[];
+  fechaCreacion: z.string().optional(),
+  automatico: z.boolean().optional(),
+  dias: z.array(DiaSchema).optional(),
+  nombre: z.string().optional(),
+  descripcion: z.string().optional(),
+  tipo: TipoDeCronogramaSchema.optional(),
+  periodos: z.array(PeriodoSchema).optional(),
   //
-  configuracion?: ConfigCronograma; // Colores, el nombre de de lo que se está mostrando, etc
+  configuracion: ConfigCronogramaSchema.optional(), // Colores, el nombre de de lo que se está mostrando, etc
   // Populate
-  cliente?: ICliente;
-  ancestros?: ICliente[];
-  ubicacion?: IUbicacion;
-}
+  cliente: ClienteSchema.optional(),
+  ancestros: z.array(ClienteSchema).optional(),
+  ubicacion: UbicacionSchema.optional(),
+});
+export type ICronograma = z.infer<typeof CronogramaSchema>;
 
-type OmitirCreate = '_id' | 'cliente' | 'ubicacion';
+export const CreateCronogramaSchema = CronogramaSchema.omit({
+  _id: true,
+  cliente: true,
+  ubicacion: true,
+});
+export type ICreateCronograma = z.infer<typeof CreateCronogramaSchema>;
 
-export interface ICreateCronograma
-  extends Omit<Partial<ICronograma>, OmitirCreate> {}
-
-type OmitirUpdate = '_id' | 'cliente' | 'ubicacion';
-
-export interface IUpdateCronograma
-  extends Omit<Partial<ICronograma>, OmitirUpdate> {}
-
-export type TipoDeCronograma = 'despacho' | 'turnos';
-
-export interface Periodo {
-  desde?: string; // Sale
-  hasta?: string; // Llega
-  datos?: Record<string, any>; // Datos extras para el periodo, como el chofer, el vehículo, el usuario, etc
-}
-
-export interface ConfigCronograma {
-  color?: string;
-  nombreParaMostrar?: string;
-}
+export const UpdateCronogramaSchema = CronogramaSchema.omit({
+  _id: true,
+  cliente: true,
+  ubicacion: true,
+});
+export type IUpdateCronograma = z.infer<typeof UpdateCronogramaSchema>;

--- a/src/interfaces/despacho.ts
+++ b/src/interfaces/despacho.ts
@@ -1,59 +1,59 @@
-import { IActivo } from './activo';
-import { ICliente } from './cliente';
-import { ICronograma } from './cronograma';
-import { IRecorrido } from './recorrido';
-import { IUsuario } from './usuario';
+import { z } from 'zod';
+import { ActivoSchema } from './activo';
+import { ClienteSchema } from './cliente';
+import { CronogramaSchema } from './cronograma';
+import { RecorridoSchema } from './recorrido';
+import { UsuarioSchema } from './usuario';
 
-export interface IDespacho {
-  _id?: string;
+export const DespachoSchema = z.object({
+  _id: z.string().optional(),
   //
-  idCliente?: string;
-  idsAncestros?: string[];
-  idUsuario?: string;
+  idCliente: z.string().optional(),
+  idsAncestros: z.array(z.string()).optional(),
+  idUsuario: z.string().optional(),
   //
-  fechaCreacion?: string;
-  fecha?: string;
-  hora?: string; // Sale
-  salio?: string; // Salió
-  idCronograma?: string;
-  idActivo?: string;
-  idChofer?: string;
-  idsRecorridos?: string[];
-  idRecorridoActual?: string;
-  completado?: boolean; /// Que los datos son iguales al cronograma
-  cancelado?: boolean; /// Que el despacho fue cancelado
+  fechaCreacion: z.string().optional(),
+  fecha: z.string().optional(),
+  hora: z.string().optional(), // Sale
+  salio: z.string().optional(), // Salió
+  idCronograma: z.string().optional(),
+  idActivo: z.string().optional(),
+  idChofer: z.string().optional(),
+  idsRecorridos: z.array(z.string()).optional(),
+  idRecorridoActual: z.string().optional(),
+  completado: z.boolean().optional(), /// Que los datos son iguales al cronograma
+  cancelado: z.boolean().optional(), /// Que el despacho fue cancelado
   // Populate
-  cliente?: ICliente;
-  ancestros?: ICliente[];
-  usuario?: IUsuario;
-  activo?: IActivo;
-  chofer?: IUsuario;
-  recorridos?: IRecorrido[];
-  cronograma?: ICronograma;
-}
+  cliente: ClienteSchema.optional(),
+  ancestros: z.array(ClienteSchema).optional(),
+  usuario: UsuarioSchema.optional(),
+  activo: ActivoSchema.optional(),
+  chofer: UsuarioSchema.optional(),
+  recorridos: z.array(RecorridoSchema).optional(),
+  cronograma: CronogramaSchema.optional(),
+});
+export type IDespacho = z.infer<typeof DespachoSchema>;
 
-type OmitirCreate =
-  | '_id'
-  | 'cliente'
-  | 'usuario'
-  | 'fechaCreacion'
-  | 'activo'
-  | 'chofer'
-  | 'recorridos'
-  | 'cronograma';
+export const CreateDespachoSchema = DespachoSchema.omit({
+  _id: true,
+  cliente: true,
+  usuario: true,
+  fechaCreacion: true,
+  activo: true,
+  chofer: true,
+  recorridos: true,
+  cronograma: true,
+});
+export type ICreateDespacho = z.infer<typeof CreateDespachoSchema>;
 
-export interface ICreateDespacho
-  extends Omit<Partial<IDespacho>, OmitirCreate> {}
-
-type OmitirUpdate =
-  | '_id'
-  | 'cliente'
-  | 'usuario'
-  | 'fechaCreacion'
-  | 'activo'
-  | 'chofer'
-  | 'recorridos'
-  | 'cronograma';
-
-export interface IUpdateDespacho
-  extends Omit<Partial<IDespacho>, OmitirUpdate> {}
+export const UpdateDespachoSchema = DespachoSchema.omit({
+  _id: true,
+  cliente: true,
+  usuario: true,
+  fechaCreacion: true,
+  activo: true,
+  chofer: true,
+  recorridos: true,
+  cronograma: true,
+});
+export type IUpdateDespacho = z.infer<typeof UpdateDespachoSchema>;

--- a/src/interfaces/destinatario-asistencia.ts
+++ b/src/interfaces/destinatario-asistencia.ts
@@ -1,12 +1,45 @@
-import { ICliente } from "./cliente";
-import { DireccionV2 } from "../auxiliares";
-import { TipoEmergencia } from "./emergencias";
+import { z } from "zod";
+import { ClienteSchema, ICliente } from "./cliente";
+import { DireccionV2, DireccionV2Schema } from "../auxiliares";
+import type { TipoEmergencia } from "./emergencias";
 
-export interface IInfoAdicional {
-  descripcion?: string;
-  adjuntos?: string[]; // Array de URLs de archivos adjuntos
-}
+export const InfoAdicionalSchema = z.object({
+  descripcion: z.string().optional(),
+  adjuntos: z.array(z.string()).optional(), // Array de URLs de archivos adjuntos
+});
+export type IInfoAdicional = z.infer<typeof InfoAdicionalSchema>;
 
+// Populates intra-SCC como z.custom (import type-only): un schema real acá
+// arrastra el shape completo del ciclo y revienta la serialización de
+// declarations (TS7056) acá y en los consumidores NestJS.
+export const DestinatarioAsistenciaSchema = z.object({
+  _id: z.string().optional(), // ID único del destinatario
+  idCliente: z.string().optional(),
+  idsAncestros: z.array(z.string()).optional(),
+
+  fechaCreacion: z.string().optional(),
+  nombre: z.string().optional(),
+  tipoEmergencia: z.custom<TipoEmergencia>().optional(),
+  apellido: z.string().optional(),
+  sexo: z.enum(["M", "F", "X"]).optional(),
+  dni: z.string().optional(),
+  edad: z.number().optional(),
+  obraSocial: z.string().optional(),
+  infoAdicional: InfoAdicionalSchema.optional(), // Información adicional del destinatario
+  telefono: z.string().optional(), // Teléfono del destinatario
+  email: z.string().optional(), // Correo electrónico del destinatario
+  telefonoAlternativo: z.string().optional(),
+  ubicacion: DireccionV2Schema.optional(), // Ubicación del destinatario
+
+  //Populate
+  cliente: ClienteSchema.optional(),
+  ancestros: z.array(ClienteSchema).optional(),
+});
+
+/**
+ * Interface hand-written (misma forma que el schema): los tipos de entidad del
+ * SCC no usan z.infer para no arrastrar el ciclo en el declaration emit.
+ */
 export interface IDestinatarioAsistencia {
   _id?: string; // ID único del destinatario
   idCliente?: string;
@@ -33,10 +66,14 @@ export interface IDestinatarioAsistencia {
 
 type OmitirCreate = "_id";
 
+export const CreateDestinatarioAsistenciaSchema =
+  DestinatarioAsistenciaSchema.omit({ _id: true });
 export interface ICreateDestinatarioAsistencia
   extends Omit<Partial<IDestinatarioAsistencia>, OmitirCreate> {}
 
 type OmitirUpdate = "_id";
 
+export const UpdateDestinatarioAsistenciaSchema =
+  DestinatarioAsistenciaSchema.omit({ _id: true });
 export interface IUpdateDestinatarioAsistencia
   extends Omit<Partial<IDestinatarioAsistencia>, OmitirUpdate> {}

--- a/src/interfaces/dispositivo-alarma.ts
+++ b/src/interfaces/dispositivo-alarma.ts
@@ -1,149 +1,279 @@
-import { ICamara } from './camara';
-import { ICliente, IConfigHorario, ICredencialesAlarma } from './cliente';
-import { Dia } from './config-evento-usuario';
-import { estadoCuenta } from './estado-entidad';
-import { IModeloDispositivo } from './modelo-dispositivo';
-import { IServicioContratado } from './servicio-contratado';
-import { IUbicacion } from './ubicacion';
+import { z } from 'zod';
+import { CamaraSchema, ICamara } from './camara';
+import {
+  ClienteSchema,
+  ConfigHorarioSchema,
+  CredencialesAlarmaSchema,
+  ICliente,
+  IConfigHorario,
+  ICredencialesAlarma,
+} from './cliente';
+import type { Dia } from './config-evento-usuario';
+import type { estadoCuenta } from './estado-entidad';
+import {
+  IModeloDispositivo,
+  ModeloDispositivoSchema,
+} from './modelo-dispositivo';
+import {
+  IServicioContratado,
+  ServicioContratadoSchema,
+} from './servicio-contratado';
+import type { IUbicacion } from './ubicacion';
 
 /// Lepra ( interfaces para las respuestas de HSI )
-export type TipoEmergenciaAlarma = 'Pánico' | 'Médica' | 'Incendio';
-export type TiposDeArmado = 'T' | 'D' | 'p1';
+export const TipoEmergenciaAlarmaSchema = z.enum([
+  'Pánico',
+  'Médica',
+  'Incendio',
+]);
+export type TipoEmergenciaAlarma = z.infer<typeof TipoEmergenciaAlarmaSchema>;
+
+export const TiposDeArmadoSchema = z.enum(['T', 'D', 'p1']);
+export type TiposDeArmado = z.infer<typeof TiposDeArmadoSchema>;
 /// T es away(ausente ) p1 (stay (casa) D es desarmado
 ////
-export interface ISim {
-  iccid?: string;
-  numero?: string;
-  operador?: Operador;
-  apn?: string;
-  usuario?: string;
-  password?: string;
-}
 
-export interface IUltimaConexion {
-  lastIp?: string;
-  lastPort?: string;
-  sequence: number;
-}
+export const CodigoTipoSensorSchema = z.enum([
+  'PIR',
+  'DRV',
+  'MMG',
+  'BIR',
+  'PAS',
+  'PPC',
+  'TAM',
+  'OCR',
+  'HUM',
+  'PFU',
+  'ELE',
+  'BUM',
+  'CEM',
+  'VOL',
+  'DTS',
+  'SIS',
+  'AMK',
+]);
+export type CodigoTipoSensor = z.infer<typeof CodigoTipoSensorSchema>;
 
-export interface ICamaraAlarma {
-  idCamara?: string;
-  canal?: string;
-  particion?: number;
-  zona?: number;
-}
+export const ModoSensorSchema = z.enum([
+  'Seguidor',
+  'Demorado',
+  'Instantaneo',
+]);
+export type ModoSensor = z.infer<typeof ModoSensorSchema>;
 
-export interface IModoDesactivado {
-  dispositivoDesactivado?: boolean;
-  permanente?: boolean;
-  desde?: string;
-  hasta?: string;
-  codigos?: string[];
-  alarma?: {
-    particiones?: string[];
-    zonas?: {
-      particion: string;
-      zona: string;
-    }[];
-  };
-}
+export const OperadorSchema = z.enum([
+  'Personal',
+  'Claro',
+  'Movistar',
+  'Tuenti',
+  'Otro',
+]);
+export type Operador = z.infer<typeof OperadorSchema>;
 
-export interface ISensorPorZona {
-  marca?: string;
-  tipo?: CodigoTipoSensor;
-  modelo?: string;
+export const SimSchema = z.object({
+  iccid: z.string().optional(),
+  numero: z.string().optional(),
+  operador: OperadorSchema.optional(),
+  apn: z.string().optional(),
+  usuario: z.string().optional(),
+  password: z.string().optional(),
+});
+export type ISim = z.infer<typeof SimSchema>;
+
+export const UltimaConexionSchema = z.object({
+  lastIp: z.string().optional(),
+  lastPort: z.string().optional(),
+  sequence: z.number(),
+});
+export type IUltimaConexion = z.infer<typeof UltimaConexionSchema>;
+
+export const CamaraAlarmaSchema = z.object({
+  idCamara: z.string().optional(),
+  canal: z.string().optional(),
+  particion: z.number().optional(),
+  zona: z.number().optional(),
+});
+export type ICamaraAlarma = z.infer<typeof CamaraAlarmaSchema>;
+
+export const ModoDesactivadoSchema = z.object({
+  dispositivoDesactivado: z.boolean().optional(),
+  permanente: z.boolean().optional(),
+  desde: z.string().optional(),
+  hasta: z.string().optional(),
+  codigos: z.array(z.string()).optional(),
+  alarma: z
+    .object({
+      particiones: z.array(z.string()).optional(),
+      zonas: z
+        .array(
+          z.object({
+            particion: z.string(),
+            zona: z.string(),
+          }),
+        )
+        .optional(),
+    })
+    .optional(),
+});
+export type IModoDesactivado = z.infer<typeof ModoDesactivadoSchema>;
+
+export const SensorPorZonaSchema = z.object({
+  marca: z.string().optional(),
+  tipo: CodigoTipoSensorSchema.optional(),
+  modelo: z.string().optional(),
   // UNICOM (sensores RF inalámbricos). El panel guarda por sensor el código RF
   // (3 bytes) + un atributo que codifica el modo de zona (attr = 0x10 + code).
-  codigoRf?: string; // 6 hex (3 bytes), ej. "AABBCC"
-  modoRf?: string; // modo de zona UNICOM "R###" (Interior, Entrada/Salida, Perimetral, ...)
-  attrRf?: number; // byte de atributo (0x10 + code del modo)
-}
-export interface IParticionZona {
-  nombre?: string;
-  particion?: number;
-  zona?: number;
-  sensores?: ISensorPorZona[];
-  modo?: ModoSensor;
-}
+  codigoRf: z.string().optional(), // 6 hex (3 bytes), ej. "AABBCC"
+  modoRf: z.string().optional(), // modo de zona UNICOM "R###" (Interior, Entrada/Salida, Perimetral, ...)
+  attrRf: z.number().optional(), // byte de atributo (0x10 + code del modo)
+});
+export type ISensorPorZona = z.infer<typeof SensorPorZonaSchema>;
 
-export type ITipoControlHorario = 'Apertura' | 'Cierre';
-export interface IControlHorarioDetalles {
+export const ParticionZonaSchema = z.object({
+  nombre: z.string().optional(),
+  particion: z.number().optional(),
+  zona: z.number().optional(),
+  sensores: z.array(SensorPorZonaSchema).optional(),
+  modo: ModoSensorSchema.optional(),
+});
+export type IParticionZona = z.infer<typeof ParticionZonaSchema>;
+
+export const TipoControlHorarioSchema = z.enum(['Apertura', 'Cierre']);
+export type ITipoControlHorario = z.infer<typeof TipoControlHorarioSchema>;
+
+// Populates intra-SCC como z.custom (import type-only): un schema real acá
+// arrastra el shape completo del ciclo y revienta la serialización de
+// declarations (TS7056) acá y en los consumidores NestJS.
+export const ControlHorarioDetallesSchema = z.object({
   // abre los lunes a viernes  a las 8:30 con tolerancia de 30 minutos
-  tipo: ITipoControlHorario;
-  dias: Dia[];
-  hora: string;
-  toleranciaAntes: number;
-  toleranciaDespues: number;
-  particion: number;
-}
-export interface IControlHorario {
-  activo?: boolean;
-  ignorarArmadosFueraDeHorario?: boolean;
-  ignorarDesarmadosFueraDeHorario?: boolean;
-  horarios?: IControlHorarioDetalles[];
-}
+  tipo: TipoControlHorarioSchema,
+  dias: z.array(z.custom<Dia>()),
+  hora: z.string(),
+  toleranciaAntes: z.number(),
+  toleranciaDespues: z.number(),
+  particion: z.number(),
+});
+export type IControlHorarioDetalles = z.infer<
+  typeof ControlHorarioDetallesSchema
+>;
 
-export type CodigoTipoSensor =
-  | 'PIR'
-  | 'DRV'
-  | 'MMG'
-  | 'BIR'
-  | 'PAS'
-  | 'PPC'
-  | 'TAM'
-  | 'OCR'
-  | 'HUM'
-  | 'PFU'
-  | 'ELE'
-  | 'BUM'
-  | 'CEM'
-  | 'VOL'
-  | 'DTS'
-  | 'SIS'
-  | 'AMK';
-export type ModoSensor = 'Seguidor' | 'Demorado' | 'Instantaneo';
-export type Operador = 'Personal' | 'Claro' | 'Movistar' | 'Tuenti' | 'Otro';
+export const ControlHorarioSchema = z.object({
+  activo: z.boolean().optional(),
+  ignorarArmadosFueraDeHorario: z.boolean().optional(),
+  ignorarDesarmadosFueraDeHorario: z.boolean().optional(),
+  horarios: z.array(ControlHorarioDetallesSchema).optional(),
+});
+export type IControlHorario = z.infer<typeof ControlHorarioSchema>;
 
 /// UNICOM "WiFi DUO" ──────────────────────────────────────────────
 /// Comunicador WiFi (no SIM) que opera por MQTT contra el broker propio
 /// de IRIX. Modos de armado del panel (selectivo = total excluyendo zonas).
-export type ModoArmadoUnicom =
-  | 'Total'
-  | 'Perimetral'
-  | 'Selectivo'
-  | 'Desarmado';
+export const ModoArmadoUnicomSchema = z.enum([
+  'Total',
+  'Perimetral',
+  'Selectivo',
+  'Desarmado',
+]);
+export type ModoArmadoUnicom = z.infer<typeof ModoArmadoUnicomSchema>;
 
-export interface IEstadoArmadoUnicom {
-  modo?: ModoArmadoUnicom;
-  zonasExcluidas?: number[]; // solo para 'Selectivo' (zonas excluidas del armado)
-  actualizado?: string; // fecha ISO del último cambio de estado conocido
-}
+export const EstadoArmadoUnicomSchema = z.object({
+  modo: ModoArmadoUnicomSchema.optional(),
+  zonasExcluidas: z.array(z.number()).optional(), // solo para 'Selectivo' (zonas excluidas del armado)
+  actualizado: z.string().optional(), // fecha ISO del último cambio de estado conocido
+});
+export type IEstadoArmadoUnicom = z.infer<typeof EstadoArmadoUnicomSchema>;
 
 /// Último estado de energía/panel del UNICOM, decodificado del bitmask `sts` que el equipo
 /// reporta por MQTT. Lo persiste el gateway (gestion-api-alarmas) en el doc para que el resto
 /// del sistema (p.ej. consultarEstado → indicadores batería/220V) lo lea sin depender del broker.
-export interface IUltimoEstadoUnicom {
-  hay220v?: boolean; // false = falta de energía (corte 220V)
-  bateriaBaja?: boolean;
-  armadoTotal?: boolean;
-  perimetral?: boolean;
-  disparo?: boolean;
-  sirena?: boolean;
-  fecha?: string; // ISO del último sts procesado
-}
+export const UltimoEstadoUnicomSchema = z.object({
+  hay220v: z.boolean().optional(), // false = falta de energía (corte 220V)
+  bateriaBaja: z.boolean().optional(),
+  armadoTotal: z.boolean().optional(),
+  perimetral: z.boolean().optional(),
+  disparo: z.boolean().optional(),
+  sirena: z.boolean().optional(),
+  fecha: z.string().optional(), // ISO del último sts procesado
+});
+export type IUltimoEstadoUnicom = z.infer<typeof UltimoEstadoUnicomSchema>;
 
 /// Config por dispositivo del comunicador UNICOM. La identidad es el devid
 /// (= idUnicoComunicador, "uw"+MAC). El broker/credenciales son de flota y
 /// viven a nivel backend (env), NO por dispositivo en DB. Los topics se
 /// derivan del devid (cmd/<devid>, dev/uw/0001/<devid>).
-export interface IConfigComunicadorUnicom {
-  devid?: string; // "uw"+MAC (redundante con idUnicoComunicador, por claridad)
-  canal?: string; // "chan" del firmware (ej. "dev")
-  topicCmd?: string; // override opcional del topic de comandos
-  topicDev?: string; // override opcional del topic de eventos
-  tls?: boolean; // reservado: hoy plaintext, TLS es mejora futura
-}
+export const ConfigComunicadorUnicomSchema = z.object({
+  devid: z.string().optional(), // "uw"+MAC (redundante con idUnicoComunicador, por claridad)
+  canal: z.string().optional(), // "chan" del firmware (ej. "dev")
+  topicCmd: z.string().optional(), // override opcional del topic de comandos
+  topicDev: z.string().optional(), // override opcional del topic de eventos
+  tls: z.boolean().optional(), // reservado: hoy plaintext, TLS es mejora futura
+});
+export type IConfigComunicadorUnicom = z.infer<
+  typeof ConfigComunicadorUnicomSchema
+>;
 
+export const DispositivoAlarmaSchema = z.object({
+  _id: z.string().optional(),
+  //
+  fechaCreacion: z.string().optional(),
+  fechaAlta: z.string().optional(),
+  fechaUltimaComunicacion: z.string().optional(),
+  idComunicador: z.string().optional(),
+  idUnicoComunicador: z.string().optional(),
+  passwordComunicador: z.string().optional(),
+  idModelo: z.string().optional(),
+  idDomicilio: z.string().optional(),
+  idCliente: z.string().optional(),
+  idsAncestros: z.array(z.string()).optional(),
+  nombre: z.string().optional(),
+  numeroAbonado: z.string().optional(),
+  sim1: SimSchema.optional(),
+  sim2: SimSchema.optional(),
+  idsClientesQuePuedenAtender: z.array(z.string()).optional(),
+  idsClientesQuePuedenAtenderEventosTecnicos: z.array(z.string()).optional(),
+  puedeSolicitarServicioTecnico: z.boolean().optional(),
+  configHorariosAtencion: z.array(ConfigHorarioSchema).optional(),
+  configHorariosAtencionTecnica: z.array(ConfigHorarioSchema).optional(),
+  camarasPorZona: z.array(CamaraAlarmaSchema).optional(),
+  idsCamaras: z.array(z.string()).optional(),
+  armado: z.array(z.boolean()).optional(),
+  armadoPor: z.array(z.union([z.string(), z.null()])).optional(),
+  // UNICOM: estado de armado con semántica propia (total/perimetral/selectivo).
+  // Additive — NO reemplaza `armado`/`TiposDeArmado` (uso productivo de otras alarmas).
+  estadoArmadoUnicom: EstadoArmadoUnicomSchema.optional(),
+  configUnicom: ConfigComunicadorUnicomSchema.optional(),
+  // UNICOM: último estado de energía/panel decodificado del `sts` (persistido por el gateway).
+  ultimoEstadoUnicom: UltimoEstadoUnicomSchema.optional(),
+  imagenes: z.array(z.string()).optional(),
+  ultimaConexion: UltimaConexionSchema.optional(),
+  modoDesactivado: ModoDesactivadoSchema.optional(),
+  infoZonas: z.array(ParticionZonaSchema).optional(),
+  controlHorario: ControlHorarioSchema.optional(),
+  //
+  nroDeSistema: z.string().optional(),
+  //
+  estadoCuenta: z.custom<estadoCuenta>().optional(),
+  frecReporte: z.number().optional(),
+  idServiciosContratados: z.array(z.string()).optional(),
+  clave: z.string().optional(),
+  contraClave: z.string().optional(),
+  // undefined = usar credenciales del cliente (config.credencialesAlarmas)
+  credencialesAlarma: CredencialesAlarmaSchema.optional(),
+  tipoComercio: z.string().optional(),
+  tipoCategoria: z.string().optional(),
+  // Populate
+  domicilio: z.custom<IUbicacion>().optional(),
+  modelo: ModeloDispositivoSchema.optional(),
+  cliente: ClienteSchema.optional(),
+  ancestros: z.array(ClienteSchema).optional(),
+  comunicador: ModeloDispositivoSchema.optional(),
+  camaras: z.array(CamaraSchema).optional(),
+  serviciosContratados: z.array(ServicioContratadoSchema).optional(),
+});
+/**
+ * Interface hand-written (misma forma que el schema): los tipos de entidad del
+ * SCC no usan z.infer para no arrastrar el ciclo en el declaration emit.
+ */
 export interface IDispositivoAlarma {
   _id?: string;
   //
@@ -212,6 +342,15 @@ type OmitirCreate =
   | 'camaras'
   | 'serviciosContratados';
 
+export const CreateDispositivoAlarmaSchema = DispositivoAlarmaSchema.omit({
+  _id: true,
+  cliente: true,
+  modelo: true,
+  domicilio: true,
+  comunicador: true, // fix: el original tenía 'comunicador ' con espacio, que no omitía nada
+  camaras: true,
+  serviciosContratados: true,
+});
 export interface ICreateDispositivoAlarma extends Omit<
   Partial<IDispositivoAlarma>,
   OmitirCreate
@@ -226,11 +365,29 @@ type OmitirUpdate =
   | 'camaras'
   | 'serviciosContratados';
 
+export const UpdateDispositivoAlarmaSchema = DispositivoAlarmaSchema.omit({
+  _id: true,
+  cliente: true,
+  modelo: true,
+  domicilio: true,
+  comunicador: true,
+  camaras: true,
+  serviciosContratados: true,
+});
 export interface IUpdateDispositivoAlarma extends Omit<
   Partial<IDispositivoAlarma>,
   OmitirUpdate
 > {}
 
+export const DispositivoAlarmaCacheSchema = DispositivoAlarmaSchema.omit({
+  domicilio: true,
+  modelo: true,
+  cliente: true,
+  ancestros: true,
+  comunicador: true,
+  camaras: true,
+  serviciosContratados: true,
+});
 export interface IDispositivoAlarmaCache extends Omit<
   IDispositivoAlarma,
   | 'domicilio'
@@ -245,509 +402,579 @@ export interface IDispositivoAlarmaCache extends Omit<
 /////// Cosas de las apis de garnet dahua y eso
 //////
 /////
-export interface IConfigAlarmaHSI {
-  id: string;
-  lastEventReport: string;
-  cameraLink: {
-    appName: string;
-    appPackage: string;
-    appStoreUrl: string;
-    appPlayStoreUri: string;
-    appBundleId: string;
-  };
-  userPermissions: {
-    atributos: {
-      puedeArmar: boolean;
-      puedeDesarmar: boolean;
-      puedeInhibirZonas: boolean;
-      puedeInteractuarConSalidas: boolean;
-      puedeInteractuarConSirena: boolean;
-      puedeVerCamaras: boolean;
-      sharedPartitions: {
-        [key: string]: boolean;
-      };
-    };
-    configuraciones: {
-      users: boolean;
-      automations: boolean;
-      timeZone: boolean;
-    };
-    eventos: {
-      recibeAlarmas: boolean;
-      recibeAperturasYCierres: boolean;
-      recibeEventosDeEnergia: boolean;
-      recibeEventosDePanico: boolean;
-      recibeOtrosEventos: boolean;
-      sharedPartitions: {
-        [key: string]: boolean;
-      };
-    };
-    userType: number;
-  };
-  subscriptionInfo: {
-    planType: number;
-    status: number;
-    freeUsers: any[];
-    freeCards: any[];
-    orders: any[];
-    planId: string;
-    validThru: string;
-  };
-  owner: {
-    configuraciones: {
-      users: boolean;
-      automations: boolean;
-      timeZone: boolean;
-    };
-    atributos: {
-      puedeArmar: boolean;
-      puedeDesarmar: boolean;
-      puedeInhibirZonas: boolean;
-      puedeInteractuarConSalidas: boolean;
-      puedeInteractuarConSirena: boolean;
-      puedeVerCamaras: boolean;
-      sharedPartitions: {
-        [key: string]: boolean;
-      };
-    };
-    eventos: {
-      recibeAlarmas: boolean;
-      recibeAperturasYCierres: boolean;
-      recibeEventosDeEnergia: boolean;
-      recibeEventosDePanico: boolean;
-      recibeOtrosEventos: boolean;
-      sharedPartitions: {
-        [key: string]: boolean;
-      };
-    };
-    email: string;
-    nombre: string;
-    apellido: string;
-    avatar: number;
-    verified: boolean;
-    location: boolean;
-    userType: number;
-    number: number;
-  };
-  users: {
-    configuraciones: {
-      users: boolean;
-      automations: boolean;
-      timeZone: boolean;
-    };
-    atributos: {
-      puedeArmar: boolean;
-      puedeDesarmar: boolean;
-      puedeInhibirZonas: boolean;
-      puedeInteractuarConSalidas: boolean;
-      puedeInteractuarConSirena: boolean;
-      puedeVerCamaras: boolean;
-      sharedPartitions: {
-        [key: string]: boolean;
-      };
-    };
-    eventos: {
-      recibeAlarmas: boolean;
-      recibeAperturasYCierres: boolean;
-      recibeEventosDeEnergia: boolean;
-      recibeEventosDePanico: boolean;
-      recibeOtrosEventos: boolean;
-      sharedPartitions: {
-        [key: string]: boolean;
-      };
-    };
-    email: string;
-    nombre: string;
-    apellido: string;
-    avatar: number;
-    verified: boolean;
-    location: boolean;
-    userType: number;
-    number: number;
-  }[];
-  timeZone: string;
-  programation: {
-    lastEvent: string;
-    data: {
-      extraProgrammation: {
-        modulesEnabled: string;
-        reportsOne: string;
-        reportsTwo: string;
-        reportsThree: string;
-        stageOne: string;
-        stageTwo: string;
-      };
-      alarmPanel: {
-        brand: number;
-        isNewVersion: boolean;
-        model: number;
-        modelName: string;
-        version: number;
-        versionName: string;
-        isYoMonitoreo: boolean;
-      };
-      zones: {
-        number: number;
-        name: string;
-        icon: string;
-        associatedCamera: number;
-        configuration: string;
-        attributes: string;
-        enabled: boolean;
-        isPresentZone: boolean;
-      }[];
-      outputs: {
-        number: number;
-        name: string;
-        icon: string;
-        configuration: string;
-        enabled: boolean;
-      }[];
-      automations: {
-        number: number;
-        hours: number;
-        minutes: number;
-        action: number;
-        option: number;
-        enabled: boolean;
-        days: boolean[];
-      }[];
-      partitions: {
-        name: string;
-        number: number;
-        enabled: boolean;
-      }[];
-    };
-    lastUpdate: string;
-  };
-  programmers: any[];
-  nombre: string;
-  icono: number;
-}
+export const ConfigAlarmaHSISchema = z.object({
+  id: z.string(),
+  lastEventReport: z.string(),
+  cameraLink: z.object({
+    appName: z.string(),
+    appPackage: z.string(),
+    appStoreUrl: z.string(),
+    appPlayStoreUri: z.string(),
+    appBundleId: z.string(),
+  }),
+  userPermissions: z.object({
+    atributos: z.object({
+      puedeArmar: z.boolean(),
+      puedeDesarmar: z.boolean(),
+      puedeInhibirZonas: z.boolean(),
+      puedeInteractuarConSalidas: z.boolean(),
+      puedeInteractuarConSirena: z.boolean(),
+      puedeVerCamaras: z.boolean(),
+      sharedPartitions: z.record(z.string(), z.boolean()),
+    }),
+    configuraciones: z.object({
+      users: z.boolean(),
+      automations: z.boolean(),
+      timeZone: z.boolean(),
+    }),
+    eventos: z.object({
+      recibeAlarmas: z.boolean(),
+      recibeAperturasYCierres: z.boolean(),
+      recibeEventosDeEnergia: z.boolean(),
+      recibeEventosDePanico: z.boolean(),
+      recibeOtrosEventos: z.boolean(),
+      sharedPartitions: z.record(z.string(), z.boolean()),
+    }),
+    userType: z.number(),
+  }),
+  subscriptionInfo: z.object({
+    planType: z.number(),
+    status: z.number(),
+    freeUsers: z.array(z.any()),
+    freeCards: z.array(z.any()),
+    orders: z.array(z.any()),
+    planId: z.string(),
+    validThru: z.string(),
+  }),
+  owner: z.object({
+    configuraciones: z.object({
+      users: z.boolean(),
+      automations: z.boolean(),
+      timeZone: z.boolean(),
+    }),
+    atributos: z.object({
+      puedeArmar: z.boolean(),
+      puedeDesarmar: z.boolean(),
+      puedeInhibirZonas: z.boolean(),
+      puedeInteractuarConSalidas: z.boolean(),
+      puedeInteractuarConSirena: z.boolean(),
+      puedeVerCamaras: z.boolean(),
+      sharedPartitions: z.record(z.string(), z.boolean()),
+    }),
+    eventos: z.object({
+      recibeAlarmas: z.boolean(),
+      recibeAperturasYCierres: z.boolean(),
+      recibeEventosDeEnergia: z.boolean(),
+      recibeEventosDePanico: z.boolean(),
+      recibeOtrosEventos: z.boolean(),
+      sharedPartitions: z.record(z.string(), z.boolean()),
+    }),
+    email: z.string(),
+    nombre: z.string(),
+    apellido: z.string(),
+    avatar: z.number(),
+    verified: z.boolean(),
+    location: z.boolean(),
+    userType: z.number(),
+    number: z.number(),
+  }),
+  users: z.array(
+    z.object({
+      configuraciones: z.object({
+        users: z.boolean(),
+        automations: z.boolean(),
+        timeZone: z.boolean(),
+      }),
+      atributos: z.object({
+        puedeArmar: z.boolean(),
+        puedeDesarmar: z.boolean(),
+        puedeInhibirZonas: z.boolean(),
+        puedeInteractuarConSalidas: z.boolean(),
+        puedeInteractuarConSirena: z.boolean(),
+        puedeVerCamaras: z.boolean(),
+        sharedPartitions: z.record(z.string(), z.boolean()),
+      }),
+      eventos: z.object({
+        recibeAlarmas: z.boolean(),
+        recibeAperturasYCierres: z.boolean(),
+        recibeEventosDeEnergia: z.boolean(),
+        recibeEventosDePanico: z.boolean(),
+        recibeOtrosEventos: z.boolean(),
+        sharedPartitions: z.record(z.string(), z.boolean()),
+      }),
+      email: z.string(),
+      nombre: z.string(),
+      apellido: z.string(),
+      avatar: z.number(),
+      verified: z.boolean(),
+      location: z.boolean(),
+      userType: z.number(),
+      number: z.number(),
+    }),
+  ),
+  timeZone: z.string(),
+  programation: z.object({
+    lastEvent: z.string(),
+    data: z.object({
+      extraProgrammation: z.object({
+        modulesEnabled: z.string(),
+        reportsOne: z.string(),
+        reportsTwo: z.string(),
+        reportsThree: z.string(),
+        stageOne: z.string(),
+        stageTwo: z.string(),
+      }),
+      alarmPanel: z.object({
+        brand: z.number(),
+        isNewVersion: z.boolean(),
+        model: z.number(),
+        modelName: z.string(),
+        version: z.number(),
+        versionName: z.string(),
+        isYoMonitoreo: z.boolean(),
+      }),
+      zones: z.array(
+        z.object({
+          number: z.number(),
+          name: z.string(),
+          icon: z.string(),
+          associatedCamera: z.number(),
+          configuration: z.string(),
+          attributes: z.string(),
+          enabled: z.boolean(),
+          isPresentZone: z.boolean(),
+        }),
+      ),
+      outputs: z.array(
+        z.object({
+          number: z.number(),
+          name: z.string(),
+          icon: z.string(),
+          configuration: z.string(),
+          enabled: z.boolean(),
+        }),
+      ),
+      automations: z.array(
+        z.object({
+          number: z.number(),
+          hours: z.number(),
+          minutes: z.number(),
+          action: z.number(),
+          option: z.number(),
+          enabled: z.boolean(),
+          days: z.array(z.boolean()),
+        }),
+      ),
+      partitions: z.array(
+        z.object({
+          name: z.string(),
+          number: z.number(),
+          enabled: z.boolean(),
+        }),
+      ),
+    }),
+    lastUpdate: z.string(),
+  }),
+  programmers: z.array(z.any()),
+  nombre: z.string(),
+  icono: z.number(),
+});
+export type IConfigAlarmaHSI = z.infer<typeof ConfigAlarmaHSISchema>;
 
-export interface IStatusAlarmaGarnet {
-  particion?: number;
-  problemas1?: {
-    falloSalidaSirena?: boolean;
-    falloLineaTelefonica?: boolean;
-    falloAlimentacionAuxiliarPanel?: boolean;
-    falloAlimentacionAuxiliarDatos?: boolean;
-    falloEnSupSirena?: boolean;
-    fuenteAuxiliarBateriaBaja?: boolean;
-    bateriaBaja?: boolean;
-    falloDeRed?: boolean;
-  };
-  problemas2?: {
-    relojNoProgramado?: boolean;
-    falloLinkInternet?: boolean;
-    falloLinkGPRS?: boolean;
-    falloComInternet?: boolean;
-    falloComSMS?: boolean;
-    falloComGPRS?: boolean;
-    falloComTelefono2?: boolean;
-    falloComTelefono1?: boolean;
-  };
-  estadosParticiones?: {
-    part4Armada?: boolean;
-    part3Armada?: boolean;
-    part2Armada?: boolean;
-    part1Armada?: boolean;
-    part4ListaParaArmar?: boolean;
-    part3ListaParaArmar?: boolean;
-    part2ListaParaArmar?: boolean;
-    part1ListaParaArmar?: boolean;
-  };
-  estadosSalidas?: {
-    pgm4Activada?: boolean;
-    pgm3Activada?: boolean;
-    pgm2Activada?: boolean;
-    pgm1Activada?: boolean;
-    sirenaActivada?: boolean;
-  };
-  estadosAlarmas?: {
-    alarma1Activada?: boolean;
-    alarma2Activada?: boolean;
-    alarma3Activada?: boolean;
-    alarma4Activada?: boolean;
-  };
-  zonasAbiertas?: {
-    zona1Abierta?: boolean;
-    zona2Abierta?: boolean;
-    zona3Abierta?: boolean;
-    zona4Abierta?: boolean;
-    zona5Abierta?: boolean;
-    zona6Abierta?: boolean;
-    zona7Abierta?: boolean;
-    zona8Abierta?: boolean;
-    zona9Abierta?: boolean;
-    zona10Abierta?: boolean;
-    zona11Abierta?: boolean;
-    zona12Abierta?: boolean;
-    zona13Abierta?: boolean;
-    zona14Abierta?: boolean;
-    zona15Abierta?: boolean;
-    zona16Abierta?: boolean;
-    zona17Abierta?: boolean;
-    zona18Abierta?: boolean;
-    zona19Abierta?: boolean;
-    zona20Abierta?: boolean;
-    zona21Abierta?: boolean;
-    zona22Abierta?: boolean;
-    zona23Abierta?: boolean;
-    zona24Abierta?: boolean;
-    zona25Abierta?: boolean;
-    zona26Abierta?: boolean;
-    zona27Abierta?: boolean;
-    zona28Abierta?: boolean;
-    zona29Abierta?: boolean;
-    zona30Abierta?: boolean;
-    zona31Abierta?: boolean;
-    zona32Abierta?: boolean;
-  };
-  zonasAlarma?: {
-    zona1Alarma?: boolean;
-    zona2Alarma?: boolean;
-    zona3Alarma?: boolean;
-    zona4Alarma?: boolean;
-    zona5Alarma?: boolean;
-    zona6Alarma?: boolean;
-    zona7Alarma?: boolean;
-    zona8Alarma?: boolean;
-    zona9Alarma?: boolean;
-    zona10Alarma?: boolean;
-    zona11Alarma?: boolean;
-    zona12Alarma?: boolean;
-    zona13Alarma?: boolean;
-    zona14Alarma?: boolean;
-    zona15Alarma?: boolean;
-    zona16Alarma?: boolean;
-    zona17Alarma?: boolean;
-    zona18Alarma?: boolean;
-    zona19Alarma?: boolean;
-    zona20Alarma?: boolean;
-    zona21Alarma?: boolean;
-    zona22Alarma?: boolean;
-    zona23Alarma?: boolean;
-    zona24Alarma?: boolean;
-    zona25Alarma?: boolean;
-    zona26Alarma?: boolean;
-    zona27Alarma?: boolean;
-    zona28Alarma?: boolean;
-    zona29Alarma?: boolean;
-    zona30Alarma?: boolean;
-    zona31Alarma?: boolean;
-    zona32Alarma?: boolean;
-  };
-  zonasInhibidas?: {
-    zona1?: boolean;
-    zona2?: boolean;
-    zona3?: boolean;
-    zona4?: boolean;
-    zona5?: boolean;
-    zona6?: boolean;
-    zona7?: boolean;
-    zona8?: boolean;
-    zona9?: boolean;
-    zona10?: boolean;
-    zona11?: boolean;
-    zona12?: boolean;
-    zona13?: boolean;
-    zona14?: boolean;
-    zona15?: boolean;
-    zona16?: boolean;
-    zona17?: boolean;
-    zona18?: boolean;
-    zona19?: boolean;
-    zona20?: boolean;
-    zona21?: boolean;
-    zona22?: boolean;
-    zona23?: boolean;
-    zona24?: boolean;
-    zona25?: boolean;
-    zona26?: boolean;
-    zona27?: boolean;
-    zona28?: boolean;
-    zona29?: boolean;
-    zona30?: boolean;
-    zona31?: boolean;
-    zona32?: boolean;
-  };
-  estadosSalidasInalambricas?: {
-    PGMW1?: boolean;
-    PGMW2?: boolean;
-    PGMW3?: boolean;
-    PGMW4?: boolean;
-  };
-  estadoPanel2?: {
-    armadoPresenteDemoradoPart1?: boolean;
-    armadoPresenteDemoradoPart2?: boolean;
-    armadoPresenteDemoradoPart3?: boolean;
-    armadoPresenteDemoradoPart4?: boolean;
-    armadoPresenteInstantaneoPart1?: boolean;
-    armadoPresenteInstantaneoPart2?: boolean;
-    armadoPresenteInstantaneoPart3?: boolean;
-    armadoPresenteInstantaneoPart4?: boolean;
-  };
-  registroDeDemoras?: {
-    demoraPart1?: boolean;
-    demoraPart2?: boolean;
-    demoraPart3?: boolean;
-    demoraPart4?: boolean;
-  };
-}
+export const StatusAlarmaGarnetSchema = z.object({
+  particion: z.number().optional(),
+  problemas1: z
+    .object({
+      falloSalidaSirena: z.boolean().optional(),
+      falloLineaTelefonica: z.boolean().optional(),
+      falloAlimentacionAuxiliarPanel: z.boolean().optional(),
+      falloAlimentacionAuxiliarDatos: z.boolean().optional(),
+      falloEnSupSirena: z.boolean().optional(),
+      fuenteAuxiliarBateriaBaja: z.boolean().optional(),
+      bateriaBaja: z.boolean().optional(),
+      falloDeRed: z.boolean().optional(),
+    })
+    .optional(),
+  problemas2: z
+    .object({
+      relojNoProgramado: z.boolean().optional(),
+      falloLinkInternet: z.boolean().optional(),
+      falloLinkGPRS: z.boolean().optional(),
+      falloComInternet: z.boolean().optional(),
+      falloComSMS: z.boolean().optional(),
+      falloComGPRS: z.boolean().optional(),
+      falloComTelefono2: z.boolean().optional(),
+      falloComTelefono1: z.boolean().optional(),
+    })
+    .optional(),
+  estadosParticiones: z
+    .object({
+      part4Armada: z.boolean().optional(),
+      part3Armada: z.boolean().optional(),
+      part2Armada: z.boolean().optional(),
+      part1Armada: z.boolean().optional(),
+      part4ListaParaArmar: z.boolean().optional(),
+      part3ListaParaArmar: z.boolean().optional(),
+      part2ListaParaArmar: z.boolean().optional(),
+      part1ListaParaArmar: z.boolean().optional(),
+    })
+    .optional(),
+  estadosSalidas: z
+    .object({
+      pgm4Activada: z.boolean().optional(),
+      pgm3Activada: z.boolean().optional(),
+      pgm2Activada: z.boolean().optional(),
+      pgm1Activada: z.boolean().optional(),
+      sirenaActivada: z.boolean().optional(),
+    })
+    .optional(),
+  estadosAlarmas: z
+    .object({
+      alarma1Activada: z.boolean().optional(),
+      alarma2Activada: z.boolean().optional(),
+      alarma3Activada: z.boolean().optional(),
+      alarma4Activada: z.boolean().optional(),
+    })
+    .optional(),
+  zonasAbiertas: z
+    .object({
+      zona1Abierta: z.boolean().optional(),
+      zona2Abierta: z.boolean().optional(),
+      zona3Abierta: z.boolean().optional(),
+      zona4Abierta: z.boolean().optional(),
+      zona5Abierta: z.boolean().optional(),
+      zona6Abierta: z.boolean().optional(),
+      zona7Abierta: z.boolean().optional(),
+      zona8Abierta: z.boolean().optional(),
+      zona9Abierta: z.boolean().optional(),
+      zona10Abierta: z.boolean().optional(),
+      zona11Abierta: z.boolean().optional(),
+      zona12Abierta: z.boolean().optional(),
+      zona13Abierta: z.boolean().optional(),
+      zona14Abierta: z.boolean().optional(),
+      zona15Abierta: z.boolean().optional(),
+      zona16Abierta: z.boolean().optional(),
+      zona17Abierta: z.boolean().optional(),
+      zona18Abierta: z.boolean().optional(),
+      zona19Abierta: z.boolean().optional(),
+      zona20Abierta: z.boolean().optional(),
+      zona21Abierta: z.boolean().optional(),
+      zona22Abierta: z.boolean().optional(),
+      zona23Abierta: z.boolean().optional(),
+      zona24Abierta: z.boolean().optional(),
+      zona25Abierta: z.boolean().optional(),
+      zona26Abierta: z.boolean().optional(),
+      zona27Abierta: z.boolean().optional(),
+      zona28Abierta: z.boolean().optional(),
+      zona29Abierta: z.boolean().optional(),
+      zona30Abierta: z.boolean().optional(),
+      zona31Abierta: z.boolean().optional(),
+      zona32Abierta: z.boolean().optional(),
+    })
+    .optional(),
+  zonasAlarma: z
+    .object({
+      zona1Alarma: z.boolean().optional(),
+      zona2Alarma: z.boolean().optional(),
+      zona3Alarma: z.boolean().optional(),
+      zona4Alarma: z.boolean().optional(),
+      zona5Alarma: z.boolean().optional(),
+      zona6Alarma: z.boolean().optional(),
+      zona7Alarma: z.boolean().optional(),
+      zona8Alarma: z.boolean().optional(),
+      zona9Alarma: z.boolean().optional(),
+      zona10Alarma: z.boolean().optional(),
+      zona11Alarma: z.boolean().optional(),
+      zona12Alarma: z.boolean().optional(),
+      zona13Alarma: z.boolean().optional(),
+      zona14Alarma: z.boolean().optional(),
+      zona15Alarma: z.boolean().optional(),
+      zona16Alarma: z.boolean().optional(),
+      zona17Alarma: z.boolean().optional(),
+      zona18Alarma: z.boolean().optional(),
+      zona19Alarma: z.boolean().optional(),
+      zona20Alarma: z.boolean().optional(),
+      zona21Alarma: z.boolean().optional(),
+      zona22Alarma: z.boolean().optional(),
+      zona23Alarma: z.boolean().optional(),
+      zona24Alarma: z.boolean().optional(),
+      zona25Alarma: z.boolean().optional(),
+      zona26Alarma: z.boolean().optional(),
+      zona27Alarma: z.boolean().optional(),
+      zona28Alarma: z.boolean().optional(),
+      zona29Alarma: z.boolean().optional(),
+      zona30Alarma: z.boolean().optional(),
+      zona31Alarma: z.boolean().optional(),
+      zona32Alarma: z.boolean().optional(),
+    })
+    .optional(),
+  zonasInhibidas: z
+    .object({
+      zona1: z.boolean().optional(),
+      zona2: z.boolean().optional(),
+      zona3: z.boolean().optional(),
+      zona4: z.boolean().optional(),
+      zona5: z.boolean().optional(),
+      zona6: z.boolean().optional(),
+      zona7: z.boolean().optional(),
+      zona8: z.boolean().optional(),
+      zona9: z.boolean().optional(),
+      zona10: z.boolean().optional(),
+      zona11: z.boolean().optional(),
+      zona12: z.boolean().optional(),
+      zona13: z.boolean().optional(),
+      zona14: z.boolean().optional(),
+      zona15: z.boolean().optional(),
+      zona16: z.boolean().optional(),
+      zona17: z.boolean().optional(),
+      zona18: z.boolean().optional(),
+      zona19: z.boolean().optional(),
+      zona20: z.boolean().optional(),
+      zona21: z.boolean().optional(),
+      zona22: z.boolean().optional(),
+      zona23: z.boolean().optional(),
+      zona24: z.boolean().optional(),
+      zona25: z.boolean().optional(),
+      zona26: z.boolean().optional(),
+      zona27: z.boolean().optional(),
+      zona28: z.boolean().optional(),
+      zona29: z.boolean().optional(),
+      zona30: z.boolean().optional(),
+      zona31: z.boolean().optional(),
+      zona32: z.boolean().optional(),
+    })
+    .optional(),
+  estadosSalidasInalambricas: z
+    .object({
+      PGMW1: z.boolean().optional(),
+      PGMW2: z.boolean().optional(),
+      PGMW3: z.boolean().optional(),
+      PGMW4: z.boolean().optional(),
+    })
+    .optional(),
+  estadoPanel2: z
+    .object({
+      armadoPresenteDemoradoPart1: z.boolean().optional(),
+      armadoPresenteDemoradoPart2: z.boolean().optional(),
+      armadoPresenteDemoradoPart3: z.boolean().optional(),
+      armadoPresenteDemoradoPart4: z.boolean().optional(),
+      armadoPresenteInstantaneoPart1: z.boolean().optional(),
+      armadoPresenteInstantaneoPart2: z.boolean().optional(),
+      armadoPresenteInstantaneoPart3: z.boolean().optional(),
+      armadoPresenteInstantaneoPart4: z.boolean().optional(),
+    })
+    .optional(),
+  registroDeDemoras: z
+    .object({
+      demoraPart1: z.boolean().optional(),
+      demoraPart2: z.boolean().optional(),
+      demoraPart3: z.boolean().optional(),
+      demoraPart4: z.boolean().optional(),
+    })
+    .optional(),
+});
+export type IStatusAlarmaGarnet = z.infer<typeof StatusAlarmaGarnetSchema>;
 
-export interface ArmOptions {
-  profile: string;
-  triggerId: string;
-  triggerName: string;
-}
+export const ArmOptionsSchema = z.object({
+  profile: z.string(),
+  triggerId: z.string(),
+  triggerName: z.string(),
+});
+export type ArmOptions = z.infer<typeof ArmOptionsSchema>;
 
-export interface IArmModeRequest {
-  deviceId: string;
-  devCode: string;
-  armMode: TiposDeArmado;
-  areaIds: number[];
-  armOptions: ArmOptions;
-}
+export const ArmModeRequestSchema = z.object({
+  deviceId: z.string(),
+  devCode: z.string(),
+  armMode: TiposDeArmadoSchema,
+  areaIds: z.array(z.number()),
+  armOptions: ArmOptionsSchema,
+});
+export type IArmModeRequest = z.infer<typeof ArmModeRequestSchema>;
 
-export interface respuestaDoLynk {
-  code?: string;
-  data?: dolynkAuthRes | dolynkAlarmUser[] | ResponseInformationData;
-  msg?: string;
-  success?: boolean;
-}
+export const DolynkAuthResSchema = z.object({
+  appAccessToken: z.string().optional(),
+});
+export type dolynkAuthRes = z.infer<typeof DolynkAuthResSchema>;
 
-export interface dolynkAuthRes {
-  appAccessToken?: string;
-}
+export const DolynkAlarmUserSchema = z.object({
+  userId: z.string(), // ejemplo: "42950568110"
+  userType: z.string(), // ejemplo: "Keypad"
+  group: z.string(), // ejemplo: "Admin"
+  name: z.string(), // ejemplo: "admin"
+  userCode: z.string(), // puede estar vacío
+  duressCode: z.string(), // puede estar vacío
+  authorities: z.array(z.string()), // lista de permisos/autoridades
+  cards: z.array(z.string()), // UID(s) de tarjetas
+  reserved: z.boolean(),
+  status: z.string(),
+  accessAllowTime: z.string().nullable(), // fecha/hora en ISO o null si no aplica
+  areaIds: z.array(z.number()), // ids de áreas permitidas
+  memo: z.string().nullable(), // nota opcional
+  oneClickArming: z.boolean().nullable(), // modo de armado rápido (o null si no definido)
+});
+export type dolynkAlarmUser = z.infer<typeof DolynkAlarmUserSchema>;
 
-export interface dolynkAlarmUser {
-  userId: string; // ejemplo: "42950568110"
-  userType: string; // ejemplo: "Keypad"
-  group: string; // ejemplo: "Admin"
-  name: string; // ejemplo: "admin"
-  userCode: string; // puede estar vacío
-  duressCode: string; // puede estar vacío
-  authorities: string[]; // lista de permisos/autoridades
-  cards: string[]; // UID(s) de tarjetas
-  reserved: boolean;
-  status: string;
-  accessAllowTime: string | null; // fecha/hora en ISO o null si no aplica
-  areaIds: number[]; // ids de áreas permitidas
-  memo: string | null; // nota opcional
-  oneClickArming: boolean | null; // modo de armado rápido (o null si no definido)
-}
+export const AccessoryInfoSchema = z.object({
+  name: z.string().optional(),
+  id: z.string().optional(),
+  deviceId: z.string().optional(),
+});
+export type AccessoryInfo = z.infer<typeof AccessoryInfoSchema>;
 
-export interface AccessoryInfo {
-  name?: string;
-  id?: string;
-  deviceId?: string;
-}
+export const AreaInfoSchema = z.object({
+  enable: z.boolean().optional(),
+  name: z.string().optional(),
+  accessoryInfos: z.array(AccessoryInfoSchema).optional(),
+});
+export type AreaInfo = z.infer<typeof AreaInfoSchema>;
 
-export interface AreaInfo {
-  enable?: boolean;
-  name?: string;
-  accessoryInfos?: AccessoryInfo[];
-}
+export const ResponseInformationDataSchema = z.object({
+  areaInfos: z.array(AreaInfoSchema).optional(),
+});
+export type ResponseInformationData = z.infer<
+  typeof ResponseInformationDataSchema
+>;
 
-export interface armModes {
-  areaId: number;
-  mode: TiposDeArmado;
-}
+export const RespuestaDoLynkSchema = z.object({
+  code: z.string().optional(),
+  data: z
+    .union([
+      DolynkAuthResSchema,
+      z.array(DolynkAlarmUserSchema),
+      ResponseInformationDataSchema,
+    ])
+    .optional(),
+  msg: z.string().optional(),
+  success: z.boolean().optional(),
+});
+export type respuestaDoLynk = z.infer<typeof RespuestaDoLynkSchema>;
 
-export interface accessoryInfo {
-  deviceId?: string;
-  id?: string;
-  name?: string;
-  type?: string;
-  model?: string;
-  areaId?: number;
-  bypassMode?: 'Active' | 'DisableTamper' | 'Bypassed';
-  mode?: TiposDeArmado;
-}
+export const ArmModesSchema = z.object({
+  areaId: z.number(),
+  mode: TiposDeArmadoSchema,
+});
+export type armModes = z.infer<typeof ArmModesSchema>;
 
-export interface ResponseInformationData {
-  areaInfos?: AreaInfo[];
-}
+// Nota: el original tenía `AccessoryInfo` y `accessoryInfo` (solo difieren en
+// mayúscula inicial). El schema de `accessoryInfo` se llama
+// AccessoryInfoItemSchema para no colisionar con AccessoryInfoSchema.
+export const AccessoryInfoItemSchema = z.object({
+  deviceId: z.string().optional(),
+  id: z.string().optional(),
+  name: z.string().optional(),
+  type: z.string().optional(),
+  model: z.string().optional(),
+  areaId: z.number().optional(),
+  bypassMode: z.enum(['Active', 'DisableTamper', 'Bypassed']).optional(),
+  mode: TiposDeArmadoSchema.optional(),
+});
+export type accessoryInfo = z.infer<typeof AccessoryInfoItemSchema>;
 
-export interface ResponseStateData {
-  armModes?: armModes[];
-}
+export const ResponseStateDataSchema = z.object({
+  armModes: z.array(ArmModesSchema).optional(),
+});
+export type ResponseStateData = z.infer<typeof ResponseStateDataSchema>;
 
-export interface ResponseAccessoryInfos {
-  accessoryInfos?: accessoryInfo[];
-}
+export const ResponseAccessoryInfosSchema = z.object({
+  accessoryInfos: z.array(AccessoryInfoItemSchema).optional(),
+});
+export type ResponseAccessoryInfos = z.infer<
+  typeof ResponseAccessoryInfosSchema
+>;
 
 /// hikvision ( esta hecho para que coincida con la api de mierda que tienen )
 
-export type EstadoArmadoHikvision = 'disarm' | 'away' | 'stay';
+export const EstadoArmadoHikvisionSchema = z.enum(['disarm', 'away', 'stay']);
+export type EstadoArmadoHikvision = z.infer<typeof EstadoArmadoHikvisionSchema>;
 
-export interface ISubSysHikvision {
-  id?: number;
-  arming?: EstadoArmadoHikvision;
-  alarm?: boolean;
-  enabled?: boolean;
-  name?: string;
-  delayTime?: number;
-}
+export const SubSysHikvisionSchema = z.object({
+  id: z.number().optional(),
+  arming: EstadoArmadoHikvisionSchema.optional(),
+  alarm: z.boolean().optional(),
+  enabled: z.boolean().optional(),
+  name: z.string().optional(),
+  delayTime: z.number().optional(),
+});
+export type ISubSysHikvision = z.infer<typeof SubSysHikvisionSchema>;
 
-export interface ISubSysItemHikvision {
-  SubSys?: ISubSysHikvision;
-}
+export const SubSysItemHikvisionSchema = z.object({
+  SubSys: SubSysHikvisionSchema.optional(),
+});
+export type ISubSysItemHikvision = z.infer<typeof SubSysItemHikvisionSchema>;
 
-export interface IStatusAlarmaHikvision {
-  SubSysList?: ISubSysItemHikvision[];
-}
+export const StatusAlarmaHikvisionSchema = z.object({
+  SubSysList: z.array(SubSysItemHikvisionSchema).optional(),
+});
+export type IStatusAlarmaHikvision = z.infer<
+  typeof StatusAlarmaHikvisionSchema
+>;
 
-export type EstadoZonaHikvision = 'online' | 'offline';
-export type EstadoSensorHikvision = 'normal';
-export type CargaZonaHikvision = 'normal';
-export type TipoDetectorHikvision = 'passiveInfraredDetector';
-export type TipoZonaHikvision = 'Instant';
-export type AtributoZonaHikvision = 'wireless';
+export const EstadoZonaHikvisionSchema = z.enum(['online', 'offline']);
+export type EstadoZonaHikvision = z.infer<typeof EstadoZonaHikvisionSchema>;
 
-export interface IZoneHikvision {
-  id?: number;
-  name?: string;
-  status?: EstadoZonaHikvision;
-  sensorStatus?: EstadoSensorHikvision;
-  tamperEvident?: boolean;
-  shielded?: boolean;
-  bypassed?: boolean;
-  armed?: boolean;
-  isArming?: boolean;
-  alarm?: boolean;
-  charge?: CargaZonaHikvision;
-  chargeValue?: number;
-  signal?: number;
-  realSignal?: number;
-  signalType?: string;
-  temperature?: number;
-  subSystemNo?: number;
-  linkageSubSystem?: number[];
-  detectorType?: TipoDetectorHikvision;
-  model?: string;
-  stayAway?: boolean;
-  zoneType?: TipoZonaHikvision;
-  isViaRepeater?: boolean;
-  zoneAttrib?: AtributoZonaHikvision;
-  version?: string;
-  deviceNo?: number;
-  abnormalOrNot?: boolean;
-}
+export const EstadoSensorHikvisionSchema = z.literal('normal');
+export type EstadoSensorHikvision = z.infer<typeof EstadoSensorHikvisionSchema>;
 
-export interface IZoneItemHikvision {
-  Zone?: IZoneHikvision;
-}
+export const CargaZonaHikvisionSchema = z.literal('normal');
+export type CargaZonaHikvision = z.infer<typeof CargaZonaHikvisionSchema>;
 
-export interface IZoneListHikvision {
-  ZoneList?: IZoneItemHikvision[];
-}
+export const TipoDetectorHikvisionSchema = z.literal(
+  'passiveInfraredDetector',
+);
+export type TipoDetectorHikvision = z.infer<typeof TipoDetectorHikvisionSchema>;
 
-export interface IResponseHikvision {
-  statusCode?: number;
-  statusString?: string;
-  subStatusCode?: string;
-  errorCode?: number;
-  errorMsg?: string;
-}
+export const TipoZonaHikvisionSchema = z.literal('Instant');
+export type TipoZonaHikvision = z.infer<typeof TipoZonaHikvisionSchema>;
+
+export const AtributoZonaHikvisionSchema = z.literal('wireless');
+export type AtributoZonaHikvision = z.infer<typeof AtributoZonaHikvisionSchema>;
+
+export const ZoneHikvisionSchema = z.object({
+  id: z.number().optional(),
+  name: z.string().optional(),
+  status: EstadoZonaHikvisionSchema.optional(),
+  sensorStatus: EstadoSensorHikvisionSchema.optional(),
+  tamperEvident: z.boolean().optional(),
+  shielded: z.boolean().optional(),
+  bypassed: z.boolean().optional(),
+  armed: z.boolean().optional(),
+  isArming: z.boolean().optional(),
+  alarm: z.boolean().optional(),
+  charge: CargaZonaHikvisionSchema.optional(),
+  chargeValue: z.number().optional(),
+  signal: z.number().optional(),
+  realSignal: z.number().optional(),
+  signalType: z.string().optional(),
+  temperature: z.number().optional(),
+  subSystemNo: z.number().optional(),
+  linkageSubSystem: z.array(z.number()).optional(),
+  detectorType: TipoDetectorHikvisionSchema.optional(),
+  model: z.string().optional(),
+  stayAway: z.boolean().optional(),
+  zoneType: TipoZonaHikvisionSchema.optional(),
+  isViaRepeater: z.boolean().optional(),
+  zoneAttrib: AtributoZonaHikvisionSchema.optional(),
+  version: z.string().optional(),
+  deviceNo: z.number().optional(),
+  abnormalOrNot: z.boolean().optional(),
+});
+export type IZoneHikvision = z.infer<typeof ZoneHikvisionSchema>;
+
+export const ZoneItemHikvisionSchema = z.object({
+  Zone: ZoneHikvisionSchema.optional(),
+});
+export type IZoneItemHikvision = z.infer<typeof ZoneItemHikvisionSchema>;
+
+export const ZoneListHikvisionSchema = z.object({
+  ZoneList: z.array(ZoneItemHikvisionSchema).optional(),
+});
+export type IZoneListHikvision = z.infer<typeof ZoneListHikvisionSchema>;
+
+export const ResponseHikvisionSchema = z.object({
+  statusCode: z.number().optional(),
+  statusString: z.string().optional(),
+  subStatusCode: z.string().optional(),
+  errorCode: z.number().optional(),
+  errorMsg: z.string().optional(),
+});
+export type IResponseHikvision = z.infer<typeof ResponseHikvisionSchema>;

--- a/src/interfaces/dispositivo-lorawan.ts
+++ b/src/interfaces/dispositivo-lorawan.ts
@@ -1,45 +1,60 @@
-import { IGeoJSONPoint } from '../auxiliares';
-import { ICliente } from './cliente';
-import { IComando } from './comando';
-import { IModeloDispositivo } from './modelo-dispositivo';
-import { IModoLuminaria, IReporteGenerico } from './reporte-generico';
+import { z } from 'zod';
+import { GeoJSONPointSchema, IGeoJSONPoint } from '../auxiliares';
+import { ClienteSchema, ICliente } from './cliente';
+import type { IComando } from './comando';
+import {
+  IModeloDispositivo,
+  ModeloDispositivoSchema,
+} from './modelo-dispositivo';
+import type { IModoLuminaria, IReporteGenerico } from './reporte-generico';
 
 /* ────────────────────────────────────────────────
  *  TIPOS, PAYLOADS E INTERFACES
  * ────────────────────────────────────────────────*/
 
-export type TipoDispositivoLorawan =
-  | 'Luminaria GPE'
-  | 'Luminaria Wellness'
-  | 'Luminaria ACTIS FING';
+export const TipoDispositivoLorawanSchema = z.enum([
+  'Luminaria GPE',
+  'Luminaria Wellness',
+  'Luminaria ACTIS FING',
+]);
+export type TipoDispositivoLorawan = z.infer<
+  typeof TipoDispositivoLorawanSchema
+>;
 
 //Las luminarias ACTIS pueden tener más de un modo de funcionamiento en simultáneo (ej: astronómico + fotocélula para el encendido).
-export interface IModosACTIS {
-  fotocelula?: boolean;
-  astronomico?: boolean;
-}
+export const ModosACTISSchema = z.object({
+  fotocelula: z.boolean().optional(),
+  astronomico: z.boolean().optional(),
+});
+export type IModosACTIS = z.infer<typeof ModosACTISSchema>;
+
 //Notas: En el caso de estos dispositivos:
 // Potencia de dispositivo GPE = consumo instantáneo (W)
 // Energía de dispositivo GPE = Reactive Power de dispositivo Wellness = Consumo acumulado (kWh)
 //Esta es la estructura de la config de un dispositivoGPE. A partir de sus valores se va a generar un payload para cambiar la configuración del dispositivo
 
-export interface IConfigGeneralGPE {
+// Populates/referencias intra-SCC como z.custom (import type-only): un schema
+// real acá arrastra el shape completo del ciclo y revienta la serialización de
+// declarations (TS7056) acá y en los consumidores NestJS.
+export const ConfigGeneralGPESchema = z.object({
   //Llegan con cada reporte de estado
-  mode?: IModoLuminaria;
-  estadoRele?: boolean;
-  dimmerHabilitado?: boolean;
-  energiaExterna?: boolean;
-  adrHabilitado?: boolean;
+  mode: z.custom<IModoLuminaria>().optional(),
+  estadoRele: z.boolean().optional(),
+  dimmerHabilitado: z.boolean().optional(),
+  energiaExterna: z.boolean().optional(),
+  adrHabilitado: z.boolean().optional(),
 
   //Datos de configuración (llegan al inicio del firmware o por pedido de downlink)
-  limLuzInferior?: number;
-  limLuzSuperior?: number;
-  offsetGPSAmanecer?: number;
-  offsetGPSAtardecer?: number;
-  timeZone?: number;
-  frecReporte?: number;
-  dataRate?: number;
-}
+  limLuzInferior: z.number().optional(),
+  limLuzSuperior: z.number().optional(),
+  offsetGPSAmanecer: z.number().optional(),
+  offsetGPSAtardecer: z.number().optional(),
+  timeZone: z.number().optional(),
+  frecReporte: z.number().optional(),
+  dataRate: z.number().optional(),
+});
+export type IConfigGeneralGPE = z.infer<typeof ConfigGeneralGPESchema>;
+
 // ===== MODO ACTIS (Puerto 10) =====
 //Uplinks asociados:
 // puerto 10 (si se consulta con downlink al puerto 15, devuelve el modo actual configurado)
@@ -48,17 +63,22 @@ export interface IConfigGeneralGPE {
 //puerto 11 (encendido manual, con opción de salir por fotocélula o reloj astronómico)
 //puerto 15 (se puede consultar la configuración de modo)
 //puerto 42 (consulta el estado de la luminaria)
-export interface PayloadSetModeActis {
-  modoFotocelula?: {
-    encendidoHabilitado?: boolean; // bit0
-    apagadoHabilitado?: boolean; // bit1
-  };
-  modoRelojAstronomico?: {
-    encendidoHabilitado?: boolean; // bit2
-    apagadoHabilitado?: boolean; // bit3
-  };
-  iniciarEncendida?: boolean; // bit4 - Estado inicial al salir de modo manual
-}
+export const PayloadSetModeActisSchema = z.object({
+  modoFotocelula: z
+    .object({
+      encendidoHabilitado: z.boolean().optional(), // bit0
+      apagadoHabilitado: z.boolean().optional(), // bit1
+    })
+    .optional(),
+  modoRelojAstronomico: z
+    .object({
+      encendidoHabilitado: z.boolean().optional(), // bit2
+      apagadoHabilitado: z.boolean().optional(), // bit3
+    })
+    .optional(),
+  iniciarEncendida: z.boolean().optional(), // bit4 - Estado inicial al salir de modo manual
+});
+export type PayloadSetModeActis = z.infer<typeof PayloadSetModeActisSchema>;
 
 // ===== PAYLOAD MODO MANUAL ACTIS (Puerto 11) =====
 //Uplinks asociados:
@@ -66,14 +86,17 @@ export interface PayloadSetModeActis {
 //puerto 131 (llega de manera periódica o se puede consultar por puerto 42, indica si la luminaria está encendida o apagada y en qué modo se apagó/encendió una luminaria)
 // Downlinks asociados:
 //puerto 10 (cambia el modo de la luminaria)
-export interface PayloadSetManualActis {
-  estadoManual?: {
-    nivelDimming?: number; // 0-31 (31 = 100%)
-    encendido?: boolean;
-    salirPorFotocelula?: boolean;
-    salirPorRelojAstronomico?: boolean;
-  };
-}
+export const PayloadSetManualActisSchema = z.object({
+  estadoManual: z
+    .object({
+      nivelDimming: z.number().optional(), // 0-31 (31 = 100%)
+      encendido: z.boolean().optional(),
+      salirPorFotocelula: z.boolean().optional(),
+      salirPorRelojAstronomico: z.boolean().optional(),
+    })
+    .optional(),
+});
+export type PayloadSetManualActis = z.infer<typeof PayloadSetManualActisSchema>;
 
 // ===== PAYLOAD GET STATE ACTIS (Puerto 42) =====
 //Uplinks asociados:
@@ -82,12 +105,13 @@ export interface PayloadSetManualActis {
 //puerto 120 (sensado de la fotocélula)
 //puerto 121 (reporte fecha/hora)
 //Cada bit del byte enviado solicita un reporte distinto del controlador.
-export interface PayloadGetStateActis {
-  reporteEnergia?: boolean; // bit0 - puerto 130
-  reporteEstado?: boolean; // bit1 - puerto 131
-  fotocelula?: boolean; // bit2 - puerto 120
-  fechaHora?: boolean; // bit3 - puerto 121
-}
+export const PayloadGetStateActisSchema = z.object({
+  reporteEnergia: z.boolean().optional(), // bit0 - puerto 130
+  reporteEstado: z.boolean().optional(), // bit1 - puerto 131
+  fotocelula: z.boolean().optional(), // bit2 - puerto 120
+  fechaHora: z.boolean().optional(), // bit3 - puerto 121
+});
+export type PayloadGetStateActis = z.infer<typeof PayloadGetStateActisSchema>;
 
 // ===== PAYLOAD GET CONFIG ACTIS (Puerto 15) =====
 //Uplinks asociados:
@@ -96,12 +120,13 @@ export interface PayloadGetStateActis {
 // puerto 13 (setThreshold - umbrales fotocélula)
 // puerto 14 (setCoordinates)
 //Cada bit del byte enviado al puerto 15 solicita la configuración correspondiente.
-export interface PayloadGetConfigActis {
-  setMode?: boolean; // bit0 - puerto 10
-  setOffset?: boolean; // bit1 - puerto 12
-  setThreshold?: boolean; // bit2 - puerto 13
-  setCoordinates?: boolean; // bit3 - puerto 14
-}
+export const PayloadGetConfigActisSchema = z.object({
+  setMode: z.boolean().optional(), // bit0 - puerto 10
+  setOffset: z.boolean().optional(), // bit1 - puerto 12
+  setThreshold: z.boolean().optional(), // bit2 - puerto 13
+  setCoordinates: z.boolean().optional(), // bit3 - puerto 14
+});
+export type PayloadGetConfigActis = z.infer<typeof PayloadGetConfigActisSchema>;
 
 // ===== PAYLOAD GET CONFIG GENERAL ACTIS (Puerto 45) =====
 //Uplinks asociados:
@@ -110,29 +135,59 @@ export interface PayloadGetConfigActis {
 // puerto 43  (configuración de reportes -> setReportConfig)
 // puerto 44  (configuración de ACKs    -> setACKConfig)
 //Cada bit del byte enviado solicita un parámetro distinto de la configuración general.
-export interface PayloadGetConfigGeneralActis {
-  versionFirmwareMCU?: boolean; // bit0 - puerto 110
-  versionFirmwareXDot?: boolean; // bit1 - puerto 111
-  configReportes?: boolean; // bit2 - puerto 43 (setReportConfig)
-  configACK?: boolean; // bit3 - puerto 44 (setACKConfig)
-}
+export const PayloadGetConfigGeneralActisSchema = z.object({
+  versionFirmwareMCU: z.boolean().optional(), // bit0 - puerto 110
+  versionFirmwareXDot: z.boolean().optional(), // bit1 - puerto 111
+  configReportes: z.boolean().optional(), // bit2 - puerto 43 (setReportConfig)
+  configACK: z.boolean().optional(), // bit3 - puerto 44 (setACKConfig)
+});
+export type PayloadGetConfigGeneralActis = z.infer<
+  typeof PayloadGetConfigGeneralActisSchema
+>;
 
 // Estructura de perfiles de dimerizado para ACTIS FING
-export interface ICambioDimmingACTIS {
-  offsetMinutos?: number; // -720 a 720 desde medianoche
-  nivelDimming?: number; // 0-31
-}
+export const CambioDimmingACTISSchema = z.object({
+  offsetMinutos: z.number().optional(), // -720 a 720 desde medianoche
+  nivelDimming: z.number().optional(), // 0-31
+});
+export type ICambioDimmingACTIS = z.infer<typeof CambioDimmingACTISSchema>;
 
-export interface IPerfilDiasSeleccionados {
-  diasSemana?: boolean[]; // [domingo, lunes, ..., sábado]
-  cambios?: ICambioDimmingACTIS[];
-}
+export const PerfilDiasSeleccionadosSchema = z.object({
+  diasSemana: z.array(z.boolean()).optional(), // [domingo, lunes, ..., sábado]
+  cambios: z.array(CambioDimmingACTISSchema).optional(),
+});
+export type IPerfilDiasSeleccionados = z.infer<
+  typeof PerfilDiasSeleccionadosSchema
+>;
 
-export interface IPerfilDiaEspecial {
-  diaDelAnio?: number; // 1-366
-  cambios?: ICambioDimmingACTIS[];
-}
+export const PerfilDiaEspecialSchema = z.object({
+  diaDelAnio: z.number().optional(), // 1-366
+  cambios: z.array(CambioDimmingACTISSchema).optional(),
+});
+export type IPerfilDiaEspecial = z.infer<typeof PerfilDiaEspecialSchema>;
 
+export const PerfilesDimmingACTISSchema = z.object({
+  dimDefault: z.number().optional(), // 0-31
+  perfilesHabilitados: z.number().optional(), // Byte con flags
+
+  // 2 perfiles "Todos los días"
+  perfilTodosLosDias1: z.array(CambioDimmingACTISSchema).optional(),
+  perfilTodosLosDias2: z.array(CambioDimmingACTISSchema).optional(),
+
+  // 2 perfiles "Días seleccionados"
+  perfilDiasSemana1: PerfilDiasSeleccionadosSchema.optional(),
+  perfilDiasSemana2: PerfilDiasSeleccionadosSchema.optional(),
+
+  // 4 perfiles "Días especiales"
+  perfilDiaEspecial1: PerfilDiaEspecialSchema.optional(),
+  perfilDiaEspecial2: PerfilDiaEspecialSchema.optional(),
+  perfilDiaEspecial3: PerfilDiaEspecialSchema.optional(),
+  perfilDiaEspecial4: PerfilDiaEspecialSchema.optional(),
+});
+
+// Interface hand-written (no z.infer): config-perfil la usa dentro de
+// z.custom<> y el declaration emitter expande los aliases z.infer (TS7056);
+// las interfaces se imprimen por nombre.
 export interface IPerfilesDimmingACTIS {
   dimDefault?: number; // 0-31
   perfilesHabilitados?: number; // Byte con flags
@@ -152,24 +207,28 @@ export interface IPerfilesDimmingACTIS {
   perfilDiaEspecial4?: IPerfilDiaEspecial;
 }
 
-export interface IPaquetesDispositivoLorawan {
-  inicioSesion?: Date; //Cuando inició la sesión actual del dispositivo
-  fCntInicial?: number; // fCnt inicial (normalmente 0, 1 o 2)
-  ultimoFcnt?: number; // Último fCnt recibido
-  framesRecibidos?: number; //Cantidad de frames recibidos
-  perdidaPaquetes?: number; // Porcentaje de pérdida de paquetes
-}
+export const PaquetesDispositivoLorawanSchema = z.object({
+  inicioSesion: z.date().optional(), //Cuando inició la sesión actual del dispositivo
+  fCntInicial: z.number().optional(), // fCnt inicial (normalmente 0, 1 o 2)
+  ultimoFcnt: z.number().optional(), // Último fCnt recibido
+  framesRecibidos: z.number().optional(), //Cantidad de frames recibidos
+  perdidaPaquetes: z.number().optional(), // Porcentaje de pérdida de paquetes
+});
+export type IPaquetesDispositivoLorawan = z.infer<
+  typeof PaquetesDispositivoLorawanSchema
+>;
 
 // Último gateway que captó el dispositivo. Se actualiza en cada uplink (o cada
 // cierto TTL, en lora-luminarias) eligiendo el de mejor SNR (relación señal/ruido). Lo usa el orchestrator de downlinks (en el Cron)
 // para hacer throttling por gateway (airtime compartido).
 
-export interface IUltimoGateway {
-  gatewayEui?: string;
-  rssi?: number;
-  snr?: number;
-  fechaCaptura?: string; // ISO timestamp
-}
+export const UltimoGatewaySchema = z.object({
+  gatewayEui: z.string().optional(),
+  rssi: z.number().optional(),
+  snr: z.number().optional(),
+  fechaCaptura: z.string().optional(), // ISO timestamp
+});
+export type IUltimoGateway = z.infer<typeof UltimoGatewaySchema>;
 
 // Rastreo del cron de consulta de configuración inicial (gestion-cron). Una
 // luminaria cuyo dispositivo nunca tuvo perfil ni SET manual nunca recibe un
@@ -178,22 +237,46 @@ export interface IUltimoGateway {
 // sub-doc evita bucles infinitos en dispositivos que no responden: cuenta los
 // intentos sin respuesta y bloquea temporalmente (circuit breaker) tras superar
 // el máximo.
-export interface IConsultaConfigDispositivo {
-  intentos?: number; // ciclos consultados sin que la config se complete
-  ultimaConsulta?: string; // ISO — última vez que se enviaron los gets
-  bloqueadoHasta?: string; // ISO — circuit breaker, no se consulta hasta que expire
-}
+export const ConsultaConfigDispositivoSchema = z.object({
+  intentos: z.number().optional(), // ciclos consultados sin que la config se complete
+  ultimaConsulta: z.string().optional(), // ISO — última vez que se enviaron los gets
+  bloqueadoHasta: z.string().optional(), // ISO — circuit breaker, no se consulta hasta que expire
+});
+export type IConsultaConfigDispositivo = z.infer<
+  typeof ConsultaConfigDispositivoSchema
+>;
+
+//Información para cada punto del modo calendario
+export const PuntoDimmerSchema = z.object({
+  hora: z.string(),
+  porcentaje: z.number(),
+  activo: z.boolean(),
+});
+export type IPuntoDimmer = z.infer<typeof PuntoDimmerSchema>;
+
+//Información para el modo calendario
+export const DimmerCalendarioConfigSchema = z.object({
+  calendarioHabilitado: z.boolean(),
+  puntos: z.array(PuntoDimmerSchema),
+  porcentajeDefecto: z.number(),
+});
+export type IDimmerCalendarioConfig = z.infer<
+  typeof DimmerCalendarioConfigSchema
+>;
 
 /* ────────────────────────────────────────────────
  *  CONFIGURACIONES DE DISPOSITIVOS
  * ────────────────────────────────────────────────*/
 
-// Union type para config (retrocompatibilidad - ahora se usa MapaConfigDispositivo)
-export type IDispositivoLuminariaConfig =
-  | IDispositivoLuminariaGPE
-  | IDispositivoLuminariaWellness
-  | IDispositivoLuminariaACTIS;
+export const DispositivoLuminariaGPESchema = z.object({
+  configGeneral: ConfigGeneralGPESchema.optional(),
+  configCalendario: DimmerCalendarioConfigSchema.optional(),
+  alarma: z.string().optional(),
+});
 
+// Interfaces hand-written (no z.infer): config-perfil las usa dentro de
+// z.custom<> y el declaration emitter expande los aliases z.infer (TS7056);
+// las interfaces se imprimen por nombre.
 export interface IDispositivoLuminariaGPE {
   configGeneral?: IConfigGeneralGPE;
   configCalendario?: IDimmerCalendarioConfig;
@@ -201,6 +284,14 @@ export interface IDispositivoLuminariaGPE {
 }
 
 //⚠️⚠️⚠️⚠️⚠️ No deberían haber datos energéticos en las configuraciones de los dispositivos. Peor bueno, son Wellness y ni se usan
+export const DispositivoLuminariaWellnessSchema = z.object({
+  mode: z.custom<IModoLuminaria>().optional(),
+  activePowerTotal: z.number().optional(), // kWh - acumulada (A pesar de que digen power, realmente son energía)
+  reactivePowerTotal: z.number().optional(), // kWh - acumulada
+  turnOnOffStatus: z.boolean().optional(), // True: Encendido, False: Apagado
+  alarma: z.string().optional(),
+});
+
 export interface IDispositivoLuminariaWellness {
   mode?: IModoLuminaria;
   activePowerTotal?: number; // kWh - acumulada (A pesar de que digen power, realmente son energía)
@@ -208,6 +299,77 @@ export interface IDispositivoLuminariaWellness {
   turnOnOffStatus?: boolean; // True: Encendido, False: Apagado
   alarma?: string;
 }
+
+// Configuración para dispositivos ACTIS FING
+export const DispositivoLuminariaACTISSchema = z.object({
+  // ===== MODOS (Puerto 10 consultado por 15 / modo manual por 11 / reporte por 131) =====
+  modoEncendido: ModosACTISSchema.optional(),
+  modoApagado: ModosACTISSchema.optional(),
+  iniciarEncendida: z.boolean().optional(),
+
+  // ===== COORDENADAS GPS (Puerto 14 consultado por 15) =====
+  coordenadas: z
+    .object({
+      geojson: GeoJSONPointSchema.optional(),
+      timeZone: z.number().optional(), // UTC offset en horas
+    })
+    .optional(),
+
+  // ===== FOTOCÉLULA (Puerto 13 consultado por 15) =====
+  fotocelula: z
+    .object({
+      umbralSuperior: z.number().optional(), // 0-255 (0-3.3V)
+      umbralInferior: z.number().optional(), // 0-255
+      promedio: z.number().optional(), // Puerto 120: promedio último minuto (0-255)
+    })
+    .optional(),
+
+  // ===== RELOJ ASTRONÓMICO (Puerto 12 consultado por 15) =====
+  relojAstronomico: z
+    .object({
+      offsetAtardecer: z.number().optional(), // -128 a 127 minutos
+      offsetAmanecer: z.number().optional(), // -128 a 127 minutos
+    })
+    .optional(),
+
+  // ===== CONFIG REPORTES (Puerto 43 consultado por 45, reportes 130/131) =====
+  configReportes: z
+    .object({
+      reportarEncendidoApagado: z.boolean().optional(), // bit0
+      reportarDimerizado: z.boolean().optional(), // bit1
+      periodoEstado: z.literal([0, 5, 15, 30, 60, 90, 120, 180]).optional(), // bits 2-4 (min)
+      periodoEnergia: z.literal([0, 5, 15, 30, 60, 90, 120, 180]).optional(), // bits 5-7 (min)
+    })
+    .optional(),
+
+  // ===== CONFIG ACK (Puerto 44 consultado por 45) =====
+  configACK: z
+    .object({
+      periodoHoras: z.number().optional(), // bits 0-4 (0-31 horas)
+      forzado: z.boolean().optional(), // bit5: envía mensaje vacío al expirar timer
+      ackEstado: z.boolean().optional(), // bit6
+      ackEnergia: z.boolean().optional(), // bit7
+    })
+    .optional(),
+
+  // ===== PERFILES DIMERIZADO (Puertos 20-30) =====
+  perfilesDimming: PerfilesDimmingACTISSchema.optional(),
+
+  // ===== FIRMWARE =====
+  versionFirmware: z.string().optional(), // Puerto 110
+  versionModuloLoRa: z.string().optional(), // Puerto 111
+
+  // ===== ALARMAS =====
+  alarma: z.string().optional(),
+
+  // ===== FECHA/HORA (Puerto 121) =====
+  reporteFechaHora: z
+    .object({
+      reportada: z.string().optional(), // timestamp del dispositivo
+      receivedAt: z.string().optional(), // timestamp de recepción API
+    })
+    .optional(),
+});
 
 // Configuración para dispositivos ACTIS FING
 export interface IDispositivoLuminariaACTIS {
@@ -267,6 +429,17 @@ export interface IDispositivoLuminariaACTIS {
     receivedAt?: string; // timestamp de recepción API
   };
 }
+
+// Union type para config (retrocompatibilidad - ahora se usa MapaConfigDispositivo)
+export const DispositivoLuminariaConfigSchema = z.union([
+  DispositivoLuminariaGPESchema,
+  DispositivoLuminariaWellnessSchema,
+  DispositivoLuminariaACTISSchema,
+]);
+export type IDispositivoLuminariaConfig =
+  | IDispositivoLuminariaGPE
+  | IDispositivoLuminariaWellness
+  | IDispositivoLuminariaACTIS;
 
 /* ────────────────────────────────────────────────
  *  MAPA DE TIPO → CONFIG (TYPE-SAFE)
@@ -335,10 +508,82 @@ export interface IDispositivoLorawanBase<
   modeloDispositivo?: IModeloDispositivo;
 }
 
+// Campos comunes a todas las variantes (sin tipo/config, que discriminan)
+const DispositivoLorawanCamposSchema = z.object({
+  _id: z.string().optional(),
+  idCliente: z.string().optional(),
+  idsAncestros: z.array(z.string()).optional(),
+  idModeloDispositivo: z.string().optional(),
+  fechaCreacion: z.string().optional(),
+
+  // Campos comunes
+  fechaUltimaComunicacion: z.string().optional(),
+  ultimoReporte: z.custom<IReporteGenerico>().optional(),
+  margin: z.number().optional(), //Es la señal del dispositivo, expresada en dB
+  tiempoLimiteComunicacion: z.number().optional(), // Tiempo máximo sin reportar (en horas) antes de generar evento "Sin comunicación".
+
+  ubicacion: GeoJSONPointSchema.optional(), // GeoJSON de la ubicacion del dispositivo
+  ultimoComando: z.custom<IComando>().optional(), //Último downlink enviado a este dispositivo
+  paquetes: PaquetesDispositivoLorawanSchema.optional(), //Información para calcular la pérdida de paquetes
+  ultimoGateway: UltimoGatewaySchema.optional(), //Gateway con mejor señal en el último uplink capturado
+  consultaConfig: ConsultaConfigDispositivoSchema.optional(), //Rastreo del cron de consulta de configuración inicial (bootstrap de config).
+
+  // Datos para el lora server
+  deveui: z.string().optional(),
+  joineui: z.string().optional(),
+  description: z.string().optional(),
+  name: z.string().optional(),
+  tags: z.record(z.string(), z.string()).optional(),
+  applicationId: z.string().optional(),
+  deviceProfileId: z.string().optional(),
+  variables: z.record(z.string(), z.string()).optional(),
+  isDisabled: z.boolean().optional(),
+  skipFcntCheck: z.boolean().optional(),
+
+  // Datos para OTAA
+  appkey: z.string().optional(), //Con esta se completa tanto el appKey y el nwkKey para deviceKeys
+
+  //Datos para ABP
+  devAddr: z.string().optional(),
+  appSKey: z.string().optional(),
+  fCntUp: z.number().optional(),
+  nFCntDown: z.number().optional(),
+  nwkskey: z.string().optional(), //Con esta se completa fNwkSIntKey, nwkSEncKey y sNwkSIntKey para activationKeys
+
+  //Populate
+  cliente: ClienteSchema.optional(),
+  ancestros: z.array(ClienteSchema).optional(),
+  modeloDispositivo: ModeloDispositivoSchema.optional(),
+});
+
+const VarianteDispositivoLorawanGPE = DispositivoLorawanCamposSchema.extend({
+  tipo: z.literal('Luminaria GPE').optional(),
+  config: DispositivoLuminariaGPESchema.optional(),
+});
+const VarianteDispositivoLorawanWellness =
+  DispositivoLorawanCamposSchema.extend({
+    tipo: z.literal('Luminaria Wellness').optional(),
+    config: DispositivoLuminariaWellnessSchema.optional(),
+  });
+const VarianteDispositivoLorawanACTIS = DispositivoLorawanCamposSchema.extend({
+  tipo: z.literal('Luminaria ACTIS FING').optional(),
+  config: DispositivoLuminariaACTISSchema.optional(),
+});
+
 /* ────────────────────────────────────────────────
  *  TIPO DISCRIMINADO (TYPE-SAFE) - READ
  * ────────────────────────────────────────────────*/
 
+export const DispositivoLorawanSchema = z.union([
+  VarianteDispositivoLorawanGPE,
+  VarianteDispositivoLorawanWellness,
+  VarianteDispositivoLorawanACTIS,
+]);
+
+/**
+ * Tipo hand-written (misma forma que el schema): los tipos de entidad del
+ * SCC no usan z.infer porque los ciclos de aliases mutuos disparan TS2589.
+ */
 export type IDispositivoLorawan =
   | IDispositivoLorawanBase<'Luminaria GPE'>
   | IDispositivoLorawanBase<'Luminaria Wellness'>
@@ -348,11 +593,29 @@ export type IDispositivoLorawan =
  *  CREATE / UPDATE - UNIONES DISCRIMINADAS
  * ────────────────────────────────────────────────*/
 
-type OmitirCreate = '_id' | 'cliente' | 'ancestros' | 'modeloDispositivo';
+const camposOmitidos: {
+  _id: true;
+  cliente: true;
+  ancestros: true;
+  modeloDispositivo: true;
+} = {
+  _id: true,
+  cliente: true,
+  ancestros: true,
+  modeloDispositivo: true,
+};
 
 /** Create: no incluimos los virtuales/ids que manejás en el backend.
  *  Mantiene `tipo` como discriminante para type safety.
  */
+export const CreateDispositivoLorawanSchema = z.union([
+  VarianteDispositivoLorawanGPE.omit(camposOmitidos),
+  VarianteDispositivoLorawanWellness.omit(camposOmitidos),
+  VarianteDispositivoLorawanACTIS.omit(camposOmitidos),
+]);
+
+type OmitirCreate = '_id' | 'cliente' | 'ancestros' | 'modeloDispositivo';
+
 export type ICreateDispositivoLorawan =
   | Omit<Partial<IDispositivoLorawanBase<'Luminaria GPE'>>, OmitirCreate>
   | Omit<Partial<IDispositivoLorawanBase<'Luminaria Wellness'>>, OmitirCreate>
@@ -361,11 +624,17 @@ export type ICreateDispositivoLorawan =
       OmitirCreate
     >;
 
-type OmitirUpdate = '_id' | 'cliente' | 'ancestros' | 'modeloDispositivo';
-
 /** Update: permitimos campos parciales pero mantenemos `tipo` para que TS pueda discriminar.
  *  Cuando actualizás config, TypeScript valida que sea del tipo correcto según `tipo`.
  */
+export const UpdateDispositivoLorawanSchema = z.union([
+  VarianteDispositivoLorawanGPE.omit(camposOmitidos),
+  VarianteDispositivoLorawanWellness.omit(camposOmitidos),
+  VarianteDispositivoLorawanACTIS.omit(camposOmitidos),
+]);
+
+type OmitirUpdate = '_id' | 'cliente' | 'ancestros' | 'modeloDispositivo';
+
 export type IUpdateDispositivoLorawan =
   | Omit<Partial<IDispositivoLorawanBase<'Luminaria GPE'>>, OmitirUpdate>
   | Omit<Partial<IDispositivoLorawanBase<'Luminaria Wellness'>>, OmitirUpdate>
@@ -373,16 +642,3 @@ export type IUpdateDispositivoLorawan =
       Partial<IDispositivoLorawanBase<'Luminaria ACTIS FING'>>,
       OmitirUpdate
     >;
-
-//Información para el modo calendario
-export interface IDimmerCalendarioConfig {
-  calendarioHabilitado: boolean;
-  puntos: IPuntoDimmer[];
-  porcentajeDefecto: number;
-}
-//Información para cada punto del modo calendario
-export interface IPuntoDimmer {
-  hora: string;
-  porcentaje: number;
-  activo: boolean;
-}

--- a/src/interfaces/documentacion.ts
+++ b/src/interfaces/documentacion.ts
@@ -1,34 +1,43 @@
-import { IActivo } from './activo';
-import { ICliente } from './cliente';
-import { IUsuario } from './usuario';
+import { z } from 'zod';
+import { ActivoSchema } from './activo';
+import { ClienteSchema } from './cliente';
+import { UsuarioSchema } from './usuario';
 
-export type TipoDocumentacion = 'Licencia' | 'Seguro';
+export const TipoDocumentacionSchema = z.enum(['Licencia', 'Seguro']);
+export type TipoDocumentacion = z.infer<typeof TipoDocumentacionSchema>;
 
-export interface IDocumentacion {
-  _id?: string;
-  tipo?: TipoDocumentacion;
-  vencimiento?: string;
-  fechaCreacion?: string;
-  emision?: string;
-  descripcion?: string;
-  imagenes?: string[];
-  idCliente?: string;
-  idsAncestros?: string[];
-  idChofer?: string;
-  idActivo?: string;
+export const DocumentacionSchema = z.object({
+  _id: z.string().optional(),
+  tipo: TipoDocumentacionSchema.optional(),
+  vencimiento: z.string().optional(),
+  fechaCreacion: z.string().optional(),
+  emision: z.string().optional(),
+  descripcion: z.string().optional(),
+  imagenes: z.array(z.string()).optional(),
+  idCliente: z.string().optional(),
+  idsAncestros: z.array(z.string()).optional(),
+  idChofer: z.string().optional(),
+  idActivo: z.string().optional(),
   // Populate
-  cliente?: ICliente;
-  ancestros?: ICliente[];
-  chofer?: IUsuario;
-  activo?: IActivo;
-}
+  cliente: ClienteSchema.optional(),
+  ancestros: z.array(ClienteSchema).optional(),
+  chofer: UsuarioSchema.optional(),
+  activo: ActivoSchema.optional(),
+});
+export type IDocumentacion = z.infer<typeof DocumentacionSchema>;
 
-type OmitirCreate = '_id' | 'chofer' | 'activo' | 'Cliente';
+// El omit original incluía la clave 'Cliente' (con mayúscula), que no existe en
+// IDocumentacion y por lo tanto era un no-op; se descarta.
+export const CreateDocumentacionSchema = DocumentacionSchema.omit({
+  _id: true,
+  chofer: true,
+  activo: true,
+});
+export type ICreateDocumentacion = z.infer<typeof CreateDocumentacionSchema>;
 
-export interface ICreateDocumentacion
-  extends Omit<Partial<IDocumentacion>, OmitirCreate> {}
-
-type OmitirUpdate = '_id' | 'chofer' | 'activo' | 'Cliente';
-
-export interface IUpdateDocumentacion
-  extends Omit<Partial<IDocumentacion>, OmitirUpdate> {}
+export const UpdateDocumentacionSchema = DocumentacionSchema.omit({
+  _id: true,
+  chofer: true,
+  activo: true,
+});
+export type IUpdateDocumentacion = z.infer<typeof UpdateDocumentacionSchema>;

--- a/src/interfaces/downlink-job.ts
+++ b/src/interfaces/downlink-job.ts
@@ -1,124 +1,130 @@
-import { ICliente } from './cliente';
-import { IObjetivoComando } from './comando';
+import { z } from 'zod';
+import { ClienteSchema } from './cliente';
+import { ObjetivoComandoSchema } from './comando';
 import {
-  IDispositivoLorawan,
-  TipoDispositivoLorawan,
+  DispositivoLorawanSchema,
+  TipoDispositivoLorawanSchema,
 } from './dispositivo-lorawan';
 
 // Estado de cada job en la cola de downlinks. Se persiste en la BD para
 // auditoría y para que la UI pueda mostrar progreso. Espejo (en parte) del
 // estado de BullMQ + el estado del IComando emitido.
 
-export type EstadoDownlinkJob =
-  | 'En cola' // creado, esperando turno
-  | 'Programado' // tiene delay y está en BullMQ (delayed)
-  | 'Enviando' // worker tomó el job
-  | 'Enviado' // se llamó a chirpstack.sendDownlink OK
-  | 'Confirmado' // se asoció a comando con estado terminal favorable
-  | 'Descartado' // device offline / NS sin sesión
-  | 'Cancelado' // cancelado por superseding job
-  | 'Fallido'; // error técnico tras N reintentos
+export const EstadoDownlinkJobSchema = z.enum([
+  'En cola', // creado, esperando turno
+  'Programado', // tiene delay y está en BullMQ (delayed)
+  'Enviando', // worker tomó el job
+  'Enviado', // se llamó a chirpstack.sendDownlink OK
+  'Confirmado', // se asoció a comando con estado terminal favorable
+  'Descartado', // device offline / NS sin sesión
+  'Cancelado', // cancelado por superseding job
+  'Fallido', // error técnico tras N reintentos
+]);
+export type EstadoDownlinkJob = z.infer<typeof EstadoDownlinkJobSchema>;
 
 // Origen = eje de POLÍTICA (cómo se trata el downlink). Lo leen el processor (expiresAt) y el cron de reintento. Los orígenes actuales son (Manual, Reconciliacion y AutoGet).
 // La PROCEDENCIA (de qué nivel/entidad nació) vive en `objetivo` (ver IObjetivoComando).
-export type OrigenDownlinkJob =
-  | 'Reconciliacion' // Viene del Cron cuando intenta ajustar la configuración del dispositivo si esta difiere de la configuración deseada
-  | 'Manual' // Viene de la UI: cualquier acción de usuario (individual, grupo, puesta o grupos de puestas)
-  | 'AutoGet' // Get encadenado tras un SET que no autoreporta su cambio. Refresca dispositivo.config para cerrar el lazo del reconciliador.
-  | 'ConsultaConfig'; // Viene del Cron de consulta de configuración inicial: GETs puros para hacer el bootstrap de dispositivo.config en luminarias que nunca tuvieron perfil ni SET manual (config vacía). No escribe IConfigDeseada ni se reintenta.
+export const OrigenDownlinkJobSchema = z.enum([
+  'Reconciliacion', // Viene del Cron cuando intenta ajustar la configuración del dispositivo si esta difiere de la configuración deseada
+  'Manual', // Viene de la UI: cualquier acción de usuario (individual, grupo, puesta o grupos de puestas)
+  'AutoGet', // Get encadenado tras un SET que no autoreporta su cambio. Refresca dispositivo.config para cerrar el lazo del reconciliador.
+  'ConsultaConfig', // Viene del Cron de consulta de configuración inicial: GETs puros para hacer el bootstrap de dispositivo.config en luminarias que nunca tuvieron perfil ni SET manual (config vacía). No escribe IConfigDeseada ni se reintenta.
+]);
+export type OrigenDownlinkJob = z.infer<typeof OrigenDownlinkJobSchema>;
 
 // Una entrada por intento de TRANSPORTE (reintento BullMQ del MISMO job). Es
 // append-only: el processor la agrega en cada outcome (Enviado/Descartado/Error)
 // vía $push, para que la UI muestre qué se intentó y cuándo, no solo el contador.
 // Los reintentos del RECONCILIADOR son jobs distintos → nodos propios, no entran acá.
-export interface IIntentoDownlink {
-  numero: number; // 1..N (attemptsMade + 1)
-  fecha: string; // ISO del intento
-  resultado: 'Enviado' | 'Descartado' | 'Error';
-  error?: string; // mensaje si falló o motivo de descarte
-  idComando?: string; // IComando creado en este intento (si hubo)
-}
+export const IntentoDownlinkSchema = z.object({
+  numero: z.number(), // 1..N (attemptsMade + 1)
+  fecha: z.string(), // ISO del intento
+  resultado: z.enum(['Enviado', 'Descartado', 'Error']),
+  error: z.string().optional(), // mensaje si falló o motivo de descarte
+  idComando: z.string().optional(), // IComando creado en este intento (si hubo)
+});
+export type IIntentoDownlink = z.infer<typeof IntentoDownlinkSchema>;
 
 // Get encadenado tras un SET que no autoreporta su cambio. El processor lee este
 // campo y, tras enviar el set, encola un nuevo job (origen='AutoGet') con el
 // delay indicado.
-export interface IProximoGetDownlinkJob {
-  puerto: number;
-  payload: string;
-  delaySegundos: number;
-}
+export const ProximoGetDownlinkJobSchema = z.object({
+  puerto: z.number(),
+  payload: z.string(),
+  delaySegundos: z.number(),
+});
+export type IProximoGetDownlinkJob = z.infer<
+  typeof ProximoGetDownlinkJobSchema
+>;
 
-export interface IDownlinkJob {
-  _id?: string;
-  idCliente?: string;
-  idsAncestros?: string[];
+export const DownlinkJobSchema = z.object({
+  _id: z.string().optional(),
+  idCliente: z.string().optional(),
+  idsAncestros: z.array(z.string()).optional(),
 
-  idDispositivoLorawan: string;
-  deveui: string;
-  tipoDispositivo?: TipoDispositivoLorawan;
+  idDispositivoLorawan: z.string(),
+  deveui: z.string(),
+  tipoDispositivo: TipoDispositivoLorawanSchema.optional(),
 
-  origen: OrigenDownlinkJob;
-  objetivo?: IObjetivoComando; // Procedencia: desde qué nivel/entidad se originó (se propaga al IComando)
-  idEjecucion?: string; // batch id (uuid) — agrupa todos los jobs de una acción
-  idJobBull?: string; // BullMQ job id
-  indicePaso?: number; //posición de este downlink dentro del plan ordenado del dispositivo
+  origen: OrigenDownlinkJobSchema,
+  objetivo: ObjetivoComandoSchema.optional(), // Procedencia: desde qué nivel/entidad se originó (se propaga al IComando)
+  idEjecucion: z.string().optional(), // batch id (uuid) — agrupa todos los jobs de una acción
+  idJobBull: z.string().optional(), // BullMQ job id
+  indicePaso: z.number().optional(), //posición de este downlink dentro del plan ordenado del dispositivo
 
-  puerto: number;
-  payload: string;
-  nombre: string;
-  descripcion?: string;
+  puerto: z.number(),
+  payload: z.string(),
+  nombre: z.string(),
+  descripcion: z.string().optional(),
 
   // Idempotencia / superseding. Default '<deveui>:<puerto>' o
   // '<deveui>:<puerto>:<sha1(payload)[:8]>' si distintos payloads coexisten (Ej: perfiles de dimerizado ACTIS).
-  claveDedup?: string; //Si dos downlinks tienen la misma claveDedup, el segundo cancela al primero (si no se ejecutó aún) y lo reemplaza en la cola de BullMQ. El processor siempre procesa el más reciente.
+  claveDedup: z.string().optional(), //Si dos downlinks tienen la misma claveDedup, el segundo cancela al primero (si no se ejecutó aún) y lo reemplaza en la cola de BullMQ. El processor siempre procesa el más reciente.
   //Ej de uso: se envía un downlink de cambio de configuración, se encola con clave, si después se envía otro downlink de cambio de configuración, con la misma clave, el primer downlink se cancela si aún no se ejecutó. Se prioriza el último
 
   // Estado
-  estado: EstadoDownlinkJob;
-  intentos: number;
-  ultimoError?: string;
-  intentosLog?: IIntentoDownlink[]; // historial append-only por intento de transporte
-  idComando?: string; // se llena al crear el IComando real en BD
+  estado: EstadoDownlinkJobSchema,
+  intentos: z.number(),
+  ultimoError: z.string().optional(),
+  intentosLog: z.array(IntentoDownlinkSchema).optional(), // historial append-only por intento de transporte
+  idComando: z.string().optional(), // se llena al crear el IComando real en BD
 
   // Auto-get encadenado (ACTIS)
-  proximoGet?: IProximoGetDownlinkJob;
+  proximoGet: ProximoGetDownlinkJobSchema.optional(),
 
-  datosExtra?: Record<string, any>;
+  datosExtra: z.record(z.string(), z.any()).optional(),
 
   //Fechas
-  fechaCreacion?: string;
-  fechaProgramada?: string; // cuando se encola en BullMQ con delay
-  fechaEnviado?: string;
-  fechaConfirmado?: string;
+  fechaCreacion: z.string().optional(),
+  fechaProgramada: z.string().optional(), // cuando se encola en BullMQ con delay
+  fechaEnviado: z.string().optional(),
+  fechaConfirmado: z.string().optional(),
 
   //Populate
-  cliente?: ICliente;
-  ancestros?: ICliente[];
-  dispositivo?: IDispositivoLorawan;
-}
+  cliente: ClienteSchema.optional(),
+  ancestros: z.array(ClienteSchema).optional(),
+  dispositivo: DispositivoLorawanSchema.optional(),
+});
+export type IDownlinkJob = z.infer<typeof DownlinkJobSchema>;
 
-type OmitirCreate =
-  | '_id'
-  | 'fechaCreacion'
-  | 'fechaEnviado'
-  | 'fechaConfirmado'
-  | 'idsAncestros';
-export interface ICreateDownlinkJob extends Omit<
-  Partial<IDownlinkJob>,
-  OmitirCreate
-> {
-  idDispositivoLorawan: string;
-  deveui: string;
-  origen: OrigenDownlinkJob;
-  puerto: number;
-  payload: string;
-  nombre: string;
-  estado: EstadoDownlinkJob;
-  intentos: number;
-}
+// El original era Omit<Partial<IDownlinkJob>, OmitirCreate> re-declarando como
+// requeridos exactamente los mismos 8 campos que ya son requeridos en la base
+// (idDispositivoLorawan, deveui, origen, puerto, payload, nombre, estado,
+// intentos) → equivale a un omit directo sin partial.
+export const CreateDownlinkJobSchema = DownlinkJobSchema.omit({
+  _id: true,
+  fechaCreacion: true,
+  fechaEnviado: true,
+  fechaConfirmado: true,
+  idsAncestros: true,
+});
+export type ICreateDownlinkJob = z.infer<typeof CreateDownlinkJobSchema>;
 
-type OmitirUpdate = '_id' | 'fechaCreacion' | 'idsAncestros';
-export interface IUpdateDownlinkJob extends Omit<
-  Partial<IDownlinkJob>,
-  OmitirUpdate
-> {}
+// El original era Omit<Partial<IDownlinkJob>, OmitirUpdate>: acá el Partial NO
+// era no-op (la base tiene campos requeridos), por eso se agrega .partial().
+export const UpdateDownlinkJobSchema = DownlinkJobSchema.omit({
+  _id: true,
+  fechaCreacion: true,
+  idsAncestros: true,
+}).partial();
+export type IUpdateDownlinkJob = z.infer<typeof UpdateDownlinkJobSchema>;

--- a/src/interfaces/emergencias.ts
+++ b/src/interfaces/emergencias.ts
@@ -1,10 +1,145 @@
-import { DireccionV2, IGeoJSONPoint } from '../auxiliares';
-import { ICliente } from './cliente';
-import { IConfigEventoUsuario } from './config-evento-usuario';
-import { IDestinatarioAsistencia } from './destinatario-asistencia';
-import { IEventoGenerico } from './evento-generico';
-import { IUbicacion } from './ubicacion';
+import { z } from 'zod';
+import { GeoJSONPointSchema, IGeoJSONPoint } from '../auxiliares';
+import { ClienteSchema, ICliente } from './cliente';
+import type { IDestinatarioAsistencia } from './destinatario-asistencia';
+import type { IEventoGenerico } from './evento-generico';
+import type { IUbicacion } from './ubicacion';
 
+//////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+export const PrioridadEmergenciaMedicaSchema = z.enum([
+  'Verde',
+  'Amarillo',
+  'Rojo',
+  'Negro',
+  'Celeste',
+]);
+export type PrioridadEmergenciaMedica = z.infer<
+  typeof PrioridadEmergenciaMedicaSchema
+>;
+
+export const PrioridadEmergenciaBomberoSchema = z.enum([
+  'Baja',
+  'Media',
+  'Alta',
+  'Crítica',
+  'Óbito',
+]);
+export type PrioridadEmergenciaBombero = z.infer<
+  typeof PrioridadEmergenciaBomberoSchema
+>;
+
+export const TipoEmergenciaSchema = z.enum(['Médica', 'Bombero']);
+export type TipoEmergencia = z.infer<typeof TipoEmergenciaSchema>;
+
+export const ArchivosAdjuntosSchema = z.object({
+  fechaSubida: z.string().optional(),
+  descripcion: z.string().optional(),
+  archivo: z.string().optional(), //url del archivo
+  usuario: z.string().optional(), //usuario que subió el archivo
+  nombreOriginal: z.string().optional(), //El nombre del archivo que se subió
+});
+export type IArchivosAdjuntos = z.infer<typeof ArchivosAdjuntosSchema>;
+
+export const SignosVitalesSchema = z.object({
+  tensionArterial: z.number().optional(), //miligramos de mercurio (mmHg)
+  frecuenciaRespiratoria: z.number().optional(), //impulsos respiratorios por minuto (irpm)
+  frecuenciaCardiaca: z.number().optional(), //latidos por minuto (lpm)
+  saturacionOxigeno: z.number().optional(), // %
+  temperatura: z.number().optional(), //grados
+});
+export type SignosVitales = z.infer<typeof SignosVitalesSchema>;
+
+export const InfoTrasladoSchema = z.object({
+  traslado: z.boolean().optional(),
+  direccion: z.string().optional(),
+  aceptaTraslado: z.boolean().optional(), //indica si el paciente acepta ser trasladado o se niega
+});
+export type InfoTraslado = z.infer<typeof InfoTrasladoSchema>;
+
+export const EmergenciaMedicaSchema = z.object({
+  sintomasApertura: z.array(z.string()).optional(), // Lista de síntomas reportados al inicio
+  sintomasCierre: z.array(z.string()).optional(), // Lista de síntomas reportados al finalizar una emergencia con un diagnóstico
+  tratamiento: z.string().optional(), //Tratamiento realizado
+  diagnostico: z.string().optional(), // Diagnóstico hecho
+  medicacion: z.string().optional(), // Medicación administrada
+  irAHospital: z.boolean().optional(), //Esto se marca una vez que la ambulancia haya llegado a la dirección de auxilio y se dé el ok para ir al hospital (se indica manualmente)
+  fechaLlegadaHospital: z.string().optional(),
+  signosVitales: SignosVitalesSchema.optional(),
+  traslado: InfoTrasladoSchema.optional(),
+});
+export type IEmergenciaMedica = z.infer<typeof EmergenciaMedicaSchema>;
+
+export const EmergenciaBomberosSchema = z.object({
+  irCuartel: z.array(z.string()).optional(), //Acá irán todos los usuarios que confirman ir al cuartel
+});
+export type IEmergenciaBomberos = z.infer<typeof EmergenciaBomberosSchema>;
+
+// Populates intra-SCC como z.custom (import type-only): un schema real acá
+// arrastra el shape completo del ciclo y revienta la serialización de
+// declarations (TS7056) acá y en los consumidores NestJS.
+export const EmergenciaSchema = z.object({
+  //IDS
+  _id: z.string().optional(),
+  idDestinatarioAsistencia: z.string().optional(),
+  idCliente: z.string().optional(),
+  idsAncestros: z.array(z.string()).optional(),
+
+  //DATOS GENERALES DE LA EMERGENCIA
+  tipo: TipoEmergenciaSchema.optional(),
+  prioridadApertura: z
+    .union([PrioridadEmergenciaMedicaSchema, PrioridadEmergenciaBomberoSchema])
+    .optional(), //Prioridad de apertura de la emergencia
+  prioridadCierre: z
+    .union([PrioridadEmergenciaMedicaSchema, PrioridadEmergenciaBomberoSchema])
+    .optional(), //Prioridad asignada por el personal correspondiente
+  codigo: z.number().optional(), // Código único del caso de emergencia médica es incremental
+  solicitante: z.string().optional(), // Nombre del solicitante de la emergencia
+  telefono: z.string().optional(), // Teléfono de contacto del solicitante
+  archivosAdjuntos: z.array(ArchivosAdjuntosSchema).optional(),
+  observaciones: z.string().optional(), // Notas adicionales sobre el auxilio
+
+  //FECHAS RELEVANTES DE LA EMERGENCIA
+  fechaCreacion: z.string().optional(),
+  fechaPrimeraAsignacion: z.string().optional(),
+  fechaSalida: z.string().optional(), //La ambulancia puede salir del centro o salir desde otro lugar (este dato debe analizarse junto con el campo salioDelCentro)
+  fechaLlegadaDestino: z.string().optional(),
+  fechaFinalizacion: z.string().optional(),
+
+  //SITUACIÓN DE LA EMERGENCIA
+  //Si no es ninguna de estas, es una llamada común que no requiere seguimiento ni auxilio, ni tampoco es una emergencia ya atendida en el hospital.
+  esAuxilio: z.boolean().optional(), //Esto es para indicar si la emergencia requiere un seguimiento extra, es decir, se hace algo más que sólo registrarla
+  enSeguimiento: z.boolean().optional(), //Una emergencia en seguimiento es aquella que no es auxilio y requiere seguimiento. Si está en seguimiento, no se le pueden asignar/reasignar nada. Pueden pasarse en un futuro a auxilio.
+  iniciaFinalizada: z.boolean().optional(), //Indica que la emergencia que se está cargando ya está finalizada (simplemente sirve como registro), si está esta opción, se pueden cargar detalles de la atención recibida.
+  importada: z.boolean().optional(), //Las emergencias importadas sólo sirven para las métricas, no se muestran en el listado
+
+  //DATOS DE UBICACIÓN
+  direccion: z.string().optional(), //Esta es la dirección que el solicitante indica para la emergencia. No tiene nada que ver con las direcciones que puede haber en los seguimientos
+  ubicacionDestino: GeoJSONPointSchema.optional(), //geojson del lugar de la emergencia
+  idUbicacion: z.string().optional(), //Cuando se crea una emergencia, se genera la entidad IUbicacion para la ubicacion, para luego ejecutar una lógica de negocio junto con la configEventoUsuario.
+
+  //SEGUIMIENTO DE LA EMERGENCIA
+  asignada: z.boolean().optional(), //Indica si a la emergencia se le asignó alguna clase de personal para el seguimiento (vehículos, médicos, choferes, etc)
+  ultimaActualizacion: z.string().optional(),
+  ultimoEventoEmergencia: z.custom<IEventoGenerico>().optional(), //Acá se carga el último evento para hacer el seguimiento del auxilio
+  salioDelCentro: z.boolean().optional(), //En caso de que sea un auxilio, se indica si el móvil asignado salió del centro o no para ir al destino.
+  centroEnTransito: z.boolean().optional(), //Indica si la ambulancia pasó por un centro en el camino (sirve para diferenciar el caso en el que la ambulancia sale de un centro o pasa por uno. Esto sirve para determinar el campo salioDelCentro)
+  cantidadReasignaciones: z.number().optional(), //Cuenta la cantidad de reasignaciones que tuvo la emergencia
+
+  //DATOS ESPECÍFICOS DE CADA TIPO DE EMERGENCIA
+  emergenciaMedica: EmergenciaMedicaSchema.optional(),
+  emergenciaBomberos: EmergenciaBomberosSchema.optional(),
+
+  //Populate
+  destinatarioAsistencia: z.custom<IDestinatarioAsistencia>().optional(), // Información del paciente
+  cliente: ClienteSchema.optional(),
+  ancestros: z.array(ClienteSchema).optional(),
+  ubicacion: z.custom<IUbicacion>().optional(),
+});
+
+/**
+ * Interface hand-written (misma forma que el schema): los tipos de entidad del
+ * SCC no usan z.infer porque los ciclos de aliases mutuos disparan TS2589.
+ */
 export interface IEmergencia {
   //IDS
   _id?: string;
@@ -60,69 +195,20 @@ export interface IEmergencia {
   ubicacion?: IUbicacion;
 }
 
-//////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-export type PrioridadEmergenciaMedica =
-  | 'Verde'
-  | 'Amarillo'
-  | 'Rojo'
-  | 'Negro'
-  | 'Celeste';
-
-export type PrioridadEmergenciaBombero =
-  | 'Baja'
-  | 'Media'
-  | 'Alta'
-  | 'Crítica'
-  | 'Óbito';
-
-export type TipoEmergencia = 'Médica' | 'Bombero';
-
-export interface IArchivosAdjuntos {
-  fechaSubida?: string;
-  descripcion?: string;
-  archivo?: string; //url del archivo
-  usuario?: string; //usuario que subió el archivo
-  nombreOriginal?: string; //El nombre del archivo que se subió
-}
-
-export interface SignosVitales {
-  tensionArterial?: number; //miligramos de mercurio (mmHg)
-  frecuenciaRespiratoria?: number; //impulsos respiratorios por minuto (irpm)
-  frecuenciaCardiaca?: number; //latidos por minuto (lpm)
-  saturacionOxigeno?: number; // %
-  temperatura?: number; //grados
-}
-export interface InfoTraslado {
-  traslado?: boolean;
-  direccion?: string;
-  aceptaTraslado?: boolean; //indica si el paciente acepta ser trasladado o se niega
-}
-export interface IEmergenciaMedica {
-  sintomasApertura?: string[]; // Lista de síntomas reportados al inicio
-  sintomasCierre?: string[]; // Lista de síntomas reportados al finalizar una emergencia con un diagnóstico
-  tratamiento?: string; //Tratamiento realizado
-  diagnostico?: string; // Diagnóstico hecho
-  medicacion?: string; // Medicación administrada
-  irAHospital?: boolean; //Esto se marca una vez que la ambulancia haya llegado a la dirección de auxilio y se dé el ok para ir al hospital (se indica manualmente)
-  fechaLlegadaHospital?: string;
-  signosVitales?: SignosVitales;
-  traslado?: InfoTraslado;
-}
-
-export interface IEmergenciaBomberos {
-  irCuartel?: string[]; //Acá irán todos los usuarios que confirman ir al cuartel
-}
+export const CreateEmergenciaSchema = EmergenciaSchema.omit({
+  _id: true,
+});
 
 type OmitirCreate = '_id';
 
-export interface ICreateEmergencia extends Omit<
-  Partial<IEmergencia>,
-  OmitirCreate
-> {}
+export interface ICreateEmergencia
+  extends Omit<Partial<IEmergencia>, OmitirCreate> {}
+
+export const UpdateEmergenciaSchema = EmergenciaSchema.omit({
+  _id: true,
+});
 
 type OmitirUpdate = '_id';
 
-export interface IUpdateEmergencia extends Omit<
-  Partial<IEmergencia>,
-  OmitirUpdate
-> {}
+export interface IUpdateEmergencia
+  extends Omit<Partial<IEmergencia>, OmitirUpdate> {}

--- a/src/interfaces/envio-vehiculo.ts
+++ b/src/interfaces/envio-vehiculo.ts
@@ -1,56 +1,58 @@
-import { IActivo } from './activo';
-import { ICliente } from './cliente';
-import { IEventoGenerico } from './evento-generico';
-import { IUsuario } from './usuario';
+import { z } from 'zod';
+import { ActivoSchema } from './activo';
+import { ClienteSchema } from './cliente';
+import type { IEventoGenerico } from './evento-generico';
+import { UsuarioSchema } from './usuario';
 
-export type EstadoEnvioVehiculo =
-  | 'Asignado'
-  | 'En Camino'
-  | 'Rechazado'
-  | 'Finalizado'
-  | 'En Destino';
+export const EstadoEnvioVehiculoSchema = z.enum([
+  'Asignado',
+  'En Camino',
+  'Rechazado',
+  'Finalizado',
+  'En Destino',
+]);
+export type EstadoEnvioVehiculo = z.infer<typeof EstadoEnvioVehiculoSchema>;
 
-export interface IEnvioVehiculo {
-  _id?: string;
-  fechaCreacion?: string;
-  fechaFinalizacion?: string;
-  descripcion?: string;
-  estado?: EstadoEnvioVehiculo;
+export const EnvioVehiculoSchema = z.object({
+  _id: z.string().optional(),
+  fechaCreacion: z.string().optional(),
+  fechaFinalizacion: z.string().optional(),
+  descripcion: z.string().optional(),
+  estado: EstadoEnvioVehiculoSchema.optional(),
   ///
-  idCliente?: string;
-  idsAncestros?: string[];
-  idConductor?: string;
-  idsEventos?: string[];
+  idCliente: z.string().optional(),
+  idsAncestros: z.array(z.string()).optional(),
+  idConductor: z.string().optional(),
+  idsEventos: z.array(z.string()).optional(),
   //Usuario que lo crea
-  idUsuario?: string;
-  idActivo?: string;
+  idUsuario: z.string().optional(),
+  idActivo: z.string().optional(),
   // Populate
-  cliente?: ICliente;
-  ancestros?: ICliente[];
-  conductor?: IUsuario;
-  usuario?: IUsuario;
-  eventos?: IEventoGenerico[];
-  activo?: IActivo;
-}
+  cliente: ClienteSchema.optional(),
+  ancestros: z.array(ClienteSchema).optional(),
+  conductor: UsuarioSchema.optional(),
+  usuario: UsuarioSchema.optional(),
+  eventos: z.array(z.custom<IEventoGenerico>()).optional(),
+  activo: ActivoSchema.optional(),
+});
+export type IEnvioVehiculo = z.infer<typeof EnvioVehiculoSchema>;
 
-type OmitirCreate =
-  | '_id'
-  | 'usuario'
-  | 'activo'
-  | 'cliente'
-  | 'conductor'
-  | 'eventos';
+export const CreateEnvioVehiculoSchema = EnvioVehiculoSchema.omit({
+  _id: true,
+  usuario: true,
+  activo: true,
+  cliente: true,
+  conductor: true,
+  eventos: true,
+});
+export type ICreateEnvioVehiculo = z.infer<typeof CreateEnvioVehiculoSchema>;
 
-export interface ICreateEnvioVehiculo
-  extends Omit<Partial<IEnvioVehiculo>, OmitirCreate> {}
-
-type OmitirUpdate =
-  | '_id'
-  | 'usuario'
-  | 'activo'
-  | 'cliente'
-  | 'conductor'
-  | 'eventos';
-
-export interface IUpdateEnvioVehiculo
-  extends Omit<Partial<IEnvioVehiculo>, OmitirUpdate> {}
+export const UpdateEnvioVehiculoSchema = EnvioVehiculoSchema.omit({
+  _id: true,
+  usuario: true,
+  activo: true,
+  cliente: true,
+  conductor: true,
+  eventos: true,
+});
+export type IUpdateEnvioVehiculo = z.infer<typeof UpdateEnvioVehiculoSchema>;

--- a/src/interfaces/estado-entidad.ts
+++ b/src/interfaces/estado-entidad.ts
@@ -1,10 +1,41 @@
-import { ICliente } from './cliente';
-import { IDispositivoAlarma } from './dispositivo-alarma';
-import { ITracker } from './tracker';
-import { IUsuario } from './usuario';
+import { z } from 'zod';
+import { ClienteSchema, ICliente } from './cliente';
+import type { IDispositivoAlarma } from './dispositivo-alarma';
+import type { ITracker } from './tracker';
+import type { IUsuario } from './usuario';
 
-export type estadoCuenta = 'Habilitado' | 'Suspendido';
+// Nota: no se llama EstadoCuentaSchema porque cliente.ts ya exporta ese nombre
+// (para el type EstadoCuenta) y el barrel `export *` daría TS2308.
+export const EstadoCuentaEntidadSchema = z.enum(['Habilitado', 'Suspendido']);
+export type estadoCuenta = z.infer<typeof EstadoCuentaEntidadSchema>;
 
+// Populates intra-SCC como z.custom (import type-only): un schema real acá
+// arrastra el shape completo del ciclo tracker↔activo↔usuario↔permiso↔alarma
+// y revienta la serialización de declarations (TS7056) en este paquete y en
+// los consumidores NestJS (compilan este fuente con declaration: true).
+export const EstadoEntidadSchema = z.object({
+  _id: z.string().optional(),
+  fechaCreacion: z.string().optional(),
+  estado: EstadoCuentaEntidadSchema.optional(),
+  idEntidad: z.string().optional(), /// POR DISPOSITIVO
+  idCliente: z.string().optional(),
+  idsAncestros: z.array(z.string()).optional(),
+  idUsuario: z.string().optional(),
+  nota: z.string().optional(),
+  motivos: z.array(z.string()).optional(),
+  vigencia: z.string().optional(), // Desde cuando se aplica el estado
+  // Populate
+  cliente: ClienteSchema.optional(),
+  ancestros: z.array(ClienteSchema).optional(),
+  usuario: z.custom<IUsuario>().optional(),
+  alarma: z.custom<IDispositivoAlarma>().optional(),
+  tracker: z.custom<ITracker>().optional(),
+});
+
+/**
+ * Interface hand-written (misma forma que el schema): los tipos de entidad del
+ * SCC no usan z.infer porque los ciclos de aliases mutuos disparan TS2589.
+ */
 export interface IEstadoEntidad {
   _id?: string;
   fechaCreacion?: string;
@@ -26,8 +57,22 @@ export interface IEstadoEntidad {
 
 type Omitir = '_id' | 'cliente' | 'usuario' | 'alarma' | 'tracker';
 
+export const CreateEstadoEntidadSchema = EstadoEntidadSchema.omit({
+  _id: true,
+  cliente: true,
+  usuario: true,
+  alarma: true,
+  tracker: true,
+});
 export interface ICreateEstadoEntidad
   extends Omit<Partial<IEstadoEntidad>, Omitir> {}
 
+export const UpdateEstadoEntidadSchema = EstadoEntidadSchema.omit({
+  _id: true,
+  cliente: true,
+  usuario: true,
+  alarma: true,
+  tracker: true,
+});
 export interface IUpdateEstadoEntidad
   extends Omit<Partial<IEstadoEntidad>, Omitir> {}

--- a/src/interfaces/evento-generico.ts
+++ b/src/interfaces/evento-generico.ts
@@ -1,22 +1,124 @@
 // evento-generico.ts
 import { IEntidades } from './asignacion';
-import { ICliente, IConfigHorario } from './cliente';
-import { ITracker } from './tracker';
-import { IDispositivoAlarma, ModoArmadoUnicom } from './dispositivo-alarma';
-import { IActivo } from './activo';
-import { IConfigEventoUsuario } from './config-evento-usuario';
-import { SonidoEvento } from './categoria-evento';
-import { IUsuario } from './usuario';
-import { ILuminaria } from './luminaria';
-import { IBotonBluetooth } from './boton-bluetooth';
-import { IReporteGenerico } from './reporte-generico';
-import { IDestinatarioAsistencia } from './destinatario-asistencia';
-import { IEmergencia } from './emergencias';
-import { IPersonalSalud } from './personal-salud';
-import { IGeoJSONPoint } from '../auxiliares';
-import { ISirena } from './sirena';
-import { IUbicacion } from './ubicacion';
-import { IGateway } from './gateway';
+import { z } from 'zod';
+import { ClienteSchema, ConfigHorarioSchema, ICliente, IConfigHorario } from './cliente';
+import type { ITracker } from './tracker';
+import { ModoArmadoUnicomSchema } from './dispositivo-alarma';
+import type { IDispositivoAlarma } from './dispositivo-alarma';
+import type { IActivo } from './activo';
+import type { IConfigEventoUsuario } from './config-evento-usuario';
+import { SonidoEventoSchema } from './categoria-evento';
+import type { IUsuario } from './usuario';
+import type { ILuminaria } from './luminaria';
+import { BotonBluetoothSchema, IBotonBluetooth } from './boton-bluetooth';
+import type { IReporteGenerico } from './reporte-generico';
+import type { IDestinatarioAsistencia } from './destinatario-asistencia';
+import type { IEmergencia } from './emergencias';
+import { PersonalSaludSchema, IPersonalSalud } from './personal-salud';
+import { GeoJSONPointSchema } from '../auxiliares';
+import { SirenaSchema, ISirena } from './sirena';
+import type { IUbicacion } from './ubicacion';
+import { GatewaySchema, IGateway } from './gateway';
+
+/* ────────────────────────────────────────────────
+ *  TIPOS DE EVENTO (DISCRIMINANTE)
+ * ────────────────────────────────────────────────*/
+
+export const TipoEventoGenericoSchema = z.enum([
+  'Evento Colectivo',
+  'Evento Activo',
+  'Evento Tracker',
+  'Evento Vehiculo',
+  'Evento Alarma',
+  'Evento Luminaria',
+  'Evento Gateway',
+  'Evento BotonBLE',
+  'Evento Sirena',
+  'Evento Técnico Alarma',
+  'Evento Técnico Tracker',
+  'Evento Técnico Vehículo',
+  'Evento Técnico Luminaria',
+  'Evento Técnico Sirena',
+  'Evento Técnico Gateway',
+  'Evento Emergencia Médica',
+  'Evento Emergencia Bomberos',
+]);
+export type TipoEventoGenerico = z.infer<typeof TipoEventoGenericoSchema>;
+
+/* ────────────────────────────────────────────────
+ *  CATEGORIAS
+ * ────────────────────────────────────────────────*/
+export const CategoriaSchema = z.enum([
+  'Evento', // Eventos operacionales que pueden ser atendidos. (colectivos, activos, trackers, vehículos, alarmas, luminarias, botón BLE, gateways)
+  'Servicio Técnico', // Eventos técnicos (alarma, tracker, luminaria)
+  'Seguimiento Emergencia', // Eventos de emergencia (médica, bomberos)
+  'Verificación', // Eventos de verificación (subir fotos y notas de entidades particulares)
+]);
+export type Categoria = z.infer<typeof CategoriaSchema>;
+
+/* ────────────────────────────────────────────────
+ *  Auxiliares
+ * ────────────────────────────────────────────────*/
+export const RangoHorarioSchema = z.object({
+  dias: z.array(z.string()).optional(), // ['Lunes', 'Martes', ...]
+  horarioDesde: z.string().optional(), // '08:00'
+  horarioHasta: z.string().optional(), // '18:00'
+});
+export type RangoHorario = z.infer<typeof RangoHorarioSchema>;
+
+export const CategoriaTecnicaSchema = z.enum([
+  'Alarma',
+  'Tracker',
+  'Vehículo',
+  'Luminaria',
+  'Sirena',
+  'Gateway',
+]);
+export type CategoriaTecnica = z.infer<typeof CategoriaTecnicaSchema>;
+
+export const EstadoEventoTecnicoSchema = z.enum([
+  'Pendiente',
+  'Asignado',
+  'En Atención',
+  'Pendiente de Aprobación',
+  'Firma Cliente',
+  'Finalizado',
+]);
+export type estadoEventoTecnico = z.infer<typeof EstadoEventoTecnicoSchema>;
+
+export const EstadoEventoSchema = z.enum([
+  'Sin Tratamiento',
+  'Pendiente',
+  'En Atención',
+  'En Espera',
+  'Liberada',
+  'Finalizada',
+]);
+export type estadoEvento = z.infer<typeof EstadoEventoSchema>;
+
+export const EstadoEmergenciaMedicaSchema = z.enum([
+  'Pendiente', // Auxilio recién creado
+  'Asignada', // Se asignó vehículo/médico/enfermero
+  'Reasignada', //Se reasignó vehículo/médico/enfermero
+  'En tránsito', // El vehículo salió del centro
+  'Llegó a destino', // El vehículo llegó al lugar de la emergencia
+  'Rumbo a hospital', // El vehículo sale hacia el hospital
+  'Llegada a hospital', //El vehículo Llegó al hospital
+  'Finalizada', // La emergencia fue tratada. Ya sea porque se llegó al hospital o no
+  'Cancelada', // La emergencia se canceló
+]);
+export type EstadoEmergenciaMedica = z.infer<typeof EstadoEmergenciaMedicaSchema>;
+
+export const EstadoEmergenciaBomberosSchema = z.enum([
+  'Pendiente', // Auxilio recién creado
+  'Asignada', // Se asignó vehículo
+  'Reasignada', //Se reasignó vehículo
+  'En tránsito', // El vehículo salió del centro
+  'Llegó a destino', // El vehículo llegó al lugar de la emergencia
+  'Finalizada', // La emergencia fue tratada
+  'Cancelada', // La emergencia se canceló
+]);
+export type EstadoEmergenciaBomberos = z.infer<typeof EstadoEmergenciaBomberosSchema>;
 
 /* ────────────────────────────────────────────────
  *  ALIAS DE TIPOS EXISTENTES
@@ -28,184 +130,181 @@ export type EstadoEventoEmergencia =
   | EstadoEmergenciaMedica
   | EstadoEmergenciaBomberos;
 
-/* ────────────────────────────────────────────────
- *  TIPOS DE EVENTO (DISCRIMINANTE)
- * ────────────────────────────────────────────────*/
+export const EstadoEventoEmergenciaSchema = z.union([
+  EstadoEmergenciaMedicaSchema,
+  EstadoEmergenciaBomberosSchema,
+]);
 
-export type TipoEventoGenerico =
-  | 'Evento Colectivo'
-  | 'Evento Activo'
-  | 'Evento Tracker'
-  | 'Evento Vehiculo'
-  | 'Evento Alarma'
-  | 'Evento Luminaria'
-  | 'Evento Gateway'
-  | 'Evento BotonBLE'
-  | 'Evento Sirena'
-  | 'Evento Técnico Alarma'
-  | 'Evento Técnico Tracker'
-  | 'Evento Técnico Vehículo'
-  | 'Evento Técnico Luminaria'
-  | 'Evento Técnico Sirena'
-  | 'Evento Técnico Gateway'
-  | 'Evento Emergencia Médica'
-  | 'Evento Emergencia Bomberos';
+export const ContactIDSchema = z.object({
+  numeroCuenta: z.string().optional(),
+  tipoMensaje: z.string().optional(),
+  calificadorDeEvento: z.string().optional(),
+  codigoDeEvento: z.string().optional(),
+  numeroDeParticion: z.string().optional(),
+  numeroDeZona: z.string().optional(),
+  checksum: z.string().optional(),
+});
+export type IContactID = z.infer<typeof ContactIDSchema>;
 
-/* ────────────────────────────────────────────────
- *  CATEGORIAS
- * ────────────────────────────────────────────────*/
-export type Categoria =
-  | 'Evento' // Eventos operacionales que pueden ser atendidos. (colectivos, activos, trackers, vehículos, alarmas, luminarias, botón BLE, gateways)
-  | 'Servicio Técnico' // Eventos técnicos (alarma, tracker, luminaria)
-  | 'Seguimiento Emergencia' // Eventos de emergencia (médica, bomberos)
-  | 'Verificación'; // Eventos de verificación (subir fotos y notas de entidades particulares)
-
-/* ────────────────────────────────────────────────
- *  Auxiliares
- * ────────────────────────────────────────────────*/
-export interface RangoHorario {
-  dias?: string[]; // ['Lunes', 'Martes', ...]
-  horarioDesde?: string; // '08:00'
-  horarioHasta?: string; // '18:00'
-}
-
-export type CategoriaTecnica =
-  | 'Alarma'
-  | 'Tracker'
-  | 'Vehículo'
-  | 'Luminaria'
-  | 'Sirena'
-  | 'Gateway';
-
-export type estadoEventoTecnico =
-  | 'Pendiente'
-  | 'Asignado'
-  | 'En Atención'
-  | 'Pendiente de Aprobación'
-  | 'Firma Cliente'
-  | 'Finalizado';
-
-export type estadoEvento =
-  | 'Sin Tratamiento'
-  | 'Pendiente'
-  | 'En Atención'
-  | 'En Espera'
-  | 'Liberada'
-  | 'Finalizada';
-
-export type EstadoEmergenciaMedica =
-  | 'Pendiente' // Auxilio recién creado
-  | 'Asignada' // Se asignó vehículo/médico/enfermero
-  | 'Reasignada' //Se reasignó vehículo/médico/enfermero
-  | 'En tránsito' // El vehículo salió del centro
-  | 'Llegó a destino' // El vehículo llegó al lugar de la emergencia
-  | 'Rumbo a hospital' // El vehículo sale hacia el hospital
-  | 'Llegada a hospital' //El vehículo Llegó al hospital
-  | 'Finalizada' // La emergencia fue tratada. Ya sea porque se llegó al hospital o no
-  | 'Cancelada'; // La emergencia se canceló
-
-export type EstadoEmergenciaBomberos =
-  | 'Pendiente' // Auxilio recién creado
-  | 'Asignada' // Se asignó vehículo
-  | 'Reasignada' //Se reasignó vehículo
-  | 'En tránsito' // El vehículo salió del centro
-  | 'Llegó a destino' // El vehículo llegó al lugar de la emergencia
-  | 'Finalizada' // La emergencia fue tratada
-  | 'Cancelada'; // La emergencia se canceló
-
-export interface IContactID {
-  numeroCuenta?: string;
-  tipoMensaje?: string;
-  calificadorDeEvento?: string;
-  codigoDeEvento?: string;
-  numeroDeParticion?: string;
-  numeroDeZona?: string;
-  checksum?: string;
-}
 /* ────────────────────────────────────────────────
  *  VALORES ESPECÍFICOS POR TIPO DE EVENTO
  * ────────────────────────────────────────────────*/
 
 // IValoresEventoOperacional
 // Separar en Alarmas - Trackers (Colectivos/Activos/Vehículos) - Luminarias
-export interface IValoresEventoBase {
-  titulo?: string;
-  mensaje?: string;
-  color?: string;
-  sonido?: SonidoEvento;
-}
+export const ValoresEventoBaseSchema = z.object({
+  titulo: z.string().optional(),
+  mensaje: z.string().optional(),
+  color: z.string().optional(),
+  sonido: SonidoEventoSchema.optional(),
+});
+export type IValoresEventoBase = z.infer<typeof ValoresEventoBaseSchema>;
 
-export interface IValoresEventoTracker extends IValoresEventoBase {
-  geojson?: IGeoJSONPoint;
-  codigoTracker?: string;
-  direccion?: string; // Coordenadas traducidas a dirección legible
-}
+export const ValoresEventoTrackerSchema = ValoresEventoBaseSchema.extend({
+  geojson: GeoJSONPointSchema.optional(),
+  codigoTracker: z.string().optional(),
+  direccion: z.string().optional(), // Coordenadas traducidas a dirección legible
+});
+export type IValoresEventoTracker = z.infer<typeof ValoresEventoTrackerSchema>;
 
-export interface IValoresEventoAlarma extends IValoresEventoBase {
-  contactId?: IContactID;
-  codigoAlarma?: string;
-  codigoComunicador?: string;
-  tiposEvento?: ('Armado' | 'Desarmado' | 'Detonación' | 'Test')[];
+export const ValoresEventoAlarmaSchema = ValoresEventoBaseSchema.extend({
+  contactId: ContactIDSchema.optional(),
+  codigoAlarma: z.string().optional(),
+  codigoComunicador: z.string().optional(),
+  tiposEvento: z
+    .array(z.enum(['Armado', 'Desarmado', 'Detonación', 'Test']))
+    .optional(),
   // Usuario que generó el armado/desarmado. Ausentes si no se pudo resolver
   // (armado rápido/llave/automático, zona sin contacto configurado, eventos históricos).
-  idUsuario?: string; // Solo si se resolvió a un IUsuario de la plataforma
-  usuario?: string; // Nombre ya resuelto (denormalizado): IUsuario, contacto del panel o "Usuario N"
+  idUsuario: z.string().optional(), // Solo si se resolvió a un IUsuario de la plataforma
+  usuario: z.string().optional(), // Nombre ya resuelto (denormalizado): IUsuario, contacto del panel o "Usuario N"
   // UNICOM (additive): datos crudos del evento MQTT para trazabilidad/diagnóstico.
-  cidUnicom?: string; // "<estado> <opcode>" original, ej. "3 407"
-  opcodeUnicom?: string; // opcode del cid, ej. "407"
-  modoArmado?: ModoArmadoUnicom; // si el evento es de armado/desarmado
-  idSensor?: number; // índice del sensor en reportes 1 606 / disparos 1 134
-  crf?: string; // 8 hex del reporte de sensor (código RF + attr)
-}
+  cidUnicom: z.string().optional(), // "<estado> <opcode>" original, ej. "3 407"
+  opcodeUnicom: z.string().optional(), // opcode del cid, ej. "407"
+  // ModoArmadoUnicomSchema es un z.enum chico y dispositivo-alarma (V2) ya no
+  // importa valores intra-SCC → import de valor sin ciclo runtime.
+  modoArmado: ModoArmadoUnicomSchema.optional(), // si el evento es de armado/desarmado
+  idSensor: z.number().optional(), // índice del sensor en reportes 1 606 / disparos 1 134
+  crf: z.string().optional(), // 8 hex del reporte de sensor (código RF + attr)
+});
+export type IValoresEventoAlarma = z.infer<typeof ValoresEventoAlarmaSchema>;
 
-export interface IValoresEventoLuminaria extends IValoresEventoBase {
-  geojson?: IGeoJSONPoint;
-}
+export const ValoresEventoLuminariaSchema = ValoresEventoBaseSchema.extend({
+  geojson: GeoJSONPointSchema.optional(),
+});
+export type IValoresEventoLuminaria = z.infer<typeof ValoresEventoLuminariaSchema>;
 
-export interface IValoresEventoBotonBLE extends IValoresEventoBase {
-  geojson?: IGeoJSONPoint;
-}
+export const ValoresEventoBotonBLESchema = ValoresEventoBaseSchema.extend({
+  geojson: GeoJSONPointSchema.optional(),
+});
+export type IValoresEventoBotonBLE = z.infer<typeof ValoresEventoBotonBLESchema>;
 
-export interface IValoresEventoGateway extends IValoresEventoBase {
-  geojson?: IGeoJSONPoint;
-}
+export const ValoresEventoGatewaySchema = ValoresEventoBaseSchema.extend({
+  geojson: GeoJSONPointSchema.optional(),
+});
+export type IValoresEventoGateway = z.infer<typeof ValoresEventoGatewaySchema>;
 
-export interface IValoresEventoSirena extends IValoresEventoBase {
-  idSirena?: string;
-  chipId?: string;
-  origen?: 'APP' | 'Botón' | 'Monitoreo'; /// Pánico (APP) - Manual (Botón físico) - Monitoreo (¿Programado o algo así?)
-  efecto?: 'Reflector' | 'Sirena' | 'Pánico'; /// Reflector (Luz) - Sirena (Sonido) - Pánico (Luz y Sonido)
-  direccion?: string; // Dirección parseada de la sirena
-  idVecino?: string;
-  nombreVecino?: string;
-  telefono?: string; // Solo del vecino
-  idUsuario?: string; // Si viene de monitoreo
-  usuario?: string; // Si viene de monitoreo
-  geojson?: IGeoJSONPoint; /// Ubicación del vecino cuando es APP Sirena en lkos otros casos.
-}
+export const ValoresEventoSirenaSchema = ValoresEventoBaseSchema.extend({
+  idSirena: z.string().optional(),
+  chipId: z.string().optional(),
+  origen: z.enum(['APP', 'Botón', 'Monitoreo']).optional(), /// Pánico (APP) - Manual (Botón físico) - Monitoreo (¿Programado o algo así?)
+  efecto: z.enum(['Reflector', 'Sirena', 'Pánico']).optional(), /// Reflector (Luz) - Sirena (Sonido) - Pánico (Luz y Sonido)
+  direccion: z.string().optional(), // Dirección parseada de la sirena
+  idVecino: z.string().optional(),
+  nombreVecino: z.string().optional(),
+  telefono: z.string().optional(), // Solo del vecino
+  idUsuario: z.string().optional(), // Si viene de monitoreo
+  usuario: z.string().optional(), // Si viene de monitoreo
+  geojson: GeoJSONPointSchema.optional(), /// Ubicación del vecino cuando es APP Sirena en lkos otros casos.
+});
+export type IValoresEventoSirena = z.infer<typeof ValoresEventoSirenaSchema>;
 
 // Valores para eventos técnicos
-export interface IValoresEventoTecnico extends IValoresEventoBase {
-  categoria?: CategoriaTecnica;
-  solicitante?: {
-    nombre?: string;
-    telefono?: string;
-    email?: string;
-  };
-  disponibilidad?: RangoHorario[];
-  prioridad?: 'Normal' | 'Alta' | 'Urgente';
-  numeroIncidente?: string; // Random cuando se crea.
-}
+export const ValoresEventoTecnicoSchema = ValoresEventoBaseSchema.extend({
+  categoria: CategoriaTecnicaSchema.optional(),
+  solicitante: z
+    .object({
+      nombre: z.string().optional(),
+      telefono: z.string().optional(),
+      email: z.string().optional(),
+    })
+    .optional(),
+  disponibilidad: z.array(RangoHorarioSchema).optional(),
+  prioridad: z.enum(['Normal', 'Alta', 'Urgente']).optional(),
+  numeroIncidente: z.string().optional(), // Random cuando se crea.
+});
+export type IValoresEventoTecnico = z.infer<typeof ValoresEventoTecnicoSchema>;
 
 // Valores para eventos de emergencia
-export interface IValoresEventoEmergencia extends IValoresEventoBase {
-  ubicacionActual?: IGeoJSONPoint; //Es la ubicación donde se generó el evento. Cuando se crea la emergencia, el primer evento no tiene ubicación porque no tiene ninguna ambulancia asignada
-  direccionActual?: string;
-  motivoCancelacion?: string;
-  motivoReasignacion?: string;
-  observaciones?: string;
-  diagnostico?: string;
-}
+export const ValoresEventoEmergenciaSchema = ValoresEventoBaseSchema.extend({
+  ubicacionActual: GeoJSONPointSchema.optional(), //Es la ubicación donde se generó el evento. Cuando se crea la emergencia, el primer evento no tiene ubicación porque no tiene ninguna ambulancia asignada
+  direccionActual: z.string().optional(),
+  motivoCancelacion: z.string().optional(),
+  motivoReasignacion: z.string().optional(),
+  observaciones: z.string().optional(),
+  diagnostico: z.string().optional(),
+});
+export type IValoresEventoEmergencia = z.infer<typeof ValoresEventoEmergenciaSchema>;
+
+/* ────────────────────────────────────────────────
+ *  DETALLES (sub-objetos con populates)
+ * ────────────────────────────────────────────────*/
+
+/** Cambio de entidad propuesto por el técnico durante la atención de un servicio
+ *  técnico. Ej: cambio de nodo de una luminaria. Se aplica recién cuando
+ *  administración aprueba (finaliza) el evento. */
+export const CambioEntidadPropuestoSchema = z.object({
+  tipoEntidad: z.custom<IEntidades>().optional(),
+  idEntidadAnterior: z.string().optional(),
+  idEntidadNueva: z.string().optional(),
+  aplicado: z.boolean().optional(), // false hasta que administración aprueba
+  fechaAplicado: z.string().optional(),
+});
+export type CambioEntidadPropuesto = z.infer<
+  typeof CambioEntidadPropuestoSchema
+>;
+
+// Populates intra-SCC como z.custom (import type-only): un schema real acá
+// arrastra el shape completo del ciclo y revienta la serialización de
+// declarations (TS7056) acá y en los consumidores NestJS.
+export const DetallesTecnicosSchema = z.object({
+  idTecnicoAsignado: z.string().optional(),
+  fechaDisponibleParaTratar: z.string().optional(),
+  cambioEntidadPropuesto: CambioEntidadPropuestoSchema.optional(),
+
+  // Populate opcional
+  tecnico: z.custom<IUsuario>().optional(),
+});
+export type DetallesTecnicos = z.infer<typeof DetallesTecnicosSchema>;
+
+export const DetallesEmergenciasSchema = z.object({
+  // Ubicaciones
+  idEmergencia: z.string().optional(),
+  idCentroDeAtencion: z.string().optional(),
+  idHospital: z.string().optional(),
+
+  // Cosas que deberían ser usuarios, pero algunas no lo son.
+  idDestinatarioAsistencia: z.string().optional(),
+  idChofer: z.string().optional(),
+  idMovilUsuario: z.string().optional(),
+  idsMedicos: z.array(z.string()).optional(),
+  idsEnfermeros: z.array(z.string()).optional(),
+  idUsuarioResponsable: z.string().optional(),
+  idMovilAsignado: z.string().optional(),
+
+  // Populate opcional
+  destinatarioAsistencia: z.custom<IDestinatarioAsistencia>().optional(),
+  emergencia: z.custom<IEmergencia>().optional(),
+  chofer: z.custom<IUsuario>().optional(),
+  centroDeAtencion: z.custom<IUbicacion>().optional(),
+  movilUsuario: z.custom<IUsuario>().optional(),
+  medicos: z.array(PersonalSaludSchema).optional(),
+  enfermeros: z.array(PersonalSaludSchema).optional(),
+  hospital: z.custom<IUbicacion>().optional(),
+  usuarioResponsable: z.custom<IUsuario>().optional(),
+  movilAsignado: z.custom<IActivo>().optional(),
+});
+export type DetallesEmergencias = z.infer<typeof DetallesEmergenciasSchema>;
 
 /* ────────────────────────────────────────────────
  *  MAPA DE TIPOS DE EVENTO → VALORES Y ESTADO
@@ -285,6 +384,9 @@ export type MapaEventoGenerico = {
 
 /* ────────────────────────────────────────────────
  *  BASE DEL EVENTO (GENÉRICO)
+ *
+ *  Tipo legacy hand-written: el discriminante `tipoEvento` es OPCIONAL acá,
+ *  pero REQUERIDO en los schemas Zod de abajo. Por eso NO se deriva con z.infer.
  * ────────────────────────────────────────────────*/
 
 export interface IEventoBaseGenerico<T extends keyof MapaEventoGenerico> {
@@ -346,53 +448,6 @@ export interface IEventoBaseGenerico<T extends keyof MapaEventoGenerico> {
   reporte?: IReporteGenerico;
   configEventoUsuario?: IConfigEventoUsuario;
 }
-
-/** Cambio de entidad propuesto por el técnico durante la atención de un servicio
- *  técnico. Ej: cambio de nodo de una luminaria. Se aplica recién cuando
- *  administración aprueba (finaliza) el evento. */
-export type CambioEntidadPropuesto = {
-  tipoEntidad?: IEntidades;
-  idEntidadAnterior?: string;
-  idEntidadNueva?: string;
-  aplicado?: boolean; // false hasta que administración aprueba
-  fechaAplicado?: string;
-};
-
-export type DetallesTecnicos = {
-  idTecnicoAsignado?: string;
-  fechaDisponibleParaTratar?: string;
-  cambioEntidadPropuesto?: CambioEntidadPropuesto;
-  // Populate opcional
-  tecnico?: IUsuario;
-};
-
-export type DetallesEmergencias = {
-  // Ubicaciones
-  idEmergencia?: string;
-  idCentroDeAtencion?: string;
-  idHospital?: string;
-
-  // Cosas que deberían ser usuarios, pero algunas no lo son.
-  idDestinatarioAsistencia?: string;
-  idChofer?: string;
-  idMovilUsuario?: string;
-  idsMedicos?: string[];
-  idsEnfermeros?: string[];
-  idUsuarioResponsable?: string;
-  idMovilAsignado?: string;
-
-  // Populate opcional
-  destinatarioAsistencia?: IDestinatarioAsistencia;
-  emergencia?: IEmergencia;
-  chofer?: IUsuario;
-  centroDeAtencion?: IUbicacion;
-  movilUsuario?: IUsuario;
-  medicos?: IPersonalSalud[];
-  enfermeros?: IPersonalSalud[];
-  hospital?: IUbicacion;
-  usuarioResponsable?: IUsuario;
-  movilAsignado?: IActivo;
-};
 
 /* ────────────────────────────────────────────────
  *  TIPO DISCRIMINADO (TYPE-SAFE) - READ
@@ -544,22 +599,30 @@ export type IUpdateEventoGenerico =
  *  ATENCIÓN (arrays idsUsuariosAtendiendo / idsClientesAtendiendo)
  * ────────────────────────────────────────────────*/
 
-export type AccionAtencionEvento = 'atender' | 'desatender' | 'limpiar';
+export const AccionAtencionEventoSchema = z.enum([
+  'atender',
+  'desatender',
+  'limpiar',
+]);
+export type AccionAtencionEvento = z.infer<typeof AccionAtencionEventoSchema>;
 
 /** Body de PUT /eventos-genericos/:id/atencion (api-datos).
  *  Actualiza estado + arrays de atención en una sola operación atómica
  *  ($addToSet/$pull), sin ventana de carrera entre operadores. */
-export interface IActualizarAtencionEventoGenerico {
-  accion: AccionAtencionEvento;
-  idUsuario: string;
-  idCliente: string;
-  estado: EstadoEvento;
+export const ActualizarAtencionEventoGenericoSchema = z.object({
+  accion: AccionAtencionEventoSchema,
+  idUsuario: z.string(),
+  idCliente: z.string(),
+  estado: EstadoEventoSchema,
   /** Solo para 'limpiar' (En Espera) */
-  posponerHasta?: string;
+  posponerHasta: z.string().optional(),
   /** Solo para 'atender': si es true, falla con 409 si otro usuario ya está
    *  atendiendo (lock de atención única). */
-  exclusivo?: boolean;
-}
+  exclusivo: z.boolean().optional(),
+});
+export type IActualizarAtencionEventoGenerico = z.infer<
+  typeof ActualizarAtencionEventoGenericoSchema
+>;
 
 /* ────────────────────────────────────────────────
  *  TIPO CACHE (SIN POPULATE)
@@ -598,3 +661,180 @@ export type IEventoGenericoCache = Omit<
     | 'usuarioResponsable'
   >;
 };
+
+/* ────────────────────────────────────────────────
+ *  SCHEMAS ZOD (nuevos, discriminante REQUERIDO)
+ *
+ *  Para validación runtime y JSON Schema de datos nuevos. A diferencia de los
+ *  tipos legacy de arriba, acá `tipoEvento` es obligatorio (z.discriminatedUnion
+ *  lo exige). Los populates hacia el SCC van como getters (ciclo de imports);
+ *  `reporte` usa z.custom para conservar el tipo legacy IReporteGenerico.
+ * ────────────────────────────────────────────────*/
+
+// Populates intra-SCC como z.custom (import type-only) — ver comentario en
+// DetallesTecnicosSchema. Sin getters, el objeto es spreadeable.
+const camposComunesEvento = {
+  _id: z.string().optional(),
+  fechaCreacion: z.string().optional(),
+  expireAt: z.string().optional(),
+  idCliente: z.string().optional(),
+  idsAncestros: z.array(z.string()).optional(),
+  filtrador: CategoriaSchema.optional(), // Para las vistas de atender
+  notificar: z.boolean().optional(),
+  atender: z.boolean().optional(),
+  /** Derivado en backend (hooks): atender===true && estado en estados activos. */
+  requiereAtencion: z.boolean().optional(),
+  noDerivar: z.boolean().optional(),
+  posponerHasta: z.string().optional(),
+  categoria: z.string().optional(), // Nombre de la categoria del tipo de evento
+  prioridad: z.number().optional(),
+  repetido: z.number().optional(),
+  fechaUltimoRepetido: z.string().optional(),
+  tiempoRespuesta: z.number().optional(),
+  idEntidad: z.string().optional(), // Lo que generó el evento
+  idReporte: z.string().optional(), // En caso de ser un evento generado por un reporte automático
+  idConfigEventoUsuario: z.string().optional(),
+  detallesTecnicos: DetallesTecnicosSchema.optional(),
+  detallesEmergencias: DetallesEmergenciasSchema.optional(),
+  idsClientesQuePuedenAtender: z.array(z.string()).optional(),
+  configHorariosAtencion: z.array(ConfigHorarioSchema).optional(),
+  idsClientesAtendiendo: z.array(z.string()).optional(),
+  idsUsuariosAtendiendo: z.array(z.string()).optional(),
+  // Populates fuera del SCC (directas)
+  cliente: ClienteSchema.optional(),
+  ancestros: z.array(ClienteSchema).optional(),
+  botonBluetooth: BotonBluetoothSchema.optional(),
+  sirena: SirenaSchema.optional(),
+  gateway: GatewaySchema.optional(),
+  // Populates intra-SCC → z.custom
+  usuariosAtendiendo: z.array(z.custom<IUsuario>()).optional(),
+  tracker: z.custom<ITracker>().optional(),
+  alarma: z.custom<IDispositivoAlarma>().optional(),
+  luminaria: z.custom<ILuminaria>().optional(),
+  usuario: z.custom<IUsuario>().optional(),
+  activo: z.custom<IActivo>().optional(),
+  configEventoUsuario: z.custom<IConfigEventoUsuario>().optional(),
+  // Tipo legacy con discriminante opcional → z.custom conserva compatibilidad
+  reporte: z.custom<IReporteGenerico>().optional(),
+};
+
+const varianteEvento = <
+  T extends TipoEventoGenerico,
+  V extends z.ZodTypeAny,
+  E extends z.ZodTypeAny,
+>(
+  tipo: T,
+  valores: V,
+  estado: E,
+) =>
+  z.object({
+    ...camposComunesEvento,
+    tipoEvento: z.literal(tipo),
+    estado: estado.optional(),
+    valores: valores.optional(),
+  });
+
+const vEvtColectivo = varianteEvento('Evento Colectivo', ValoresEventoTrackerSchema, EstadoEventoSchema);
+const vEvtActivo = varianteEvento('Evento Activo', ValoresEventoTrackerSchema, EstadoEventoSchema);
+const vEvtTracker = varianteEvento('Evento Tracker', ValoresEventoTrackerSchema, EstadoEventoSchema);
+const vEvtVehiculo = varianteEvento('Evento Vehiculo', ValoresEventoTrackerSchema, EstadoEventoSchema);
+const vEvtAlarma = varianteEvento('Evento Alarma', ValoresEventoAlarmaSchema, EstadoEventoSchema);
+const vEvtLuminaria = varianteEvento('Evento Luminaria', ValoresEventoLuminariaSchema, EstadoEventoSchema);
+const vEvtGateway = varianteEvento('Evento Gateway', ValoresEventoGatewaySchema, EstadoEventoSchema);
+const vEvtBotonBLE = varianteEvento('Evento BotonBLE', ValoresEventoBotonBLESchema, EstadoEventoSchema);
+const vEvtSirena = varianteEvento('Evento Sirena', ValoresEventoSirenaSchema, EstadoEventoSchema);
+const vEvtTecAlarma = varianteEvento('Evento Técnico Alarma', ValoresEventoTecnicoSchema, EstadoEventoTecnicoSchema);
+const vEvtTecTracker = varianteEvento('Evento Técnico Tracker', ValoresEventoTecnicoSchema, EstadoEventoTecnicoSchema);
+const vEvtTecVehiculo = varianteEvento('Evento Técnico Vehículo', ValoresEventoTecnicoSchema, EstadoEventoTecnicoSchema);
+const vEvtTecLuminaria = varianteEvento('Evento Técnico Luminaria', ValoresEventoTecnicoSchema, EstadoEventoTecnicoSchema);
+const vEvtTecSirena = varianteEvento('Evento Técnico Sirena', ValoresEventoTecnicoSchema, EstadoEventoTecnicoSchema);
+const vEvtTecGateway = varianteEvento('Evento Técnico Gateway', ValoresEventoTecnicoSchema, EstadoEventoTecnicoSchema);
+const vEvtEmergenciaMedica = varianteEvento('Evento Emergencia Médica', ValoresEventoEmergenciaSchema, EstadoEmergenciaMedicaSchema);
+const vEvtEmergenciaBomberos = varianteEvento('Evento Emergencia Bomberos', ValoresEventoEmergenciaSchema, EstadoEmergenciaBomberosSchema);
+
+// Anotación explícita: el tipo inferido de una discriminated union de 17
+// variantes (cada una embebiendo ClienteSchema) excede el límite de
+// serialización de declarations (TS7056). z.ZodType<tipo legacy> es honesto
+// (el parse devuelve esa forma) y se emite por referencia.
+export const EventoGenericoSchema: z.ZodType<IEventoGenerico> =
+  z.discriminatedUnion('tipoEvento', [
+  vEvtColectivo,
+  vEvtActivo,
+  vEvtTracker,
+  vEvtVehiculo,
+  vEvtAlarma,
+  vEvtLuminaria,
+  vEvtGateway,
+  vEvtBotonBLE,
+  vEvtSirena,
+  vEvtTecAlarma,
+  vEvtTecTracker,
+  vEvtTecVehiculo,
+  vEvtTecLuminaria,
+  vEvtTecSirena,
+  vEvtTecGateway,
+  vEvtEmergenciaMedica,
+  vEvtEmergenciaBomberos,
+]);
+
+// Mismo set que el type OmitirCreate de arriba (sirena NO se omite, igual que el original)
+const omitirCreateUpdateEvento = {
+  _id: true,
+  idsAncestros: true,
+  requiereAtencion: true,
+  cliente: true,
+  ancestros: true,
+  usuariosAtendiendo: true,
+  tracker: true,
+  alarma: true,
+  luminaria: true,
+  usuario: true,
+  activo: true,
+  gateway: true,
+  botonBluetooth: true,
+  configEventoUsuario: true,
+  reporte: true,
+} as const;
+
+export const CreateEventoGenericoSchema: z.ZodType<ICreateEventoGenerico> =
+  z.discriminatedUnion('tipoEvento', [
+  vEvtColectivo.omit(omitirCreateUpdateEvento),
+  vEvtActivo.omit(omitirCreateUpdateEvento),
+  vEvtTracker.omit(omitirCreateUpdateEvento),
+  vEvtVehiculo.omit(omitirCreateUpdateEvento),
+  vEvtAlarma.omit(omitirCreateUpdateEvento),
+  vEvtLuminaria.omit(omitirCreateUpdateEvento),
+  vEvtGateway.omit(omitirCreateUpdateEvento),
+  vEvtBotonBLE.omit(omitirCreateUpdateEvento),
+  vEvtSirena.omit(omitirCreateUpdateEvento),
+  vEvtTecAlarma.omit(omitirCreateUpdateEvento),
+  vEvtTecTracker.omit(omitirCreateUpdateEvento),
+  vEvtTecVehiculo.omit(omitirCreateUpdateEvento),
+  vEvtTecLuminaria.omit(omitirCreateUpdateEvento),
+  vEvtTecSirena.omit(omitirCreateUpdateEvento),
+  vEvtTecGateway.omit(omitirCreateUpdateEvento),
+  vEvtEmergenciaMedica.omit(omitirCreateUpdateEvento),
+  vEvtEmergenciaBomberos.omit(omitirCreateUpdateEvento),
+]);
+
+// Update: parcial pero con el discriminante requerido de nuevo (patrón UpdatePermisoSchema de acceso-modelos)
+export const UpdateEventoGenericoSchema: z.ZodType<IUpdateEventoGenerico> =
+  z.discriminatedUnion('tipoEvento', [
+  vEvtColectivo.omit(omitirCreateUpdateEvento).partial().extend({ tipoEvento: z.literal('Evento Colectivo') }),
+  vEvtActivo.omit(omitirCreateUpdateEvento).partial().extend({ tipoEvento: z.literal('Evento Activo') }),
+  vEvtTracker.omit(omitirCreateUpdateEvento).partial().extend({ tipoEvento: z.literal('Evento Tracker') }),
+  vEvtVehiculo.omit(omitirCreateUpdateEvento).partial().extend({ tipoEvento: z.literal('Evento Vehiculo') }),
+  vEvtAlarma.omit(omitirCreateUpdateEvento).partial().extend({ tipoEvento: z.literal('Evento Alarma') }),
+  vEvtLuminaria.omit(omitirCreateUpdateEvento).partial().extend({ tipoEvento: z.literal('Evento Luminaria') }),
+  vEvtGateway.omit(omitirCreateUpdateEvento).partial().extend({ tipoEvento: z.literal('Evento Gateway') }),
+  vEvtBotonBLE.omit(omitirCreateUpdateEvento).partial().extend({ tipoEvento: z.literal('Evento BotonBLE') }),
+  vEvtSirena.omit(omitirCreateUpdateEvento).partial().extend({ tipoEvento: z.literal('Evento Sirena') }),
+  vEvtTecAlarma.omit(omitirCreateUpdateEvento).partial().extend({ tipoEvento: z.literal('Evento Técnico Alarma') }),
+  vEvtTecTracker.omit(omitirCreateUpdateEvento).partial().extend({ tipoEvento: z.literal('Evento Técnico Tracker') }),
+  vEvtTecVehiculo.omit(omitirCreateUpdateEvento).partial().extend({ tipoEvento: z.literal('Evento Técnico Vehículo') }),
+  vEvtTecLuminaria.omit(omitirCreateUpdateEvento).partial().extend({ tipoEvento: z.literal('Evento Técnico Luminaria') }),
+  vEvtTecSirena.omit(omitirCreateUpdateEvento).partial().extend({ tipoEvento: z.literal('Evento Técnico Sirena') }),
+  vEvtTecGateway.omit(omitirCreateUpdateEvento).partial().extend({ tipoEvento: z.literal('Evento Técnico Gateway') }),
+  vEvtEmergenciaMedica.omit(omitirCreateUpdateEvento).partial().extend({ tipoEvento: z.literal('Evento Emergencia Médica') }),
+  vEvtEmergenciaBomberos.omit(omitirCreateUpdateEvento).partial().extend({ tipoEvento: z.literal('Evento Emergencia Bomberos') }),
+]);

--- a/src/interfaces/excepcion.ts
+++ b/src/interfaces/excepcion.ts
@@ -1,36 +1,42 @@
-import { ICliente } from './cliente';
+import { z } from 'zod';
+import { ClienteSchema } from './cliente';
 
-export interface IExcepcion {
-  _id?: string;
-  fechaCreacion?: string;
-  idCliente?: string;
-  idsAncestros?: string[];
-  tipoEntidad?: 'Cliente' | 'Alarma';
-  idEntidad?: string;
-  tipoExcepcion?: 'Control Horario';
-  fechaDesde?: string;
-  fechaHasta?: string;
+export const ExcepcionSchema = z.object({
+  _id: z.string().optional(),
+  fechaCreacion: z.string().optional(),
+  idCliente: z.string().optional(),
+  idsAncestros: z.array(z.string()).optional(),
+  tipoEntidad: z.enum(['Cliente', 'Alarma']).optional(),
+  idEntidad: z.string().optional(),
+  tipoExcepcion: z.enum(['Control Horario']).optional(),
+  fechaDesde: z.string().optional(),
+  fechaHasta: z.string().optional(),
 
   // Populate
-  cliente?: ICliente;
-  ancestros?: ICliente[];
-}
+  cliente: ClienteSchema.optional(),
+  ancestros: z.array(ClienteSchema).optional(),
+});
+export type IExcepcion = z.infer<typeof ExcepcionSchema>;
 
-type OmitirCreate =
-  | '_id'
-  | 'idsAncestros'
+export const CreateExcepcionSchema = ExcepcionSchema.omit({
+  _id: true,
+  idsAncestros: true,
   //Virtuals
-  | 'cliente'
-  | 'ancestros';
+  cliente: true,
+  ancestros: true,
+});
+export type ICreateExcepcion = z.infer<typeof CreateExcepcionSchema>;
 
-export interface ICreateExcepcion
-  extends Omit<Partial<IExcepcion>, OmitirCreate> {}
+export const UpdateExcepcionSchema = ExcepcionSchema.omit({
+  _id: true,
+  idsAncestros: true,
+  cliente: true,
+  ancestros: true,
+});
+export type IUpdateExcepcion = z.infer<typeof UpdateExcepcionSchema>;
 
-type OmitirUpdate = '_id' | 'idsAncestros' | 'cliente' | 'ancestros';
-
-export interface IUpdateExcepcion
-  extends Omit<Partial<IExcepcion>, OmitirUpdate> {}
-
-type OmitirCache = 'cliente' | 'ancestros';
-
-export interface IExcepcionCache extends Omit<IExcepcion, OmitirCache> {}
+export const ExcepcionCacheSchema = ExcepcionSchema.omit({
+  cliente: true,
+  ancestros: true,
+});
+export type IExcepcionCache = z.infer<typeof ExcepcionCacheSchema>;

--- a/src/interfaces/facturacion-cliente.ts
+++ b/src/interfaces/facturacion-cliente.ts
@@ -1,34 +1,43 @@
-import { ICliente, ITipoCliente } from './cliente';
+import { z } from 'zod';
+import { ClienteSchema, TipoClienteSchema } from './cliente';
 
-export type MonedaFacturacion = 'ARS' | 'USD';
+export const MonedaFacturacionSchema = z.enum(['ARS', 'USD']);
+export type MonedaFacturacion = z.infer<typeof MonedaFacturacionSchema>;
 
-export interface IFacturacionCliente {
-  _id?: string;
-  idCliente?: string;
-  idsAncestros?: string[];
-  activa?: boolean;
+export const FacturacionClienteSchema = z.object({
+  _id: z.string().optional(),
+  idCliente: z.string().optional(),
+  idsAncestros: z.array(z.string()).optional(),
+  activa: z.boolean().optional(),
   /**
    * Si true, el cliente no se cobra: su costo se descuenta del cliente
    * facturable padre (línea de bonificación). Si false/undefined y el
    * cliente no es nivel 1, se considera raíz independiente de facturación.
    */
-  bonificado?: boolean;
+  bonificado: z.boolean().optional(),
   // Populate
-  cliente?: ICliente;
-  ancestros?: ICliente[];
-}
+  cliente: ClienteSchema.optional(),
+  ancestros: z.array(ClienteSchema).optional(),
+});
+export type IFacturacionCliente = z.infer<typeof FacturacionClienteSchema>;
 
-type OmitirCreate = '_id' | 'cliente' | 'ancestros';
-export interface ICreateFacturacionCliente extends Omit<
-  Partial<IFacturacionCliente>,
-  OmitirCreate
-> {}
+export const CreateFacturacionClienteSchema = FacturacionClienteSchema.omit({
+  _id: true,
+  cliente: true,
+  ancestros: true,
+});
+export type ICreateFacturacionCliente = z.infer<
+  typeof CreateFacturacionClienteSchema
+>;
 
-type OmitirUpdate = '_id' | 'cliente' | 'ancestros';
-export interface IUpdateFacturacionCliente extends Omit<
-  Partial<IFacturacionCliente>,
-  OmitirUpdate
-> {}
+export const UpdateFacturacionClienteSchema = FacturacionClienteSchema.omit({
+  _id: true,
+  cliente: true,
+  ancestros: true,
+});
+export type IUpdateFacturacionCliente = z.infer<
+  typeof UpdateFacturacionClienteSchema
+>;
 
 /* ────────────────────────────────────────────────
  *  FACTURACIÓN EN CURSO (estimado vs real del mes)
@@ -40,66 +49,97 @@ export interface IUpdateFacturacionCliente extends Omit<
  * - activos: los que cuentan (trackers/alarmas con reporte en el mes;
  *   cámaras = total).
  */
-export interface ICategoriaFacturacionEnCurso {
-  total: number;
-  activos: number;
-}
-
-export interface IFacturacionEnCurso {
-  idCliente: string;
-  periodoInicio: string; // ISO, inicio del mes en curso
-  // Categorías y totales = NETO (lo que efectivamente paga el cliente).
-  trackers: ICategoriaFacturacionEnCurso;
-  alarmas: ICategoriaFacturacionEnCurso;
-  camaras: ICategoriaFacturacionEnCurso;
-  totalEstimado: number;
-  totalReal: number;
-  /** Descuento por clientes hijos bonificados (bruto = neto + bonificación). */
-  bonificacion: { totalEstimado: number; totalReal: number };
-  /**
-   * Costo real del mes pasado por categoría (del resumen ya creado para el
-   * cliente; puede no existir → 0), para comparar contra el estimado actual.
-   */
-  mesPasado: {
-    trackers: number;
-    alarmas: number;
-    camaras: number;
-    total: number;
-    /** Cantidades facturadas del mes anterior (del resumen), por categoría. */
-    cantidades?: {
-      trackers: number;
-      alarmas: number;
-      camaras: number;
-    };
-  };
-  /** Aporte de cada hijo directo (no bonificado, no raíz independiente). */
-  hijos: IDetalleClienteFacturacion[];
-  /** Detalle de cada cliente bonificado (descontado del total). */
-  bonificados: IDetalleClienteFacturacion[];
-}
+export const CategoriaFacturacionEnCursoSchema = z.object({
+  total: z.number(),
+  activos: z.number(),
+});
+export type ICategoriaFacturacionEnCurso = z.infer<
+  typeof CategoriaFacturacionEnCursoSchema
+>;
 
 /** Aporte/descuento de un cliente al total del cliente facturable. */
-export interface IDetalleClienteFacturacion {
-  idCliente: string;
-  nombre?: string;
-  tipoCliente?: ITipoCliente;
-  costoEstimado: number;
-  costoReal: number;
+export const DetalleClienteFacturacionSchema = z.object({
+  idCliente: z.string(),
+  nombre: z.string().optional(),
+  tipoCliente: TipoClienteSchema.optional(),
+  costoEstimado: z.number(),
+  costoReal: z.number(),
   /** Total del resumen del mes pasado de ese cliente (puede no existir → 0). */
-  costoPasado?: number;
+  costoPasado: z.number().optional(),
   /** Cantidades de dispositivos del cliente (activos = consolidados). */
-  cantidades?: {
-    trackers: { total: number; activos: number };
-    alarmas: { total: number; activos: number };
-    camaras: { total: number };
-  };
+  cantidades: z
+    .object({
+      trackers: z.object({ total: z.number(), activos: z.number() }),
+      alarmas: z.object({ total: z.number(), activos: z.number() }),
+      camaras: z.object({ total: z.number() }),
+    })
+    .optional(),
   /**
    * Desglose del mes pasado por categoría (del resumen guardado del
    * facturable; puede no existir en resúmenes viejos).
    */
-  pasado?: {
-    trackers?: { cantidad?: number; subtotal?: number };
-    alarmas?: { cantidad?: number; subtotal?: number };
-    camaras?: { cantidad?: number; subtotal?: number };
-  };
-}
+  pasado: z
+    .object({
+      trackers: z
+        .object({
+          cantidad: z.number().optional(),
+          subtotal: z.number().optional(),
+        })
+        .optional(),
+      alarmas: z
+        .object({
+          cantidad: z.number().optional(),
+          subtotal: z.number().optional(),
+        })
+        .optional(),
+      camaras: z
+        .object({
+          cantidad: z.number().optional(),
+          subtotal: z.number().optional(),
+        })
+        .optional(),
+    })
+    .optional(),
+});
+export type IDetalleClienteFacturacion = z.infer<
+  typeof DetalleClienteFacturacionSchema
+>;
+
+export const FacturacionEnCursoSchema = z.object({
+  idCliente: z.string(),
+  periodoInicio: z.string(), // ISO, inicio del mes en curso
+  // Categorías y totales = NETO (lo que efectivamente paga el cliente).
+  trackers: CategoriaFacturacionEnCursoSchema,
+  alarmas: CategoriaFacturacionEnCursoSchema,
+  camaras: CategoriaFacturacionEnCursoSchema,
+  totalEstimado: z.number(),
+  totalReal: z.number(),
+  /** Descuento por clientes hijos bonificados (bruto = neto + bonificación). */
+  bonificacion: z.object({
+    totalEstimado: z.number(),
+    totalReal: z.number(),
+  }),
+  /**
+   * Costo real del mes pasado por categoría (del resumen ya creado para el
+   * cliente; puede no existir → 0), para comparar contra el estimado actual.
+   */
+  mesPasado: z.object({
+    trackers: z.number(),
+    alarmas: z.number(),
+    camaras: z.number(),
+    total: z.number(),
+    /** Cantidades facturadas del mes anterior (del resumen), por categoría. */
+    cantidades: z
+      .object({
+        trackers: z.number(),
+        alarmas: z.number(),
+        camaras: z.number(),
+      })
+      .optional(),
+  }),
+  /** Aporte de cada hijo directo (no bonificado, no raíz independiente). */
+  hijos: z.array(DetalleClienteFacturacionSchema),
+  /** Detalle de cada cliente bonificado (descontado del total). */
+  bonificados: z.array(DetalleClienteFacturacionSchema),
+});
+export type IFacturacionEnCurso = z.infer<typeof FacturacionEnCursoSchema>;

--- a/src/interfaces/gateway.ts
+++ b/src/interfaces/gateway.ts
@@ -1,42 +1,42 @@
-import { ICliente } from './cliente';
-import { IGeoJSONPoint } from '../auxiliares';
+import { z } from 'zod';
+import { ClienteSchema } from './cliente';
+import { GeoJSONPointSchema } from '../auxiliares';
 
 //Esta es la interfaz del gateway que se va a guardar en nuestra base de datos. Va a requerir que ya exista creado el gateway en Chirpstack
-export interface IGateway {
+export const GatewaySchema = z.object({
   //Propios de nuestra base de datos
-  _id?: string;
-  idCliente?: string;
-  idsAncestros?: string[];
-  fechaCreacion?: string;
-  nombre?: string;
+  _id: z.string().optional(),
+  idCliente: z.string().optional(),
+  idsAncestros: z.array(z.string()).optional(),
+  fechaCreacion: z.string().optional(),
+  nombre: z.string().optional(),
   /** true si fue creado automáticamente por el cron de métricas */
-  autoCreado?: boolean;
+  autoCreado: z.boolean().optional(),
   //Propios de Chirpstack
-  fechaCreacionChirpstack?: string; //Fecha de creación en Chirpstack
-  gatewayEui?: string;
-  nombreChirpstack?: string;
-  description?: string;
-  statsInterval?: number;
-  ubicacion?: IGeoJSONPoint; //De Chirpstack vienen en otro formato, pero acá lo guardamos como GeoJSON Point
-  tags?: Record<string, string>;
-  metadata?: Record<string, string>;
+  fechaCreacionChirpstack: z.string().optional(), //Fecha de creación en Chirpstack
+  gatewayEui: z.string().optional(),
+  nombreChirpstack: z.string().optional(),
+  description: z.string().optional(),
+  statsInterval: z.number().optional(),
+  ubicacion: GeoJSONPointSchema.optional(), //De Chirpstack vienen en otro formato, pero acá lo guardamos como GeoJSON Point
+  tags: z.record(z.string(), z.string()).optional(),
+  metadata: z.record(z.string(), z.string()).optional(),
 
-  cliente?: ICliente;
-  ancestros?: ICliente[];
+  cliente: ClienteSchema.optional(),
+  ancestros: z.array(ClienteSchema).optional(),
 
   // Estadísticas calculadas por cron (actualización horaria)
   /** ToA promedio por canal en ms de la última hora */
-  toaPromedioHora?: number;
+  toaPromedioHora: z.number().optional(),
   /** Estado de salud basado en ToA: ok (<5%), warning (5-17%), error (>17%) */
-  estadoSalud?: 'ok' | 'warning' | 'error';
+  estadoSalud: z.enum(['ok', 'warning', 'error']).optional(),
   /** Fecha de última actualización de estadísticas */
-  estadisticasActualizadas?: string;
-}
+  estadisticasActualizadas: z.string().optional(),
+});
+export type IGateway = z.infer<typeof GatewaySchema>;
 
-type OmitirCreate = '_id';
+export const CreateGatewaySchema = GatewaySchema.omit({ _id: true });
+export type ICreateGateway = z.infer<typeof CreateGatewaySchema>;
 
-export interface ICreateGateway extends Omit<Partial<IGateway>, OmitirCreate> {}
-
-type OmitirUpdate = '_id';
-
-export interface IUpdateGateway extends Omit<Partial<IGateway>, OmitirUpdate> {}
+export const UpdateGatewaySchema = GatewaySchema.omit({ _id: true });
+export type IUpdateGateway = z.infer<typeof UpdateGatewaySchema>;

--- a/src/interfaces/geo-cache.ts
+++ b/src/interfaces/geo-cache.ts
@@ -1,32 +1,31 @@
-import { IGeoJSONPoint } from '../auxiliares';
+import { z } from 'zod';
+import { GeoJSONPointSchema } from '../auxiliares';
 
-export interface IPartesDireccion {
-  calle?: string;
-  numero?: string;
-  barrio?: string;
-  ciudad?: string;
-  partido?: string;
-  provincia?: string;
-  pais?: string;
-  codigoPostal?: string;
-}
+export const PartesDireccionSchema = z.object({
+  calle: z.string().optional(),
+  numero: z.string().optional(),
+  barrio: z.string().optional(),
+  ciudad: z.string().optional(),
+  partido: z.string().optional(),
+  provincia: z.string().optional(),
+  pais: z.string().optional(),
+  codigoPostal: z.string().optional(),
+});
+export type IPartesDireccion = z.infer<typeof PartesDireccionSchema>;
 
-export interface IGeoCache {
-  _id?: string;
-  fechaCreacion?: string;
-  geojson?: IGeoJSONPoint;
-  geohash?: string;
-  direccion?: string;
-  partes?: IPartesDireccion;
-  fuente?: string; // Fuente de los datos (ej. Google Maps, OpenStreetMap, etc.)
-}
+export const GeoCacheSchema = z.object({
+  _id: z.string().optional(),
+  fechaCreacion: z.string().optional(),
+  geojson: GeoJSONPointSchema.optional(),
+  geohash: z.string().optional(),
+  direccion: z.string().optional(),
+  partes: PartesDireccionSchema.optional(),
+  fuente: z.string().optional(), // Fuente de los datos (ej. Google Maps, OpenStreetMap, etc.)
+});
+export type IGeoCache = z.infer<typeof GeoCacheSchema>;
 
-type OmitirCreate = '_id';
+export const CreateGeoCacheSchema = GeoCacheSchema.omit({ _id: true });
+export type ICreateGeoCache = z.infer<typeof CreateGeoCacheSchema>;
 
-export interface ICreateGeoCache
-  extends Omit<Partial<IGeoCache>, OmitirCreate> {}
-
-type OmitirUpdate = '_id';
-
-export interface IUpdateGeoCache
-  extends Omit<Partial<IGeoCache>, OmitirUpdate> {}
+export const UpdateGeoCacheSchema = GeoCacheSchema.omit({ _id: true });
+export type IUpdateGeoCache = z.infer<typeof UpdateGeoCacheSchema>;

--- a/src/interfaces/grupo-usuario.ts
+++ b/src/interfaces/grupo-usuario.ts
@@ -1,62 +1,97 @@
-import { ICliente } from './cliente';
-import { IUsuario } from './usuario';
+import { z } from 'zod';
+import { ClienteSchema } from './cliente';
+import { UsuarioSchema } from './usuario';
 
-export interface IGrupoUsuario {
-  _id?: string;
-  idCliente?: string;
-  idsAncestros?: string[];
-  nombre?: string;
-  idAdmin?: string;
-  idsMiembros?: string[];
-  fechaCreacion?: string;
-
-  // Populate
-  cliente?: ICliente;
-  ancestros?: ICliente[];
-  admin?: IUsuario;
-  miembros?: IUsuario[];
-}
-
-type OmitCreate = '_id' | 'cliente' | 'admin' | 'miembros' | 'fechaCreacion';
-
-export interface ICreateGrupoUsuario
-  extends Omit<Partial<IGrupoUsuario>, OmitCreate> {}
-
-export interface IUpdateGrupoUsuario
-  extends Omit<Partial<IGrupoUsuario>, OmitCreate> {}
-
-export type EstadoSolicitudGrupoUsuario = 'Pendiente' | 'Aceptada' | 'Rechazada';
-
-export interface ISolicitudGrupoUsuario {
-  _id?: string;
-  idCliente?: string;
-  idsAncestros?: string[];
-  idGrupoUsuario?: string;
-  idRemitente?: string;
-  idDestinatario?: string;
-  estado?: EstadoSolicitudGrupoUsuario;
-  fechaCreacion?: string;
-  fechaRespuesta?: string;
+export const GrupoUsuarioSchema = z.object({
+  _id: z.string().optional(),
+  idCliente: z.string().optional(),
+  idsAncestros: z.array(z.string()).optional(),
+  nombre: z.string().optional(),
+  idAdmin: z.string().optional(),
+  idsMiembros: z.array(z.string()).optional(),
+  fechaCreacion: z.string().optional(),
 
   // Populate
-  cliente?: ICliente;
-  ancestros?: ICliente[];
-  grupoUsuario?: IGrupoUsuario;
-  remitente?: IUsuario;
-  destinatario?: IUsuario;
-}
+  cliente: ClienteSchema.optional(),
+  ancestros: z.array(ClienteSchema).optional(),
+  admin: UsuarioSchema.optional(),
+  miembros: z.array(UsuarioSchema).optional(),
+});
+export type IGrupoUsuario = z.infer<typeof GrupoUsuarioSchema>;
 
-type OmitCreateSolicitud =
-  | '_id'
-  | 'cliente'
-  | 'grupoUsuario'
-  | 'remitente'
-  | 'destinatario'
-  | 'fechaCreacion'
-  | 'fechaRespuesta';
+export const CreateGrupoUsuarioSchema = GrupoUsuarioSchema.omit({
+  _id: true,
+  cliente: true,
+  admin: true,
+  miembros: true,
+  fechaCreacion: true,
+});
+export type ICreateGrupoUsuario = z.infer<typeof CreateGrupoUsuarioSchema>;
 
-export interface ICreateSolicitudGrupoUsuario
-  extends Omit<Partial<ISolicitudGrupoUsuario>, OmitCreateSolicitud> {}
+export const UpdateGrupoUsuarioSchema = GrupoUsuarioSchema.omit({
+  _id: true,
+  cliente: true,
+  admin: true,
+  miembros: true,
+  fechaCreacion: true,
+});
+export type IUpdateGrupoUsuario = z.infer<typeof UpdateGrupoUsuarioSchema>;
 
-export interface IUpdateSolicitudGrupoUsuario
-  extends Omit<Partial<ISolicitudGrupoUsuario>, OmitCreateSolicitud> {}
+export const EstadoSolicitudGrupoUsuarioSchema = z.enum([
+  'Pendiente',
+  'Aceptada',
+  'Rechazada',
+]);
+export type EstadoSolicitudGrupoUsuario = z.infer<
+  typeof EstadoSolicitudGrupoUsuarioSchema
+>;
+
+export const SolicitudGrupoUsuarioSchema = z.object({
+  _id: z.string().optional(),
+  idCliente: z.string().optional(),
+  idsAncestros: z.array(z.string()).optional(),
+  idGrupoUsuario: z.string().optional(),
+  idRemitente: z.string().optional(),
+  idDestinatario: z.string().optional(),
+  estado: EstadoSolicitudGrupoUsuarioSchema.optional(),
+  fechaCreacion: z.string().optional(),
+  fechaRespuesta: z.string().optional(),
+
+  // Populate
+  cliente: ClienteSchema.optional(),
+  ancestros: z.array(ClienteSchema).optional(),
+  grupoUsuario: GrupoUsuarioSchema.optional(),
+  remitente: UsuarioSchema.optional(),
+  destinatario: UsuarioSchema.optional(),
+});
+export type ISolicitudGrupoUsuario = z.infer<
+  typeof SolicitudGrupoUsuarioSchema
+>;
+
+export const CreateSolicitudGrupoUsuarioSchema =
+  SolicitudGrupoUsuarioSchema.omit({
+    _id: true,
+    cliente: true,
+    grupoUsuario: true,
+    remitente: true,
+    destinatario: true,
+    fechaCreacion: true,
+    fechaRespuesta: true,
+  });
+export type ICreateSolicitudGrupoUsuario = z.infer<
+  typeof CreateSolicitudGrupoUsuarioSchema
+>;
+
+export const UpdateSolicitudGrupoUsuarioSchema =
+  SolicitudGrupoUsuarioSchema.omit({
+    _id: true,
+    cliente: true,
+    grupoUsuario: true,
+    remitente: true,
+    destinatario: true,
+    fechaCreacion: true,
+    fechaRespuesta: true,
+  });
+export type IUpdateSolicitudGrupoUsuario = z.infer<
+  typeof UpdateSolicitudGrupoUsuarioSchema
+>;

--- a/src/interfaces/grupo.ts
+++ b/src/interfaces/grupo.ts
@@ -1,14 +1,44 @@
-import { ICliente } from './cliente';
-import { IConfigPerfil } from './config-perfil';
+import { z } from 'zod';
+import { ClienteSchema, ICliente } from './cliente';
+import type { IConfigPerfil } from './config-perfil';
 
-export type CategoriaGrupo =
-  | 'Línea de colectivo'
-  | 'Flota'
-  | 'Activo'
-  | 'Normal'
-  | 'Luminaria'
-  | 'Puesta';
+export const CategoriaGrupoSchema = z.enum([
+  'Línea de colectivo',
+  'Flota',
+  'Activo',
+  'Normal',
+  'Luminaria',
+  'Puesta',
+]);
+export type CategoriaGrupo = z.infer<typeof CategoriaGrupoSchema>;
 
+// Populates intra-SCC como z.custom (import type-only): un schema real acá
+// arrastra el shape completo del ciclo y revienta la serialización de
+// declarations (TS7056) acá y en los consumidores NestJS.
+export const GrupoSchema = z.object({
+  _id: z.string().optional(),
+  idCliente: z.string().optional(),
+  idsAncestros: z.array(z.string()).optional(),
+  nombre: z.string().optional(),
+  color: z.string().optional(),
+  categoria: CategoriaGrupoSchema.optional(),
+  idsPerfilConfig: z.array(z.string()).optional(),
+  prioridad: z.number().optional(),
+
+  // Integracion Soflex
+  fleetId: z.string().optional(),
+  parentFleetId: z.string().optional(),
+
+  // Populate
+  cliente: ClienteSchema.optional(),
+  ancestros: z.array(ClienteSchema).optional(),
+  perfilConfigs: z.array(z.custom<IConfigPerfil>()).optional(),
+});
+
+/**
+ * Interface hand-written (misma forma que el schema): los tipos de entidad del
+ * SCC no usan z.infer porque los ciclos de aliases mutuos disparan TS2589.
+ */
 export interface IGrupo {
   _id?: string;
   idCliente?: string;
@@ -29,9 +59,19 @@ export interface IGrupo {
   perfilConfigs?: IConfigPerfil[];
 }
 
+export const CreateGrupoSchema = GrupoSchema.omit({
+  _id: true,
+  cliente: true,
+});
+
 type OmitirCreate = '_id' | 'cliente';
 
 export interface ICreateGrupo extends Omit<Partial<IGrupo>, OmitirCreate> {}
+
+export const UpdateGrupoSchema = GrupoSchema.omit({
+  _id: true,
+  cliente: true,
+});
 
 type OmitirUpdate = '_id' | 'cliente';
 

--- a/src/interfaces/inactividad-usuario.ts
+++ b/src/interfaces/inactividad-usuario.ts
@@ -1,5 +1,6 @@
-import { ICliente } from './cliente';
-import { IUsuario } from './usuario';
+import { z } from 'zod';
+import { ClienteSchema } from './cliente';
+import { UsuarioSchema } from './usuario';
 
 /**
  * Intervalo de inactividad de un usuario, generado por el control de
@@ -14,32 +15,42 @@ import { IUsuario } from './usuario';
  * `idCliente` del permiso activo); `idsAncestros` lo denormaliza api-datos
  * por hook a partir del `idCliente`. TTL 1 año sobre `inicio`.
  */
-export interface IInactividadUsuario {
-  _id?: string;
+export const InactividadUsuarioSchema = z.object({
+  _id: z.string().optional(),
   // Vínculo con el usuario.
-  idUsuario?: string;
+  idUsuario: z.string().optional(),
   // Nombre de usuario denormalizado (lowercase), por si el usuario se borra.
-  usuario?: string;
+  usuario: z.string().optional(),
   // Cliente del permiso activo al momento del evento.
-  idCliente?: string;
+  idCliente: z.string().optional(),
   // Cadena de clientes ancestros del idCliente, para roll-up por subárbol.
-  idsAncestros?: string[];
+  idsAncestros: z.array(z.string()).optional(),
   // Momento en que venció el cartel sin confirmación. Ancla del índice TTL.
-  inicio?: string;
+  inicio: z.string().optional(),
   // Momento en que volvió a confirmar actividad. Ausente = intervalo abierto.
   // La duración de la inactividad es `fin - inicio`.
-  fin?: string;
+  fin: z.string().optional(),
   // Populate / Virtual
-  usuarioDoc?: IUsuario;
-  cliente?: ICliente;
-}
+  usuarioDoc: UsuarioSchema.optional(),
+  cliente: ClienteSchema.optional(),
+});
+export type IInactividadUsuario = z.infer<typeof InactividadUsuarioSchema>;
 
-type OmitirCreate = '_id' | 'fin' | 'usuarioDoc' | 'cliente';
+export const CreateInactividadUsuarioSchema = InactividadUsuarioSchema.omit({
+  _id: true,
+  fin: true,
+  usuarioDoc: true,
+  cliente: true,
+});
+export type ICreateInactividadUsuario = z.infer<
+  typeof CreateInactividadUsuarioSchema
+>;
 
-export interface ICreateInactividadUsuario
-  extends Omit<Partial<IInactividadUsuario>, OmitirCreate> {}
-
-type OmitirUpdate = '_id' | 'usuarioDoc' | 'cliente';
-
-export interface IUpdateInactividadUsuario
-  extends Omit<Partial<IInactividadUsuario>, OmitirUpdate> {}
+export const UpdateInactividadUsuarioSchema = InactividadUsuarioSchema.omit({
+  _id: true,
+  usuarioDoc: true,
+  cliente: true,
+});
+export type IUpdateInactividadUsuario = z.infer<
+  typeof UpdateInactividadUsuarioSchema
+>;

--- a/src/interfaces/informacion-tecnica.ts
+++ b/src/interfaces/informacion-tecnica.ts
@@ -1,22 +1,38 @@
-export interface IInfoEndPoint {
-  url?: string;
-  ip?: string;
-  puerto?: { protocolo: string; info?: string; puerto: string }[];
-}
+import { z } from "zod";
 
-export interface IInformacionTecnica {
-  _id?: string;
-  titulo?: string;
-  descripcion?: string;
-  infoEndPoints?: IInfoEndPoint[];
-}
+export const InfoEndPointSchema = z.object({
+  url: z.string().optional(),
+  ip: z.string().optional(),
+  puerto: z
+    .array(
+      z.object({
+        protocolo: z.string(),
+        info: z.string().optional(),
+        puerto: z.string(),
+      }),
+    )
+    .optional(),
+});
+export type IInfoEndPoint = z.infer<typeof InfoEndPointSchema>;
 
-type OmitirCreate = "_id";
+export const InformacionTecnicaSchema = z.object({
+  _id: z.string().optional(),
+  titulo: z.string().optional(),
+  descripcion: z.string().optional(),
+  infoEndPoints: z.array(InfoEndPointSchema).optional(),
+});
+export type IInformacionTecnica = z.infer<typeof InformacionTecnicaSchema>;
 
-export interface ICreateInformacionTecnica
-  extends Omit<Partial<IInformacionTecnica>, OmitirCreate> {}
+export const CreateInformacionTecnicaSchema = InformacionTecnicaSchema.omit({
+  _id: true,
+});
+export type ICreateInformacionTecnica = z.infer<
+  typeof CreateInformacionTecnicaSchema
+>;
 
-type OmitirUpdate = "_id";
-
-export interface IUpdateInformacionTecnica
-  extends Omit<Partial<IInformacionTecnica>, OmitirUpdate> {}
+export const UpdateInformacionTecnicaSchema = InformacionTecnicaSchema.omit({
+  _id: true,
+});
+export type IUpdateInformacionTecnica = z.infer<
+  typeof UpdateInformacionTecnicaSchema
+>;

--- a/src/interfaces/listado-categoria.ts
+++ b/src/interfaces/listado-categoria.ts
@@ -1,54 +1,63 @@
-import { ICliente } from './cliente';
+import { z } from 'zod';
+import { ClienteSchema } from './cliente';
 
-export type ITipoListadoCategoria =
+export const TipoListadoCategoriaSchema = z.enum([
   //PARA TIPOS DE EVENTOS
-  | 'Evento-Alarma'
-  | 'Evento-Tracker'
-  | 'Evento-Luminaria'
-  | 'Evento-Sirena'
-  | 'Evento-Gateway'
-  | 'Evento-Activo'
+  'Evento-Alarma',
+  'Evento-Tracker',
+  'Evento-Luminaria',
+  'Evento-Sirena',
+  'Evento-Gateway',
+  'Evento-Activo',
   //PARA EMERGENCIAS MÉDICAS
-  | 'Sintomas'
-  | 'Diagnosticos'
+  'Sintomas',
+  'Diagnosticos',
   //PARA SERVICIOS TÉCNICOS
-  | 'Evento-Tecnico-Tracker'
-  | 'Evento-Tecnico-Alarma'
-  | 'Evento-Tecnico-Vehiculo'
-  | 'Evento-Tecnico-Luminaria'
-  | 'Evento-Tecnico-Sirena'
-  | 'Evento-Tecnico-Gateway'
-  | 'Evento-Tecnico-Activo';
+  'Evento-Tecnico-Tracker',
+  'Evento-Tecnico-Alarma',
+  'Evento-Tecnico-Vehiculo',
+  'Evento-Tecnico-Luminaria',
+  'Evento-Tecnico-Sirena',
+  'Evento-Tecnico-Gateway',
+  'Evento-Tecnico-Activo',
+]);
+export type ITipoListadoCategoria = z.infer<typeof TipoListadoCategoriaSchema>;
 
-export interface IListadoCategoria {
-  _id?: string;
+export const ListadoCategoriaSchema = z.object({
+  _id: z.string().optional(),
   //
-  nombre?: string;
-  categoria?: ITipoListadoCategoria;
-  idCliente?: string;
-  idsAncestros?: string[];
-  default?: boolean;
-  global?: boolean;
+  nombre: z.string().optional(),
+  categoria: TipoListadoCategoriaSchema.optional(),
+  idCliente: z.string().optional(),
+  idsAncestros: z.array(z.string()).optional(),
+  default: z.boolean().optional(),
+  global: z.boolean().optional(),
   //Populate
-  cliente?: ICliente;
-  ancestros?: ICliente[];
-}
+  cliente: ClienteSchema.optional(),
+  ancestros: z.array(ClienteSchema).optional(),
+});
+export type IListadoCategoria = z.infer<typeof ListadoCategoriaSchema>;
 
-type OmitirCreate = '_id' | 'cliente';
+export const CreateListadoCategoriaSchema = ListadoCategoriaSchema.omit({
+  _id: true,
+  cliente: true,
+});
+export type ICreateListadoCategoria = z.infer<
+  typeof CreateListadoCategoriaSchema
+>;
 
-export interface ICreateListadoCategoria extends Omit<
-  Partial<IListadoCategoria>,
-  OmitirCreate
-> {}
+export const UpdateListadoCategoriaSchema = ListadoCategoriaSchema.omit({
+  _id: true,
+  cliente: true,
+});
+export type IUpdateListadoCategoria = z.infer<
+  typeof UpdateListadoCategoriaSchema
+>;
 
-type OmitirUpdate = '_id' | 'cliente';
-
-export interface IUpdateListadoCategoria extends Omit<
-  Partial<IListadoCategoria>,
-  OmitirUpdate
-> {}
-
-export interface IListadoCategoriaCache extends Omit<
-  IListadoCategoria,
-  'cliente' | 'ancestros'
-> {}
+export const ListadoCategoriaCacheSchema = ListadoCategoriaSchema.omit({
+  cliente: true,
+  ancestros: true,
+});
+export type IListadoCategoriaCache = z.infer<
+  typeof ListadoCategoriaCacheSchema
+>;

--- a/src/interfaces/log-despacho.ts
+++ b/src/interfaces/log-despacho.ts
@@ -1,26 +1,34 @@
-import { ICliente } from './cliente';
+import { z } from 'zod';
+import { ClienteSchema } from './cliente';
 
-export interface ILogDespacho {
-  _id: string;
-  idCliente?: string;
-  idsAncestros?: string[];
-  fechaCreacion?: string;
-  expireAt?: string;
-  idExternoVehiculo?: string;
-  idExternoRecorrido?: string;
-  idExternoChofer?: string;
-  fecha?: string;
+export const LogDespachoSchema = z.object({
+  _id: z.string(),
+  idCliente: z.string().optional(),
+  idsAncestros: z.array(z.string()).optional(),
+  fechaCreacion: z.string().optional(),
+  expireAt: z.string().optional(),
+  idExternoVehiculo: z.string().optional(),
+  idExternoRecorrido: z.string().optional(),
+  idExternoChofer: z.string().optional(),
+  fecha: z.string().optional(),
   // Populate
-  cliente?: ICliente;
-  ancestros?: ICliente[];
-}
+  cliente: ClienteSchema.optional(),
+  ancestros: z.array(ClienteSchema).optional(),
+});
+export type ILogDespacho = z.infer<typeof LogDespachoSchema>;
 
 ////// CREATE
-type OmitirCreate = '_id' | 'fechaCreacion' | 'cliente';
-export interface ICreateLogDespacho
-  extends Omit<Partial<ILogDespacho>, OmitirCreate> {}
+export const CreateLogDespachoSchema = LogDespachoSchema.omit({
+  _id: true,
+  fechaCreacion: true,
+  cliente: true,
+});
+export type ICreateLogDespacho = z.infer<typeof CreateLogDespachoSchema>;
 
 ////// UPDATE
-type OmitirUpdate = '_id' | 'fechaCreacion' | 'cliente';
-export interface IUpdateLogDespacho
-  extends Omit<Partial<ILogDespacho>, OmitirUpdate> {}
+export const UpdateLogDespachoSchema = LogDespachoSchema.omit({
+  _id: true,
+  fechaCreacion: true,
+  cliente: true,
+});
+export type IUpdateLogDespacho = z.infer<typeof UpdateLogDespachoSchema>;

--- a/src/interfaces/log-evento.ts
+++ b/src/interfaces/log-evento.ts
@@ -1,53 +1,63 @@
-import { RxInfo, TxInfo } from '../auxiliares';
-import { IDispositivoLorawan } from './dispositivo-lorawan';
+import { z } from 'zod';
+import { RxInfoSchema, TxInfoSchema } from '../auxiliares';
+import { DispositivoLorawanSchema } from './dispositivo-lorawan';
 
-export type TipoLogEvento =
-  | 'up'
-  | 'status'
-  | 'join'
-  | 'ack'
-  | 'txack'
-  | 'down'
-  | 'log';
-export interface IMetadatosUplink {
-  rxInfo?: RxInfo[];
-  txInfo?: TxInfo;
-  dr?: number;
+export const TipoLogEventoSchema = z.enum([
+  'up',
+  'status',
+  'join',
+  'ack',
+  'txack',
+  'down',
+  'log',
+]);
+export type TipoLogEvento = z.infer<typeof TipoLogEventoSchema>;
+
+export const MetadatosUplinkSchema = z.object({
+  rxInfo: z.array(RxInfoSchema).optional(),
+  txInfo: TxInfoSchema.optional(),
+  dr: z.number().optional(),
   /** Tiempo en aire (Time on Air) en milisegundos */
-  timeOnAir?: number;
+  timeOnAir: z.number().optional(),
   /** Tamaño del payload en bytes */
-  payloadSize?: number;
-}
-export interface ILogEvento {
-  _id?: string;
-  fechaCreacion?: string;
-  expireAt?: string;
-  tipo?: TipoLogEvento;
-  deveui?: string;
-  deviceName?: string;
-  payload?: string;
-  puerto?: number;
-  battery?: number;
-  fCnt?: number;
-  margin?: number;
-  metadatosUplink?: IMetadatosUplink;
+  payloadSize: z.number().optional(),
+});
+export type IMetadatosUplink = z.infer<typeof MetadatosUplinkSchema>;
+
+export const LogEventoSchema = z.object({
+  _id: z.string().optional(),
+  fechaCreacion: z.string().optional(),
+  expireAt: z.string().optional(),
+  tipo: TipoLogEventoSchema.optional(),
+  deveui: z.string().optional(),
+  deviceName: z.string().optional(),
+  payload: z.string().optional(),
+  puerto: z.number().optional(),
+  battery: z.number().optional(),
+  fCnt: z.number().optional(),
+  margin: z.number().optional(),
+  metadatosUplink: MetadatosUplinkSchema.optional(),
 
   // Campos específicos para mensajes de tipo 'log' de ChirpStack
-  level?: string; // "ERROR", "WARNING", "INFO"
-  code?: string; // Código del tipo de log (ej: "DOWNLINK_GATEWAY", "UPLINK_F_CNT_RETRANSMISSION")
-  description?: string; // Descripción del evento
-  context?: Record<string, any>; // Contexto adicional del log
+  level: z.string().optional(), // "ERROR", "WARNING", "INFO"
+  code: z.string().optional(), // Código del tipo de log (ej: "DOWNLINK_GATEWAY", "UPLINK_F_CNT_RETRANSMISSION")
+  description: z.string().optional(), // Descripción del evento
+  context: z.record(z.string(), z.any()).optional(), // Contexto adicional del log
 
   //Populate
-  dispositivoLorawan?: IDispositivoLorawan;
-}
+  dispositivoLorawan: DispositivoLorawanSchema.optional(),
+});
+export type ILogEvento = z.infer<typeof LogEventoSchema>;
 
-type OmitirCreate = '_id' | 'fechaCreacion';
+export const CreateLogEventoSchema = LogEventoSchema.omit({
+  _id: true,
+  fechaCreacion: true,
+});
+export type ICreateLogEvento = z.infer<typeof CreateLogEventoSchema>;
 
-export interface ICreateLogEvento
-  extends Omit<Partial<ILogEvento>, OmitirCreate> {}
-
-type OmitirUpdate = '_id' | 'fechaCreacion' | 'cliente';
-
-export interface IUpdateLogEvento
-  extends Omit<Partial<ILogEvento>, OmitirUpdate> {}
+// El OmitirUpdate original incluía 'cliente', que no es una clave de ILogEvento
+export const UpdateLogEventoSchema = LogEventoSchema.omit({
+  _id: true,
+  fechaCreacion: true,
+});
+export type IUpdateLogEvento = z.infer<typeof UpdateLogEventoSchema>;

--- a/src/interfaces/log-generico.ts
+++ b/src/interfaces/log-generico.ts
@@ -1,28 +1,33 @@
-import { ICliente } from './cliente';
+import { z } from 'zod';
+import { ClienteSchema, ICliente } from './cliente';
 
-export type TipoEntidadLog =
-  | 'Luminaria'
-  | 'Colectivo'
-  | 'Activo'
-  | 'Tracker'
-  | 'Vehiculo';
+export const TipoEntidadLogSchema = z.enum([
+  'Luminaria',
+  'Colectivo',
+  'Activo',
+  'Tracker',
+  'Vehiculo',
+]);
+export type TipoEntidadLog = z.infer<typeof TipoEntidadLogSchema>;
+
 /* ────────────────────────────────────────────────
  *  REPORTES POR TIPO
  * ────────────────────────────────────────────────*/
-export type ILogGenerico = ILogBase<'Log Mensaje'>;
 
-export interface ILogMensaje {
-  mensaje?: string;
-  protocolo?: 'UDP' | 'TCP';
-  origen?: string;
-  puerto?: number;
-}
+export const LogMensajeSchema = z.object({
+  mensaje: z.string().optional(),
+  protocolo: z.enum(['UDP', 'TCP']).optional(),
+  origen: z.string().optional(),
+  puerto: z.number().optional(),
+});
+export type ILogMensaje = z.infer<typeof LogMensajeSchema>;
 
 export type MapaValoresLog = {
   'Log Mensaje': ILogMensaje;
 };
 
-export type TipoLogs = 'Log Mensaje';
+export const TipoLogsSchema = z.enum(['Log Mensaje']);
+export type TipoLogs = z.infer<typeof TipoLogsSchema>;
 
 export interface ILogBase<T extends keyof MapaValoresLog> {
   _id: string;
@@ -39,9 +44,36 @@ export interface ILogBase<T extends keyof MapaValoresLog> {
   ancestros?: ICliente[];
 }
 
+export const LogGenericoSchema = z.object({
+  _id: z.string(),
+  fechaCreacion: z.string().optional(),
+  idCliente: z.string().optional(),
+  expireAt: z.string().optional(),
+  //
+  idsAncestros: z.array(z.string()).optional(),
+  tipoEntidad: TipoEntidadLogSchema.optional(),
+  tipoReporte: TipoLogsSchema.optional(),
+  valores: LogMensajeSchema.optional(),
+  // Populate
+  cliente: ClienteSchema.optional(),
+  ancestros: z.array(ClienteSchema).optional(),
+});
+export type ILogGenerico = z.infer<typeof LogGenericoSchema>;
+
 ////// CREATE
-type Omitir = '_id' | 'idsAncestros' | 'cliente' | 'ancestros';
-export type ICreateLogGenerico = Omit<ILogBase<'Log Mensaje'>, Omitir>;
+export const CreateLogGenericoSchema = LogGenericoSchema.omit({
+  _id: true,
+  idsAncestros: true,
+  cliente: true,
+  ancestros: true,
+});
+export type ICreateLogGenerico = z.infer<typeof CreateLogGenericoSchema>;
 
 ////// UPDATE
-export type IUpdateLogGenerico = Omit<Partial<ILogBase<'Log Mensaje'>>, Omitir>;
+export const UpdateLogGenericoSchema = LogGenericoSchema.omit({
+  _id: true,
+  idsAncestros: true,
+  cliente: true,
+  ancestros: true,
+});
+export type IUpdateLogGenerico = z.infer<typeof UpdateLogGenericoSchema>;

--- a/src/interfaces/log-https.ts
+++ b/src/interfaces/log-https.ts
@@ -1,20 +1,27 @@
-export interface ILogHttp {
-  _id?: string;
-  fechaCreacion?: string;
-  expireAt?: string;
-  method?: string;
-  url?: string;
-  path?: string;
-  body?: string;
-  headers?: string;
-  query?: string;
-  params?: string;
-}
+import { z } from 'zod';
 
-type OmitirCreate = '_id' | 'fechaCreacion';
+export const LogHttpSchema = z.object({
+  _id: z.string().optional(),
+  fechaCreacion: z.string().optional(),
+  expireAt: z.string().optional(),
+  method: z.string().optional(),
+  url: z.string().optional(),
+  path: z.string().optional(),
+  body: z.string().optional(),
+  headers: z.string().optional(),
+  query: z.string().optional(),
+  params: z.string().optional(),
+});
+export type ILogHttp = z.infer<typeof LogHttpSchema>;
 
-export interface ICreateLogHttp extends Omit<Partial<ILogHttp>, OmitirCreate> {}
+export const CreateLogHttpSchema = LogHttpSchema.omit({
+  _id: true,
+  fechaCreacion: true,
+});
+export type ICreateLogHttp = z.infer<typeof CreateLogHttpSchema>;
 
-type OmitirUpdate = '_id' | 'fechaCreacion';
-
-export interface IUpdateLogHttp extends Omit<Partial<ILogHttp>, OmitirUpdate> {}
+export const UpdateLogHttpSchema = LogHttpSchema.omit({
+  _id: true,
+  fechaCreacion: true,
+});
+export type IUpdateLogHttp = z.infer<typeof UpdateLogHttpSchema>;

--- a/src/interfaces/log-reenvio.ts
+++ b/src/interfaces/log-reenvio.ts
@@ -1,36 +1,44 @@
-import { ICliente } from './cliente';
-import { IDispositivoAlarma } from './dispositivo-alarma';
-import { ITracker } from './tracker';
+import { z } from 'zod';
+import { ClienteSchema } from './cliente';
+import { DispositivoAlarmaSchema } from './dispositivo-alarma';
+import { TrackerSchema } from './tracker';
 
-export interface ILogReenvio {
-  _id?: string;
-  expireAt?: string;
+export const LogReenvioSchema = z.object({
+  _id: z.string().optional(),
+  expireAt: z.string().optional(),
   //
-  idCliente?: string;
-  idsAncestros?: string[];
-  fecha?: string;
-  idEntidad?: string;
+  idCliente: z.string().optional(),
+  idsAncestros: z.array(z.string()).optional(),
+  fecha: z.string().optional(),
+  idEntidad: z.string().optional(),
 
-  protocolo?: 'UDP' | 'TCP';
-  host?: string;
-  puerto?: number;
-  body?: string;
-  ack?: boolean;
-  error?: string;
+  protocolo: z.enum(['UDP', 'TCP']).optional(),
+  host: z.string().optional(),
+  puerto: z.number().optional(),
+  body: z.string().optional(),
+  ack: z.boolean().optional(),
+  error: z.string().optional(),
 
   // Populate
-  cliente?: ICliente;
-  ancestros?: ICliente[];
-  dispositivoAlarma?: IDispositivoAlarma;
-  tracker?: ITracker;
-}
+  cliente: ClienteSchema.optional(),
+  ancestros: z.array(ClienteSchema).optional(),
+  dispositivoAlarma: DispositivoAlarmaSchema.optional(),
+  tracker: TrackerSchema.optional(),
+});
+export type ILogReenvio = z.infer<typeof LogReenvioSchema>;
 
-type OmitirCreate = '_id' | 'cliente' | 'dispositivoAlarma' | 'tracker';
+export const CreateLogReenvioSchema = LogReenvioSchema.omit({
+  _id: true,
+  cliente: true,
+  dispositivoAlarma: true,
+  tracker: true,
+});
+export type ICreateLogReenvio = z.infer<typeof CreateLogReenvioSchema>;
 
-export interface ICreateLogReenvio
-  extends Omit<Partial<ILogReenvio>, OmitirCreate> {}
-
-type OmitirUpdate = '_id' | 'cliente' | 'dispositivoAlarma' | 'tracker';
-
-export interface IUpdateLogReenvio
-  extends Omit<Partial<ILogReenvio>, OmitirUpdate> {}
+export const UpdateLogReenvioSchema = LogReenvioSchema.omit({
+  _id: true,
+  cliente: true,
+  dispositivoAlarma: true,
+  tracker: true,
+});
+export type IUpdateLogReenvio = z.infer<typeof UpdateLogReenvioSchema>;

--- a/src/interfaces/log-trackeo.ts
+++ b/src/interfaces/log-trackeo.ts
@@ -1,34 +1,40 @@
-import { IActivo } from './activo';
-import { ICliente } from './cliente';
+import { z } from 'zod';
+import { ActivoSchema } from './activo';
+import { ClienteSchema } from './cliente';
 
-export interface ILogTrackeo {
-  _id?: string;
-  expireAt?: string;
+export const LogTrackeoSchema = z.object({
+  _id: z.string().optional(),
+  expireAt: z.string().optional(),
   //
-  idCliente?: string;
-  idsAncestros?: string[];
-  idActivo?: string;
-  fecha?: string;
-  nuevaParada?: boolean;
-  indexUltimaParada?: number;
-  indexParadaActual?: number;
-  ultimaParada?: string;
-  paradaActual?: string;
-  totalParadas?: number;
-  motivo?: string;
+  idCliente: z.string().optional(),
+  idsAncestros: z.array(z.string()).optional(),
+  idActivo: z.string().optional(),
+  fecha: z.string().optional(),
+  nuevaParada: z.boolean().optional(),
+  indexUltimaParada: z.number().optional(),
+  indexParadaActual: z.number().optional(),
+  ultimaParada: z.string().optional(),
+  paradaActual: z.string().optional(),
+  totalParadas: z.number().optional(),
+  motivo: z.string().optional(),
 
   // Populate
-  cliente?: ICliente;
-  ancestros?: ICliente[];
-  activo?: IActivo;
-}
+  cliente: ClienteSchema.optional(),
+  ancestros: z.array(ClienteSchema).optional(),
+  activo: ActivoSchema.optional(),
+});
+export type ILogTrackeo = z.infer<typeof LogTrackeoSchema>;
 
-type OmitirCreate = '_id' | 'cliente' | 'activo';
+export const CreateLogTrackeoSchema = LogTrackeoSchema.omit({
+  _id: true,
+  cliente: true,
+  activo: true,
+});
+export type ICreateLogTrackeo = z.infer<typeof CreateLogTrackeoSchema>;
 
-export interface ICreateLogTrackeo
-  extends Omit<Partial<ILogTrackeo>, OmitirCreate> {}
-
-type OmitirUpdate = '_id' | 'cliente' | 'activo';
-
-export interface IUpdateLogTrackeo
-  extends Omit<Partial<ILogTrackeo>, OmitirUpdate> {}
+export const UpdateLogTrackeoSchema = LogTrackeoSchema.omit({
+  _id: true,
+  cliente: true,
+  activo: true,
+});
+export type IUpdateLogTrackeo = z.infer<typeof UpdateLogTrackeoSchema>;

--- a/src/interfaces/log-twilio.ts
+++ b/src/interfaces/log-twilio.ts
@@ -1,51 +1,65 @@
-import { ICliente } from './cliente';
+import { z } from 'zod';
+import { ClienteSchema } from './cliente';
 
-export type TwilioMessageStatus =
-  | 'queued'
-  | 'sending'
-  | 'sent'
-  | 'failed'
-  | 'delivered'
-  | 'undelivered'
-  | 'receiving'
-  | 'received'
-  | 'accepted'
-  | 'scheduled'
-  | 'read'
-  | 'partially_delivered'
-  | 'canceled';
+export const TwilioMessageStatusSchema = z.enum([
+  'queued',
+  'sending',
+  'sent',
+  'failed',
+  'delivered',
+  'undelivered',
+  'receiving',
+  'received',
+  'accepted',
+  'scheduled',
+  'read',
+  'partially_delivered',
+  'canceled',
+]);
+export type TwilioMessageStatus = z.infer<typeof TwilioMessageStatusSchema>;
 
-export type TwilioMessageDirection =
-  | 'inbound'
-  | 'outbound-api'
-  | 'outbound-call'
-  | 'outbound-reply';
+export const TwilioMessageDirectionSchema = z.enum([
+  'inbound',
+  'outbound-api',
+  'outbound-call',
+  'outbound-reply',
+]);
+export type TwilioMessageDirection = z.infer<
+  typeof TwilioMessageDirectionSchema
+>;
 
-export interface ILogTwilio {
-  _id: string;
-  fechaCreacion?: string;
-  idCliente?: string;
-  idsAncestros?: string[];
-  phone?: string;
-  sid?: string;
-  body?: string;
-  direction?: TwilioMessageDirection;
-  status?: TwilioMessageStatus;
-  error?: boolean;
+export const LogTwilioSchema = z.object({
+  _id: z.string(),
+  fechaCreacion: z.string().optional(),
+  idCliente: z.string().optional(),
+  idsAncestros: z.array(z.string()).optional(),
+  phone: z.string().optional(),
+  sid: z.string().optional(),
+  body: z.string().optional(),
+  direction: TwilioMessageDirectionSchema.optional(),
+  status: TwilioMessageStatusSchema.optional(),
+  error: z.boolean().optional(),
   /// Solo en error
-  errorCode?: string;
-  errorMessage?: string;
+  errorCode: z.string().optional(),
+  errorMessage: z.string().optional(),
   // Populate
-  cliente?: ICliente;
-  ancestros?: ICliente[];
-}
+  cliente: ClienteSchema.optional(),
+  ancestros: z.array(ClienteSchema).optional(),
+});
+export type ILogTwilio = z.infer<typeof LogTwilioSchema>;
 
 ////// CREATE
-type OmitirCreate = '_id' | 'fechaCreacion' | 'cliente';
-export interface ICreateLogTwilio
-  extends Omit<Partial<ILogTwilio>, OmitirCreate> {}
+export const CreateLogTwilioSchema = LogTwilioSchema.omit({
+  _id: true,
+  fechaCreacion: true,
+  cliente: true,
+});
+export type ICreateLogTwilio = z.infer<typeof CreateLogTwilioSchema>;
 
 ////// UPDATE
-type OmitirUpdate = '_id' | 'fechaCreacion' | 'cliente';
-export interface IUpdateLogTwilio
-  extends Omit<Partial<ILogTwilio>, OmitirUpdate> {}
+export const UpdateLogTwilioSchema = LogTwilioSchema.omit({
+  _id: true,
+  fechaCreacion: true,
+  cliente: true,
+});
+export type IUpdateLogTwilio = z.infer<typeof UpdateLogTwilioSchema>;

--- a/src/interfaces/login-evento.ts
+++ b/src/interfaces/login-evento.ts
@@ -1,8 +1,17 @@
-import { ICliente } from './cliente';
-import { IUsuario } from './usuario';
+import { z } from 'zod';
+import { ClienteSchema } from './cliente';
+import { UsuarioSchema } from './usuario';
 
-export type MetodoLogin = 'password' | 'google';
-export type PlataformaLogin = 'web' | 'android' | 'ios' | 'desconocida';
+export const MetodoLoginSchema = z.enum(['password', 'google']);
+export type MetodoLogin = z.infer<typeof MetodoLoginSchema>;
+
+export const PlataformaLoginSchema = z.enum([
+  'web',
+  'android',
+  'ios',
+  'desconocida',
+]);
+export type PlataformaLogin = z.infer<typeof PlataformaLoginSchema>;
 
 /**
  * Evento de login de un usuario. Se inserta uno por login exitoso (grant
@@ -16,78 +25,91 @@ export type PlataformaLogin = 'web' | 'android' | 'ios' | 'desconocida';
  *
  * La colección tiene un índice TTL sobre `fecha` (retención 1 año).
  */
-export interface ILoginEvento {
-  _id?: string;
+export const LoginEventoSchema = z.object({
+  _id: z.string().optional(),
   // Vínculo con el usuario que inició sesión.
-  idUsuario?: string;
+  idUsuario: z.string().optional(),
   // Nombre de usuario denormalizado (lowercase), por si el usuario se borra.
-  usuario?: string;
+  usuario: z.string().optional(),
   // Cliente del usuario al momento del login (puede no tener).
-  idCliente?: string;
+  idCliente: z.string().optional(),
   // Cadena de clientes ancestros del idCliente, para roll-up por subárbol.
-  idsAncestros?: string[];
+  idsAncestros: z.array(z.string()).optional(),
   // Momento del login. Ancla del índice TTL.
-  fecha?: string;
-  metodo?: MetodoLogin;
-  plataforma?: PlataformaLogin;
+  fecha: z.string().optional(),
+  metodo: MetodoLoginSchema.optional(),
+  plataforma: PlataformaLoginSchema.optional(),
   // User-Agent crudo (best-effort), por si luego se quiere afinar plataforma.
-  userAgent?: string;
+  userAgent: z.string().optional(),
   // Populate / Virtual
-  usuarioDoc?: IUsuario;
-  cliente?: ICliente;
-}
+  usuarioDoc: UsuarioSchema.optional(),
+  cliente: ClienteSchema.optional(),
+});
+export type ILoginEvento = z.infer<typeof LoginEventoSchema>;
 
-type OmitirCreate = '_id' | 'usuarioDoc' | 'cliente';
-
-export interface ICreateLoginEvento
-  extends Omit<Partial<ILoginEvento>, OmitirCreate> {}
+export const CreateLoginEventoSchema = LoginEventoSchema.omit({
+  _id: true,
+  usuarioDoc: true,
+  cliente: true,
+});
+export type ICreateLoginEvento = z.infer<typeof CreateLoginEventoSchema>;
 
 // ---- Tipos de retorno de las estadísticas de uso (solo lectura) ----
 
-export interface IEstadisticasResumen {
-  desde?: string;
-  hasta?: string;
+export const EstadisticasResumenSchema = z.object({
+  desde: z.string().optional(),
+  hasta: z.string().optional(),
   // Usuarios activos únicos en las últimas 24h / 7d / 30d.
-  dau?: number;
-  wau?: number;
-  mau?: number;
+  dau: z.number().optional(),
+  wau: z.number().optional(),
+  mau: z.number().optional(),
   // Totales dentro del rango [desde, hasta].
-  totalLogins?: number;
-  usuariosActivos?: number;
+  totalLogins: z.number().optional(),
+  usuariosActivos: z.number().optional(),
   // Universo total de usuarios registrados (con y sin actividad).
-  usuariosRegistrados?: number;
-}
+  usuariosRegistrados: z.number().optional(),
+});
+export type IEstadisticasResumen = z.infer<typeof EstadisticasResumenSchema>;
 
-export interface IEstadisticasSeriePunto {
-  fecha?: string; // día (YYYY-MM-DD)
-  logins?: number;
-  usuariosActivos?: number;
-}
+export const EstadisticasSeriePuntoSchema = z.object({
+  fecha: z.string().optional(), // día (YYYY-MM-DD)
+  logins: z.number().optional(),
+  usuariosActivos: z.number().optional(),
+});
+export type IEstadisticasSeriePunto = z.infer<
+  typeof EstadisticasSeriePuntoSchema
+>;
 
-export interface IEstadisticasPorCliente {
-  idCliente?: string;
-  nombre?: string;
-  nivel?: number;
-  totalLogins?: number;
-  usuariosActivos?: number;
-  dau?: number;
-  wau?: number;
-  mau?: number;
-}
+export const EstadisticasPorClienteSchema = z.object({
+  idCliente: z.string().optional(),
+  nombre: z.string().optional(),
+  nivel: z.number().optional(),
+  totalLogins: z.number().optional(),
+  usuariosActivos: z.number().optional(),
+  dau: z.number().optional(),
+  wau: z.number().optional(),
+  mau: z.number().optional(),
+});
+export type IEstadisticasPorCliente = z.infer<
+  typeof EstadisticasPorClienteSchema
+>;
 
-export interface IEstadisticasPorUsuario {
-  idUsuario?: string;
-  usuario?: string;
-  nombre?: string;
-  idCliente?: string;
-  clienteNombre?: string;
-  ultimoLogin?: string;
-  primerLogin?: string;
-  cantidadLogins?: number; // acumulado histórico (contador en Usuario)
-  loginsRango?: number; // logins dentro de [desde, hasta]
-  diasActivosRango?: number; // días distintos con al menos un login en el rango
-  rachaActual?: number; // días consecutivos activos hasta hoy
-  diasDesdeUltimoLogin?: number;
-  plataformas?: string[];
-  metodos?: string[];
-}
+export const EstadisticasPorUsuarioSchema = z.object({
+  idUsuario: z.string().optional(),
+  usuario: z.string().optional(),
+  nombre: z.string().optional(),
+  idCliente: z.string().optional(),
+  clienteNombre: z.string().optional(),
+  ultimoLogin: z.string().optional(),
+  primerLogin: z.string().optional(),
+  cantidadLogins: z.number().optional(), // acumulado histórico (contador en Usuario)
+  loginsRango: z.number().optional(), // logins dentro de [desde, hasta]
+  diasActivosRango: z.number().optional(), // días distintos con al menos un login en el rango
+  rachaActual: z.number().optional(), // días consecutivos activos hasta hoy
+  diasDesdeUltimoLogin: z.number().optional(),
+  plataformas: z.array(z.string()).optional(),
+  metodos: z.array(z.string()).optional(),
+});
+export type IEstadisticasPorUsuario = z.infer<
+  typeof EstadisticasPorUsuarioSchema
+>;

--- a/src/interfaces/luminaria.ts
+++ b/src/interfaces/luminaria.ts
@@ -1,32 +1,53 @@
-import { IGeoJSONPoint } from '../auxiliares';
-import { ICliente, IConfigHorario } from './cliente';
-import { NivelObjetivo } from './comando';
-import { IConfigPerfil } from './config-perfil';
-import { IDispositivoLorawan } from './dispositivo-lorawan';
-import { IGrupo } from './grupo';
-import { IModeloDispositivo } from './modelo-dispositivo';
-import { IPuesta } from './puesta';
-import { IReporteBase } from './reporte-generico';
+import { z } from 'zod';
+import { GeoJSONPointSchema, IGeoJSONPoint } from '../auxiliares';
+import {
+  ClienteSchema,
+  ConfigHorarioSchema,
+  IConfigHorario,
+  ICliente,
+} from './cliente';
+import { NivelObjetivo, NivelObjetivoSchema } from './comando';
+import type { IConfigPerfil } from './config-perfil';
+import type { IDispositivoLorawan } from './dispositivo-lorawan';
+import type { IGrupo } from './grupo';
+import {
+  IModeloDispositivo,
+  ModeloDispositivoSchema,
+} from './modelo-dispositivo';
+import type { IPuesta } from './puesta';
+import type { IReporteBase } from './reporte-generico';
 
-export type EstadoOperativoLuminaria = 'Operativa' | 'Mantenimiento';
-export type ITipoEnergizado = 'Continuo' | 'Nocturno'; //Continuo: Siempre reportando, Nocturno: Solo reporta de noche porque a la mañana se apaga porque se le corta la energía
+export const EstadoOperativoLuminariaSchema = z.enum([
+  'Operativa',
+  'Mantenimiento',
+]);
+export type EstadoOperativoLuminaria = z.infer<
+  typeof EstadoOperativoLuminariaSchema
+>;
+
+export const TipoEnergizadoSchema = z.enum(['Continuo', 'Nocturno']); //Continuo: Siempre reportando, Nocturno: Solo reporta de noche porque a la mañana se apaga porque se le corta la energía
+export type ITipoEnergizado = z.infer<typeof TipoEnergizadoSchema>;
 
 // Estado calculado de funcionamiento (modelo de 6 estados).
 // Lo escribe el backend (gestion-lora-luminarias en uplinks + gestion-cron cada 1 min) y lo lee el front. Ver PLAN_ESTADO_LUMINARIAS_BACKEND.md.
 //   0 Sin nodo | 1 Error de comunicación | 2 Error de encendido | 3 Alarma |
 //   4 Encendida | 5 Apagada
-export type CodigoEstadoLuminaria = 0 | 1 | 2 | 3 | 4 | 5;
+export const CodigoEstadoLuminariaSchema = z.literal([0, 1, 2, 3, 4, 5]);
+export type CodigoEstadoLuminaria = z.infer<typeof CodigoEstadoLuminariaSchema>;
 
-export interface IEstadoLuminariaCalculado {
-  codigo: CodigoEstadoLuminaria;
-  encendida: boolean | null;
-  motivo?: string; // ej. 'Desenergizada (horario diurno)' — flag persistido hasta el próximo reporte
-  alarmas?: string[]; // snapshot de valores.alarmas al momento de evaluar (drilldown)
-  fechaEvaluacion: string; // ISO — última vez que se evaluó
-  fechaCambio: string; // ISO — desde cuándo está en este código
-  fechaCambioEncendida?: string; // ISO — último cambio de `encendida` (on↔off). Para la nocturna desenergizada marca el momento en que el sistema la consideró apagada
-  origen: 'uplink' | 'cron';
-}
+export const EstadoLuminariaCalculadoSchema = z.object({
+  codigo: CodigoEstadoLuminariaSchema,
+  encendida: z.boolean().nullable(),
+  motivo: z.string().optional(), // ej. 'Desenergizada (horario diurno)' — flag persistido hasta el próximo reporte
+  alarmas: z.array(z.string()).optional(), // snapshot de valores.alarmas al momento de evaluar (drilldown)
+  fechaEvaluacion: z.string(), // ISO — última vez que se evaluó
+  fechaCambio: z.string(), // ISO — desde cuándo está en este código
+  fechaCambioEncendida: z.string().optional(), // ISO — último cambio de `encendida` (on↔off). Para la nocturna desenergizada marca el momento en que el sistema la consideró apagada
+  origen: z.enum(['uplink', 'cron']),
+});
+export type IEstadoLuminariaCalculado = z.infer<
+  typeof EstadoLuminariaCalculadoSchema
+>;
 
 export type MapaValoresReportePeriodico = {
   'Luminaria GPE': IReporteBase<'Luminaria GPE Periódico'>;
@@ -38,10 +59,6 @@ export type MapaValoresReporteEnergia = {
 };
 
 export type TipoDispositivoLuminaria = keyof MapaValoresReportePeriodico;
-
-export type ILuminaria =
-  | ILuminariaGenerica<'Luminaria GPE'>
-  | ILuminariaGenerica<'Luminaria ACTIS FING'>;
 
 export interface ILuminariaGenerica<T extends TipoDispositivoLuminaria> {
   _id?: string;
@@ -90,8 +107,123 @@ export interface ILuminariaGenerica<T extends TipoDispositivoLuminaria> {
   } | null;
 }
 
+// Campos comunes a las dos variantes (sin tipoDispositivo/ultimoReporte*, que discriminan)
+const LuminariaCamposSchema = z.object({
+  _id: z.string().optional(),
+  fechaCreacion: z.string().optional(), // Default: Date.now
+  idCliente: z.string().optional(),
+  idsAncestros: z.array(z.string()).optional(),
+  deveui: z.string().optional(), // Deveui del dispositivo lorawan
+  identificacion: z.string().optional(),
+  ubicacion: GeoJSONPointSchema.optional(), // GeoJSON de la ubicacion de la luminaria (si hay idPuesta, se coloca la de la puesta)
+  direccion: z.string().optional(), // Direccion de la luminaria
+  idModeloDispositivo: z.string().optional(), // ID del modelo de dispositivo
+  idPuesta: z.string().optional(), // (opcional, solo clientes con moduloLuminarias.usaPuestas)
+  idsGrupos: z.array(z.string()).optional(),
+  tiempoEncendida: z.number().optional(), // En horas
+  fechaUltimaComunicacion: z.string().optional(), // Fecha del ultima comunicacion recibida por el dispositivo
+  idPerfilConfig: z.string().optional(),
+  tipoEnergizado: TipoEnergizadoSchema.optional(),
+  estadoOperativo: EstadoOperativoLuminariaSchema.optional(), // Condición administrativa (Operativa/Mantenimiento)
+  estado: EstadoLuminariaCalculadoSchema.optional(), // Estado calculado de funcionamiento (6 estados). Escrito por backend (uplinks + cron); persiste hasta el próximo cambio.
+
+  // Habilitación de Servicio Técnico
+  puedeSolicitarServicioTecnico: z.boolean().optional(), // Si esta luminaria puede recibir servicio técnico
+  idsClientesQuePuedenAtenderEventosTecnicos: z.array(z.string()).optional(), // Clientes habilitados a atender el ST de esta luminaria
+  configHorariosAtencionTecnica: z.array(ConfigHorarioSchema).optional(), // Clientes que atienden + ventanas horarias
+
+  // Virtuals
+  // Populates intra-SCC como z.custom (import type-only): un schema real acá
+  // arrastra el shape completo del ciclo y revienta la serialización de
+  // declarations (TS7056) acá y en los consumidores NestJS.
+  cliente: ClienteSchema.optional(),
+  ancestros: z.array(ClienteSchema).optional(),
+  clientesQuePuedenAtenderEventosTecnicos: z.array(ClienteSchema).optional(), // populate de idsClientesQuePuedenAtenderEventosTecnicos
+  dispositivo: z.custom<IDispositivoLorawan>().optional(),
+  modeloDispositivo: ModeloDispositivoSchema.optional(),
+  grupos: z.array(z.custom<IGrupo>()).optional(),
+  perfilConfig: z.custom<IConfigPerfil>().optional(),
+  puesta: z.custom<IPuesta>().optional(),
+
+  // Computado (no persistido): perfil efectivo resuelto por jerarquía
+  // (luminaria > grupo por prioridad > puesta > grupo de puestas). Solo se
+  // completa cuando la query pide `incluirPerfilEfectivo`.
+  perfilEfectivo: z
+    .object({
+      get nivel() {
+        return NivelObjetivoSchema;
+      },
+      idFuente: z.string(),
+      nombre: z.string().nullable().optional(),
+    })
+    .nullable()
+    .optional(),
+});
+
+const VarianteLuminariaGPE = LuminariaCamposSchema.extend({
+  tipoDispositivo: z.literal('Luminaria GPE').optional(), // Tipo de dispositivo (Luminaria GPE, Luminaria ACTIS FING, etc)
+  ultimoReportePeriodico: z
+    .custom<IReporteBase<'Luminaria GPE Periódico'>>()
+    .optional(), // Ultimo reporte periodico recibido
+  ultimoReporteEnergia: z
+    .custom<IReporteBase<'Luminaria GPE Energía'>>()
+    .optional(), // Ultimo reporte energia recibido
+});
+const VarianteLuminariaACTISFING = LuminariaCamposSchema.extend({
+  tipoDispositivo: z.literal('Luminaria ACTIS FING').optional(), // Tipo de dispositivo (Luminaria GPE, Luminaria ACTIS FING, etc)
+  ultimoReportePeriodico: z
+    .custom<IReporteBase<'Luminaria ACTIS FING Estado'>>()
+    .optional(), // Ultimo reporte periodico recibido
+  ultimoReporteEnergia: z
+    .custom<IReporteBase<'Luminaria ACTIS FING Energía'>>()
+    .optional(), // Ultimo reporte energia recibido
+});
+
+export const LuminariaSchema = z.union([
+  VarianteLuminariaGPE,
+  VarianteLuminariaACTISFING,
+]);
+
+/**
+ * Tipo legacy hand-written (NO z.infer): el ciclo luminaria ↔ puesta ↔
+ * dispositivo-lorawan a través de z.infer mutuos dispara TS2589. La union de
+ * ILuminariaGenerica es idéntica en forma y corta el ciclo (interfaces lazy).
+ */
+export type ILuminaria =
+  | ILuminariaGenerica<'Luminaria GPE'>
+  | ILuminariaGenerica<'Luminaria ACTIS FING'>;
+
 ////// CREATE
-type OmitirCreate =
+const camposOmitidos: {
+  _id: true;
+  fechaCreacion: true;
+  idsAncestros: true;
+  cliente: true;
+  ancestros: true;
+  dispositivo: true;
+  modeloDispositivo: true;
+  grupos: true;
+  perfilConfig: true;
+  puesta: true;
+} = {
+  _id: true,
+  fechaCreacion: true,
+  idsAncestros: true,
+  cliente: true,
+  ancestros: true,
+  dispositivo: true,
+  modeloDispositivo: true,
+  grupos: true,
+  perfilConfig: true,
+  puesta: true,
+};
+
+export const CreateLuminariaSchema = z.union([
+  VarianteLuminariaGPE.omit(camposOmitidos),
+  VarianteLuminariaACTISFING.omit(camposOmitidos),
+]);
+
+type OmitirCreateUpdate =
   | '_id'
   | 'fechaCreacion'
   | 'idsAncestros'
@@ -104,98 +236,119 @@ type OmitirCreate =
   | 'puesta';
 
 export type ICreateLuminaria =
-  | Omit<ILuminariaGenerica<'Luminaria GPE'>, OmitirCreate>
-  | Omit<ILuminariaGenerica<'Luminaria ACTIS FING'>, OmitirCreate>;
+  | Omit<ILuminariaGenerica<'Luminaria GPE'>, OmitirCreateUpdate>
+  | Omit<ILuminariaGenerica<'Luminaria ACTIS FING'>, OmitirCreateUpdate>;
 
 ////// UPDATE
-type OmitirUpdate =
-  | '_id'
-  | 'fechaCreacion'
-  | 'idsAncestros'
-  | 'cliente'
-  | 'ancestros'
-  | 'dispositivo'
-  | 'modeloDispositivo'
-  | 'grupos'
-  | 'perfilConfig'
-  | 'puesta';
-
+export const UpdateLuminariaSchema = z.union([
+  VarianteLuminariaGPE.omit(camposOmitidos),
+  VarianteLuminariaACTISFING.omit(camposOmitidos),
+]);
 export type IUpdateLuminaria =
-  | Omit<ILuminariaGenerica<'Luminaria GPE'>, OmitirUpdate>
-  | Omit<ILuminariaGenerica<'Luminaria ACTIS FING'>, OmitirUpdate>;
+  | Omit<ILuminariaGenerica<'Luminaria GPE'>, OmitirCreateUpdate>
+  | Omit<ILuminariaGenerica<'Luminaria ACTIS FING'>, OmitirCreateUpdate>;
 
 /**
  * Representa la ubicación de una luminaria con corte de energía
  */
-export interface IUbicacionCorteEnergia {
-  idLuminaria?: string;
-  deveui?: string;
-  identificacion?: string;
-  coordenadas?: IGeoJSONPoint;
-  direccion?: string;
-  cantidadCortes?: number;
-  primerCorte?: string; // ISO Date string
-  ultimoCorte?: string; // ISO Date string
-}
+export const UbicacionCorteEnergiaSchema = z.object({
+  idLuminaria: z.string().optional(),
+  deveui: z.string().optional(),
+  identificacion: z.string().optional(),
+  coordenadas: GeoJSONPointSchema.optional(),
+  direccion: z.string().optional(),
+  cantidadCortes: z.number().optional(),
+  primerCorte: z.string().optional(), // ISO Date string
+  ultimoCorte: z.string().optional(), // ISO Date string
+});
+export type IUbicacionCorteEnergia = z.infer<
+  typeof UbicacionCorteEnergiaSchema
+>;
 
 /**
  * Representa un día con luminarias que tuvieron cortes de energía
  */
-export interface IDiaCorteEnergia {
-  dia?: string; // Formato: YYYY-MM-DD
-  diaSemana?: number; // 1=Domingo, 2=Lunes, 3=Martes, 4=Miércoles, 5=Jueves, 6=Viernes, 7=Sábado
-  nombreDia?: string; // "Lunes", "Martes", "Miércoles", etc.
-  luminariasConCorte?: number;
-  ubicaciones?: IUbicacionCorteEnergia[];
-}
+export const DiaCorteEnergiaSchema = z.object({
+  dia: z.string().optional(), // Formato: YYYY-MM-DD
+  diaSemana: z.number().optional(), // 1=Domingo, 2=Lunes, 3=Martes, 4=Miércoles, 5=Jueves, 6=Viernes, 7=Sábado
+  nombreDia: z.string().optional(), // "Lunes", "Martes", "Miércoles", etc.
+  luminariasConCorte: z.number().optional(),
+  ubicaciones: z.array(UbicacionCorteEnergiaSchema).optional(),
+});
+export type IDiaCorteEnergia = z.infer<typeof DiaCorteEnergiaSchema>;
 
 /**
  * Resumen de cortes de energía por semana
  */
-export interface IResumenCortesEnergiaSemana {
-  dias?: IDiaCorteEnergia[];
-  totalLuminariasAfectadas?: number; // Cantidad única de luminarias afectadas en toda la semana
-}
+export const ResumenCortesEnergiaSemanaSchema = z.object({
+  dias: z.array(DiaCorteEnergiaSchema).optional(),
+  totalLuminariasAfectadas: z.number().optional(), // Cantidad única de luminarias afectadas en toda la semana
+});
+export type IResumenCortesEnergiaSemana = z.infer<
+  typeof ResumenCortesEnergiaSemanaSchema
+>;
+
+export const JerarquiaLuminariaSchema = z.object({
+  _id: z.string(),
+  identificacion: z.string().optional(),
+  deveui: z.string().optional(),
+  tipo: z.string(),
+  get perfilNivel() {
+    return NivelObjetivoSchema.nullable();
+  },
+  perfilNombre: z.string().nullable(),
+  elegible: z.boolean(),
+});
+export type IJerarquiaLuminaria = z.infer<typeof JerarquiaLuminariaSchema>;
 
 // Arma la jerarquía de perfiles/elegibilidad de las luminarias de un objetivo, para que la UI muestre qué luminaria recibe el comando y por qué.
-export interface IJerarquiaObjetivo {
-  nivel: NivelObjetivo;
-  luminarias: IJerarquiaLuminaria[];
-  resumenPorTipo: Record<
-    string,
-    { total: number; elegibles: number; ignoradas: number }
-  >;
-}
-
-export interface IJerarquiaLuminaria {
-  _id: string;
-  identificacion?: string;
-  deveui?: string;
-  tipo: string;
-  perfilNivel: NivelObjetivo | null;
-  perfilNombre: string | null;
-  elegible: boolean;
-}
+export const JerarquiaObjetivoSchema = z.object({
+  get nivel() {
+    return NivelObjetivoSchema;
+  },
+  luminarias: z.array(JerarquiaLuminariaSchema),
+  resumenPorTipo: z.record(
+    z.string(),
+    z.object({
+      total: z.number(),
+      elegibles: z.number(),
+      ignoradas: z.number(),
+    }),
+  ),
+});
+export type IJerarquiaObjetivo = z.infer<typeof JerarquiaObjetivoSchema>;
 
 // Cadena ASCENDENTE de jerarquía de UNA luminaria: todos los contenedores por
 // encima (la propia luminaria, sus grupos, su puesta, los grupos de la puesta)
 // con el perfil que cada uno tiene para el tipo de la luminaria y la prioridad
 // (en los grupos). Marca cuál es la FUENTE del perfil efectivo.
-export interface INivelJerarquiaLuminaria {
-  nivel: NivelObjetivo;
-  id: string;
-  nombre?: string;
-  perfilNombre?: string | null;
-  prioridad?: number | null; // solo grupos / grupos de puesta
-  esEfectivo: boolean; // este contenedor provee el perfil efectivo
-}
+export const NivelJerarquiaLuminariaSchema = z.object({
+  get nivel() {
+    return NivelObjetivoSchema;
+  },
+  id: z.string(),
+  nombre: z.string().optional(),
+  perfilNombre: z.string().nullable().optional(),
+  prioridad: z.number().nullable().optional(), // solo grupos / grupos de puesta
+  esEfectivo: z.boolean(), // este contenedor provee el perfil efectivo
+});
+export type INivelJerarquiaLuminaria = z.infer<
+  typeof NivelJerarquiaLuminariaSchema
+>;
 
-export interface IJerarquiaAscendenteLuminaria {
-  tipo: string;
-  niveles: INivelJerarquiaLuminaria[];
-  efectivo: {
-    nivel: NivelObjetivo;
-    id: string;
-    perfilNombre?: string | null;
-  } | null;
-}
+export const JerarquiaAscendenteLuminariaSchema = z.object({
+  tipo: z.string(),
+  niveles: z.array(NivelJerarquiaLuminariaSchema),
+  efectivo: z
+    .object({
+      get nivel() {
+        return NivelObjetivoSchema;
+      },
+      id: z.string(),
+      perfilNombre: z.string().nullable().optional(),
+    })
+    .nullable(),
+});
+export type IJerarquiaAscendenteLuminaria = z.infer<
+  typeof JerarquiaAscendenteLuminariaSchema
+>;

--- a/src/interfaces/material-servicio-tecnico.ts
+++ b/src/interfaces/material-servicio-tecnico.ts
@@ -1,68 +1,89 @@
+import { z } from 'zod';
 import { IEntidades } from './asignacion';
-import { ICliente } from './cliente';
-import { IDispositivoLorawan } from './dispositivo-lorawan';
-import { IEventoGenerico } from './evento-generico';
-import { IUsuario } from './usuario';
+import { ClienteSchema } from './cliente';
+import type { IDispositivoLorawan } from './dispositivo-lorawan';
+import type { IEventoGenerico } from './evento-generico';
+import { UsuarioSchema } from './usuario';
 
 /**
  * - 'usado' / 'pedido': material dentro de un servicio técnico (idEventoGenerico presente). Solo aparecen si se creó un evento técnico, esto lo gestiona el técnico.
  * - 'asignado': material/entidad en el stock (caja) del técnico que el fue asignado, sin evento (idEventoGenerico ausente). Puede ser algo libre (cables, herramientas) o una entidad del sistema referenciada por idEntidad/tipoEntidad (ej: un Dispositivo Lorawan disponible para cambio de nodo de luminaria).
  */
-export type TipoMaterialServicioTecnico = 'usado' | 'pedido' | 'asignado';
+export const TipoMaterialServicioTecnicoSchema = z.enum([
+  'usado',
+  'pedido',
+  'asignado',
+]);
+export type TipoMaterialServicioTecnico = z.infer<
+  typeof TipoMaterialServicioTecnicoSchema
+>;
 
 /**
  * Flujo del pedido: Pendiente (lo pide el técnico) → Aprobado (operador)
  * → Usado (el técnico vuelve, termina el trabajo y lo marca). Anulado en cualquier punto previo a Usado.
  * Para el stock asignado al técnico (tipo 'asignado'): Asignado ↔ Devuelto.
  */
-export type EstadoPedidoMaterial =
-  | 'Pendiente'
-  | 'Aprobado'
-  | 'Usado'
-  | 'Anulado'
-  | 'Asignado'
-  | 'Devuelto';
+export const EstadoPedidoMaterialSchema = z.enum([
+  'Pendiente',
+  'Aprobado',
+  'Usado',
+  'Anulado',
+  'Asignado',
+  'Devuelto',
+]);
+export type EstadoPedidoMaterial = z.infer<typeof EstadoPedidoMaterialSchema>;
 
-export interface IMaterialServicioTecnico {
-  _id?: string;
-  idCliente?: string;
-  idsAncestros?: string[];
-  idEventoGenerico?: string; //Ausente cuando el material es stock asignado a la caja del técnico (tipo 'asignado').
-  idUsuario?: string; //quien registró/solicitó el material, o a quien está asignado el stock
-  tipo?: TipoMaterialServicioTecnico;
-  descripcion?: string;
-  cantidad?: number;
-  imagenes?: string[];
-  estado?: EstadoPedidoMaterial;
-  idEntidad?: string; //Entidad del sistema referenciada por este material (opcional).
-  tipoEntidad?: IEntidades;
+export const MaterialServicioTecnicoSchema = z.object({
+  _id: z.string().optional(),
+  idCliente: z.string().optional(),
+  idsAncestros: z.array(z.string()).optional(),
+  idEventoGenerico: z.string().optional(), //Ausente cuando el material es stock asignado a la caja del técnico (tipo 'asignado').
+  idUsuario: z.string().optional(), //quien registró/solicitó el material, o a quien está asignado el stock
+  tipo: TipoMaterialServicioTecnicoSchema.optional(),
+  descripcion: z.string().optional(),
+  cantidad: z.number().optional(),
+  imagenes: z.array(z.string()).optional(),
+  estado: EstadoPedidoMaterialSchema.optional(),
+  idEntidad: z.string().optional(), //Entidad del sistema referenciada por este material (opcional).
+  tipoEntidad: z.custom<IEntidades>().optional(),
   /** Reservado para stock futuro: vínculo a artículo de inventario. No usar aún. */
-  idArticulo?: string;
-  fechaCreacion?: string;
+  idArticulo: z.string().optional(),
+  fechaCreacion: z.string().optional(),
   // Populate
-  cliente?: ICliente;
-  ancestros?: ICliente[];
-  evento?: IEventoGenerico;
-  usuario?: IUsuario;
-  dispositivoLorawan?: IDispositivoLorawan; // populate de idEntidad cuando tipoEntidad === 'Dispositivo Lorawan'
-}
+  cliente: ClienteSchema.optional(),
+  ancestros: z.array(ClienteSchema).optional(),
+  evento: z.custom<IEventoGenerico>().optional(),
+  usuario: UsuarioSchema.optional(),
+  dispositivoLorawan: z.custom<IDispositivoLorawan>().optional(), // populate de idEntidad cuando tipoEntidad === 'Dispositivo Lorawan'
+});
+export type IMaterialServicioTecnico = z.infer<
+  typeof MaterialServicioTecnicoSchema
+>;
 
-type OmitirCreate =
-  | '_id'
-  | 'cliente'
-  | 'ancestros'
-  | 'evento'
-  | 'usuario'
-  | 'fechaCreacion';
+export const CreateMaterialServicioTecnicoSchema =
+  MaterialServicioTecnicoSchema.omit({
+    _id: true,
+    cliente: true,
+    ancestros: true,
+    evento: true,
+    usuario: true,
+    dispositivoLorawan: true,
+    fechaCreacion: true,
+  });
+export type ICreateMaterialServicioTecnico = z.infer<
+  typeof CreateMaterialServicioTecnicoSchema
+>;
 
-export interface ICreateMaterialServicioTecnico extends Omit<
-  Partial<IMaterialServicioTecnico>,
-  OmitirCreate
-> {}
-
-type OmitirUpdate = OmitirCreate;
-
-export interface IUpdateMaterialServicioTecnico extends Omit<
-  Partial<IMaterialServicioTecnico>,
-  OmitirUpdate
-> {}
+export const UpdateMaterialServicioTecnicoSchema =
+  MaterialServicioTecnicoSchema.omit({
+    _id: true,
+    cliente: true,
+    ancestros: true,
+    evento: true,
+    usuario: true,
+    dispositivoLorawan: true,
+    fechaCreacion: true,
+  });
+export type IUpdateMaterialServicioTecnico = z.infer<
+  typeof UpdateMaterialServicioTecnicoSchema
+>;

--- a/src/interfaces/metricas-gateway.ts
+++ b/src/interfaces/metricas-gateway.ts
@@ -1,42 +1,54 @@
-import { ICliente } from './cliente';
-import { IGateway } from './gateway';
+import { z } from 'zod';
+import { ClienteSchema } from './cliente';
+import { GatewaySchema } from './gateway';
 
-export type PeriodoMetrica = 'hora' | 'dia';
+export const PeriodoMetricaSchema = z.enum(['hora', 'dia']);
+export type PeriodoMetrica = z.infer<typeof PeriodoMetricaSchema>;
 
 /**
  * Métricas agregadas de Time on Air por gateway y canal
  */
-export interface IMetricasGateway {
-  _id?: string;
+export const MetricasGatewaySchema = z.object({
+  _id: z.string().optional(),
   /** Referencia al Gateway en MongoDB */
-  idGateway?: string;
+  idGateway: z.string().optional(),
   /** EUI del gateway (para queries directas sin join) */
-  gatewayEui: string;
+  gatewayEui: z.string(),
   /** Cliente dueño del dispositivo que generó el uplink (para filtro cross-tenant) */
-  idClienteDispositivo?: string;
+  idClienteDispositivo: z.string().optional(),
   /** Inicio del periodo de agregación (ISO string) */
-  fecha: string;
+  fecha: z.string(),
   /** Granularidad de la agregación */
-  periodo: PeriodoMetrica;
+  periodo: PeriodoMetricaSchema,
   /** Frecuencia/canal en Hz (ej: 915400000) */
-  canal: number;
+  canal: z.number(),
 
   /** Suma total de Time on Air en milisegundos */
-  totalToA: number;
+  totalToA: z.number(),
   /** Cantidad de uplinks en el periodo */
-  cantidadUplinks: number;
+  cantidadUplinks: z.number(),
 
   // Virtuals
-  gateway?: IGateway;
-  clienteDispositivo?: ICliente;
-}
+  gateway: GatewaySchema.optional(),
+  clienteDispositivo: ClienteSchema.optional(),
+});
+export type IMetricasGateway = z.infer<typeof MetricasGatewaySchema>;
 
-type OmitirCreate = '_id';
+export const CreateMetricasGatewaySchema = MetricasGatewaySchema.omit({
+  _id: true,
+}).partial();
+export type ICreateMetricasGateway = z.infer<
+  typeof CreateMetricasGatewaySchema
+>;
 
-export interface ICreateMetricasGateway
-  extends Omit<Partial<IMetricasGateway>, OmitirCreate> {}
-
-type OmitirUpdate = '_id' | 'gatewayEui' | 'idClienteDispositivo' | 'fecha' | 'periodo' | 'canal';
-
-export interface IUpdateMetricasGateway
-  extends Omit<Partial<IMetricasGateway>, OmitirUpdate> {}
+export const UpdateMetricasGatewaySchema = MetricasGatewaySchema.omit({
+  _id: true,
+  gatewayEui: true,
+  idClienteDispositivo: true,
+  fecha: true,
+  periodo: true,
+  canal: true,
+}).partial();
+export type IUpdateMetricasGateway = z.infer<
+  typeof UpdateMetricasGatewaySchema
+>;

--- a/src/interfaces/modelo-dispositivo.ts
+++ b/src/interfaces/modelo-dispositivo.ts
@@ -1,98 +1,126 @@
-import { ICliente } from './cliente';
-import { ICodigosDispositivo, TipoDispositivo } from './codigos-dispositivo';
+import { z } from 'zod';
+import { ClienteSchema } from './cliente';
+import {
+  CodigosDispositivoSchema,
+  TipoDispositivoSchema,
+} from './codigos-dispositivo';
 
-export type FormatosMensajeComunicador =
-  | 'Garnet-Titanium'
-  | 'TECHNO 123'
-  | 'Netio'
-  | 'Nanocomm ED5200'
-  | 'Garnet'
-  | 'Dahua'
-  | 'Hikvision'
-  | 'Intelbras'
+export const FormatosMensajeComunicadorSchema = z.enum([
+  'Garnet-Titanium',
+  'TECHNO 123',
+  'Netio',
+  'Nanocomm ED5200',
+  'Garnet',
+  'Dahua',
+  'Hikvision',
+  'Intelbras',
   // UNICOM "WiFi DUO": comunicador WiFi (AVR128 + ESP32) que habla MQTT
   // contra el broker propio de IRIX. NO usa SIM/GPRS (sim1/sim2/numeroAbonado
   // quedan vacíos); su identidad es el devid en idUnicoComunicador.
-  | 'UNICOM';
+  'UNICOM',
+]);
+export type FormatosMensajeComunicador = z.infer<
+  typeof FormatosMensajeComunicadorSchema
+>;
 
-export type NivelDimerizacion =
-  | 'dim10'
-  | 'dim20'
-  | 'dim30'
-  | 'dim40'
-  | 'dim50'
-  | 'dim60'
-  | 'dim70'
-  | 'dim80'
-  | 'dim90'
-  | 'dim100';
+export const NivelDimerizacionSchema = z.enum([
+  'dim10',
+  'dim20',
+  'dim30',
+  'dim40',
+  'dim50',
+  'dim60',
+  'dim70',
+  'dim80',
+  'dim90',
+  'dim100',
+]);
+export type NivelDimerizacion = z.infer<typeof NivelDimerizacionSchema>;
 
 // Punto de la curva: en un nivel de dimerización dado, valores eléctricos
 // esperados y sus margenes bidireccionales de tolerancia.
-export interface IPuntoCurvaLuminaria {
-  potencia?: number; // W a un determinado dimming (Wd)
-  factorPotencia?: number; // cfidim a este dim (0..1). También llamado cosφ.
+export const PuntoCurvaLuminariaSchema = z.object({
+  potencia: z.number().optional(), // W a un determinado dimming (Wd)
+  factorPotencia: z.number().optional(), // cfidim a este dim (0..1). También llamado cosφ.
 
-  margenPotenciaSuperior?: number; // alarma si W >= Wd * (1 + potencia/100)
-  margenPotenciaInferior?: number; // alarma si W <= Wd * (1 - potencia/100)
-  margenFactorPotenciaSuperior?: number; // delta abs — alarma si cosφ > cfidim + margen
-  margenFactorPotenciaInferior?: number; // delta abs — alarma si cosφ < cfidim - margen
-}
+  margenPotenciaSuperior: z.number().optional(), // alarma si W >= Wd * (1 + potencia/100)
+  margenPotenciaInferior: z.number().optional(), // alarma si W <= Wd * (1 - potencia/100)
+  margenFactorPotenciaSuperior: z.number().optional(), // delta abs — alarma si cosφ > cfidim + margen
+  margenFactorPotenciaInferior: z.number().optional(), // delta abs — alarma si cosφ < cfidim - margen
+});
+export type IPuntoCurvaLuminaria = z.infer<typeof PuntoCurvaLuminariaSchema>;
 
-export type ICurvaDimerizacionLuminaria = {
-  [K in NivelDimerizacion]?: IPuntoCurvaLuminaria;
-};
+export const CurvaDimerizacionLuminariaSchema = z.partialRecord(
+  NivelDimerizacionSchema,
+  PuntoCurvaLuminariaSchema,
+);
+export type ICurvaDimerizacionLuminaria = z.infer<
+  typeof CurvaDimerizacionLuminariaSchema
+>;
 
 // Voltaje: independiente del dim.
-export interface IConfigVoltajeLuminaria {
-  nominalV?: number; // Vn (típicamente 230)
-  margenSuperiorV?: number; // Θv — alarma si V >= Vn + Θv
-  margenInferiorV?: number; // alarma si V <= Vn - margenInferiorV
-}
+export const ConfigVoltajeLuminariaSchema = z.object({
+  nominalV: z.number().optional(), // Vn (típicamente 230)
+  margenSuperiorV: z.number().optional(), // Θv — alarma si V >= Vn + Θv
+  margenInferiorV: z.number().optional(), // alarma si V <= Vn - margenInferiorV
+});
+export type IConfigVoltajeLuminaria = z.infer<
+  typeof ConfigVoltajeLuminariaSchema
+>;
 
-export interface IDetallesLuminarias {
-  horasVida?: number;
+export const DetallesLuminariasSchema = z.object({
+  horasVida: z.number().optional(),
 
-  voltaje?: IConfigVoltajeLuminaria;
-  dimerizacion?: ICurvaDimerizacionLuminaria;
-}
+  voltaje: ConfigVoltajeLuminariaSchema.optional(),
+  dimerizacion: CurvaDimerizacionLuminariaSchema.optional(),
+});
+export type IDetallesLuminarias = z.infer<typeof DetallesLuminariasSchema>;
 
-export interface IModeloDispositivo {
-  _id?: string;
+export const ModeloDispositivoSchema = z.object({
+  _id: z.string().optional(),
 
   //
-  tipo?: TipoDispositivo;
-  marca?: string;
-  modelo?: string;
-  formatoMensaje?: FormatosMensajeComunicador;
-  idCodigos?: string;
-  idCliente?: string;
-  idsAncestros?: string[];
+  tipo: TipoDispositivoSchema.optional(),
+  marca: z.string().optional(),
+  modelo: z.string().optional(),
+  formatoMensaje: FormatosMensajeComunicadorSchema.optional(),
+  idCodigos: z.string().optional(),
+  idCliente: z.string().optional(),
+  idsAncestros: z.array(z.string()).optional(),
 
   //Datos técnicos para luminarias
-  luminarias?: IDetallesLuminarias;
-  global?: boolean;
+  luminarias: DetallesLuminariasSchema.optional(),
+  global: z.boolean().optional(),
   // Populate
-  cliente?: ICliente;
-  ancestros?: ICliente[];
-  codigos?: ICodigosDispositivo;
-}
+  cliente: ClienteSchema.optional(),
+  ancestros: z.array(ClienteSchema).optional(),
+  codigos: CodigosDispositivoSchema.optional(),
+});
+export type IModeloDispositivo = z.infer<typeof ModeloDispositivoSchema>;
 
-type OmitirCreate = '_id' | 'codigos' | 'cliente';
+export const CreateModeloDispositivoSchema = ModeloDispositivoSchema.omit({
+  _id: true,
+  codigos: true,
+  cliente: true,
+});
+export type ICreateModeloDispositivo = z.infer<
+  typeof CreateModeloDispositivoSchema
+>;
 
-export interface ICreateModeloDispositivo extends Omit<
-  Partial<IModeloDispositivo>,
-  OmitirCreate
-> {}
+export const UpdateModeloDispositivoSchema = ModeloDispositivoSchema.omit({
+  _id: true,
+  codigos: true,
+  cliente: true,
+});
+export type IUpdateModeloDispositivo = z.infer<
+  typeof UpdateModeloDispositivoSchema
+>;
 
-type OmitirUpdate = '_id' | 'codigos' | 'cliente';
-
-export interface IUpdateModeloDispositivo extends Omit<
-  Partial<IModeloDispositivo>,
-  OmitirUpdate
-> {}
-
-export interface IModeloDispositivoCache extends Omit<
-  IModeloDispositivo,
-  'cliente' | 'ancestros' | 'codigos'
-> {}
+export const ModeloDispositivoCacheSchema = ModeloDispositivoSchema.omit({
+  cliente: true,
+  ancestros: true,
+  codigos: true,
+});
+export type IModeloDispositivoCache = z.infer<
+  typeof ModeloDispositivoCacheSchema
+>;

--- a/src/interfaces/nota.ts
+++ b/src/interfaces/nota.ts
@@ -1,59 +1,77 @@
-import { IActivo } from './activo';
-import { ICliente } from './cliente';
-import { IDispositivoAlarma } from './dispositivo-alarma';
-import { ILuminaria } from './luminaria';
+import { z } from 'zod';
+import { ActivoSchema } from './activo';
+import { ClienteSchema } from './cliente';
+import { DispositivoAlarmaSchema } from './dispositivo-alarma';
+import { LuminariaSchema } from './luminaria';
 
-export type TipoNota = 'Contacto' | 'Nota';
+export const TipoNotaSchema = z.enum(['Contacto', 'Nota']);
+export type TipoNota = z.infer<typeof TipoNotaSchema>;
 
-export interface IInformacionNota {
-  nota?: string;
-}
+export const InformacionNotaSchema = z.object({
+  nota: z.string().optional(),
+});
+export type IInformacionNota = z.infer<typeof InformacionNotaSchema>;
 
-export interface IInformacionContacto {
-  contacto?: string;
-  telefono?: string;
-  interno?: string;
-  email?: string;
+export const InformacionContactoSchema = z.object({
+  contacto: z.string().optional(),
+  telefono: z.string().optional(),
+  interno: z.string().optional(),
+  email: z.string().optional(),
 
   // Solo cuando es contacto de alarma
-  palabraSeguridadNormal?: string;
-  palabraSeguridadEmergencia?: string;
-  numeroUsuarioAlarma?: number;
-  particion: number;
-}
+  palabraSeguridadNormal: z.string().optional(),
+  palabraSeguridadEmergencia: z.string().optional(),
+  numeroUsuarioAlarma: z.number().optional(),
+  particion: z.number(),
+});
+export type IInformacionContacto = z.infer<typeof InformacionContactoSchema>;
 
-export type IInformacion = IInformacionNota & IInformacionContacto;
-export interface INota {
-  _id?: string;
-  idCliente?: string;
-  idsAncestros?: string[];
-  idAsignado?: string;
-  permanente?: boolean;
-  vigenciaDesde?: string;
-  vigenciaHasta?: string;
-  tipo?: TipoNota;
-  informacion?: IInformacion;
-  orden?: number;
+// IInformacion era IInformacionNota & IInformacionContacto (intersección de objetos)
+export const InformacionSchema = InformacionNotaSchema.extend(
+  InformacionContactoSchema.shape,
+);
+export type IInformacion = z.infer<typeof InformacionSchema>;
+
+export const NotaSchema = z.object({
+  _id: z.string().optional(),
+  idCliente: z.string().optional(),
+  idsAncestros: z.array(z.string()).optional(),
+  idAsignado: z.string().optional(),
+  permanente: z.boolean().optional(),
+  vigenciaDesde: z.string().optional(),
+  vigenciaHasta: z.string().optional(),
+  tipo: TipoNotaSchema.optional(),
+  informacion: InformacionSchema.optional(),
+  orden: z.number().optional(),
   //Para contactos
-  inhabilitadoDesde?: string; //Durante el período inhabilitado, no se mostrará el conatcto en el tratamiento de los eventos
-  inhabilitadoHasta?: string;
+  inhabilitadoDesde: z.string().optional(), //Durante el período inhabilitado, no se mostrará el conatcto en el tratamiento de los eventos
+  inhabilitadoHasta: z.string().optional(),
   // Populate
-  cliente?: ICliente;
-  ancestros?: ICliente[];
-  activo?: IActivo;
-  alarma?: IDispositivoAlarma;
-  luminaria?: ILuminaria;
-}
+  cliente: ClienteSchema.optional(),
+  ancestros: z.array(ClienteSchema).optional(),
+  activo: ActivoSchema.optional(),
+  alarma: DispositivoAlarmaSchema.optional(),
+  luminaria: LuminariaSchema.optional(),
+});
+export type INota = z.infer<typeof NotaSchema>;
 
-type OmitirCreate = '_id' | 'cliente';
+export const CreateNotaSchema = NotaSchema.omit({
+  _id: true,
+  cliente: true,
+});
+export type ICreateNota = z.infer<typeof CreateNotaSchema>;
 
-export interface ICreateNota extends Omit<Partial<INota>, OmitirCreate> {}
+export const UpdateNotaSchema = NotaSchema.omit({
+  _id: true,
+  cliente: true,
+});
+export type IUpdateNota = z.infer<typeof UpdateNotaSchema>;
 
-type OmitirUpdate = '_id' | 'cliente';
-
-export interface IUpdateNota extends Omit<Partial<INota>, OmitirUpdate> {}
-
-export interface INotaCache extends Omit<
-  INota,
-  'cliente' | 'ancestros' | 'activo' | 'alarma' | 'luminaria'
-> {}
+export const NotaCacheSchema = NotaSchema.omit({
+  cliente: true,
+  ancestros: true,
+  activo: true,
+  alarma: true,
+  luminaria: true,
+});
+export type INotaCache = z.infer<typeof NotaCacheSchema>;

--- a/src/interfaces/notificacion.ts
+++ b/src/interfaces/notificacion.ts
@@ -1,31 +1,36 @@
-import { ICliente } from './cliente';
-import { IRecordatorio } from './recordatorio';
-import { IUsuario } from './usuario';
+import { z } from 'zod';
+import { ClienteSchema } from './cliente';
+import { UsuarioSchema } from './usuario';
 
-export interface INotificacion {
-  _id?: string;
-  idCliente?: string;
-  idsAncestros?: string[];
-  idUsuario?: string;
-  fechaCreacion?: string;
-  fechaLeido?: string;
-  leido?: boolean;
-  archivado?: boolean;
-  titulo?: string;
-  mensaje?: string;
+export const NotificacionSchema = z.object({
+  _id: z.string().optional(),
+  idCliente: z.string().optional(),
+  idsAncestros: z.array(z.string()).optional(),
+  idUsuario: z.string().optional(),
+  fechaCreacion: z.string().optional(),
+  fechaLeido: z.string().optional(),
+  leido: z.boolean().optional(),
+  archivado: z.boolean().optional(),
+  titulo: z.string().optional(),
+  mensaje: z.string().optional(),
 
   // Populate
-  cliente?: ICliente;
-  ancestros?: ICliente[];
-  usuario?: IUsuario;
-}
+  cliente: ClienteSchema.optional(),
+  ancestros: z.array(ClienteSchema).optional(),
+  usuario: UsuarioSchema.optional(),
+});
+export type INotificacion = z.infer<typeof NotificacionSchema>;
 
-type OmitirCreate = '_id' | 'cliente' | 'usuario';
+export const CreateNotificacionSchema = NotificacionSchema.omit({
+  _id: true,
+  cliente: true,
+  usuario: true,
+});
+export type ICreateNotificacion = z.infer<typeof CreateNotificacionSchema>;
 
-export interface ICreateNotificacion
-  extends Omit<Partial<INotificacion>, OmitirCreate> {}
-
-type OmitirUpdate = '_id' | 'cliente' | 'usuario';
-
-export interface IUpdateNotificacion
-  extends Omit<Partial<INotificacion>, OmitirUpdate> {}
+export const UpdateNotificacionSchema = NotificacionSchema.omit({
+  _id: true,
+  cliente: true,
+  usuario: true,
+});
+export type IUpdateNotificacion = z.infer<typeof UpdateNotificacionSchema>;

--- a/src/interfaces/password-reset.ts
+++ b/src/interfaces/password-reset.ts
@@ -1,20 +1,27 @@
-import { IUsuario } from './usuario';
+import { z } from 'zod';
+import { UsuarioSchema } from './usuario';
 
-export interface IPasswordReset {
-  _id?: string;
-  fechaCreacion?: string;
-  idUsuario?: string;
-  token?: string;
-  vencimiento?: string;
-  utilizado?: boolean;
+export const PasswordResetSchema = z.object({
+  _id: z.string().optional(),
+  fechaCreacion: z.string().optional(),
+  idUsuario: z.string().optional(),
+  token: z.string().optional(),
+  vencimiento: z.string().optional(),
+  utilizado: z.boolean().optional(),
 
   // virtuals
-  usuario?: IUsuario;
-}
+  usuario: UsuarioSchema.optional(),
+});
+export type IPasswordReset = z.infer<typeof PasswordResetSchema>;
 
-type Omitir = '_id' | 'usuario';
-export interface ICreatePasswordReset
-  extends Omit<Partial<IPasswordReset>, Omitir> {}
+export const CreatePasswordResetSchema = PasswordResetSchema.omit({
+  _id: true,
+  usuario: true,
+});
+export type ICreatePasswordReset = z.infer<typeof CreatePasswordResetSchema>;
 
-export interface IUpdatePasswordReset
-  extends Omit<Partial<IPasswordReset>, Omitir> {}
+export const UpdatePasswordResetSchema = PasswordResetSchema.omit({
+  _id: true,
+  usuario: true,
+});
+export type IUpdatePasswordReset = z.infer<typeof UpdatePasswordResetSchema>;

--- a/src/interfaces/permiso.ts
+++ b/src/interfaces/permiso.ts
@@ -1,43 +1,107 @@
-import { IActivo } from './activo';
-import { ICliente } from './cliente';
-import { IDispositivoAlarma } from './dispositivo-alarma';
-import { IGrupo } from './grupo';
-import { ILuminaria } from './luminaria';
-import { IRol } from './rol';
-import { IModulos, IUsuario, Rol } from './usuario';
+import { z } from 'zod';
+import type { IActivo } from './activo';
+import { ClienteSchema, ICliente } from './cliente';
+import type { IDispositivoAlarma } from './dispositivo-alarma';
+import type { IGrupo } from './grupo';
+import type { ILuminaria } from './luminaria';
+import { IRol, RolSchema } from './rol';
+import type { IModulos, IUsuario, Rol } from './usuario';
 
-export type Nivel = 'Cliente' | 'Grupo' | 'Entidad';
-export type TipoEntidadPermiso =
-  | 'Activo'
-  | 'Vehículo'
-  | 'Colectivo'
-  | 'Luminaria'
-  | 'Alarma'
-  | 'Cámara';
+export const NivelSchema = z.enum(['Cliente', 'Grupo', 'Entidad']);
+export type Nivel = z.infer<typeof NivelSchema>;
 
-export interface IVencimientoPermisoUsuario {
+export const TipoEntidadPermisoSchema = z.enum([
+  'Activo',
+  'Vehículo',
+  'Colectivo',
+  'Luminaria',
+  'Alarma',
+  'Cámara',
+]);
+export type TipoEntidadPermiso = z.infer<typeof TipoEntidadPermisoSchema>;
+
+export const VencimientoPermisoUsuarioSchema = z.object({
   // Venicimiento de un permiso con sus respectivas opciones
-  fechaVencimiento?: string;
-  eliminarPermiso?: boolean;
-  desactivarUsuario?: boolean;
-  eliminarUsuario?: boolean;
-}
+  fechaVencimiento: z.string().optional(),
+  eliminarPermiso: z.boolean().optional(),
+  desactivarUsuario: z.boolean().optional(),
+  eliminarUsuario: z.boolean().optional(),
+});
+export type IVencimientoPermisoUsuario = z.infer<
+  typeof VencimientoPermisoUsuarioSchema
+>;
 
-export interface ICredencialesSeguridad {
-  usuario?: string;
-  claveEncriptada?: string;
-}
+export const CredencialesSeguridadSchema = z.object({
+  usuario: z.string().optional(),
+  claveEncriptada: z.string().optional(),
+});
+export type ICredencialesSeguridad = z.infer<
+  typeof CredencialesSeguridadSchema
+>;
 
 //Par actualizar credenciales de seguridad vía PUT /:id/credencialesSeguridad, se recibe este DTO con los datos en texto plano
 // (la gestion-api-gestion se encarga de cifrar la clave antes de persistir)
-export interface IUpdateCredencialesSeguridad {
-  idCliente: string;
-  usuario: string;
-  clave: string;
+export const UpdateCredencialesSeguridadSchema = z.object({
+  idCliente: z.string(),
+  usuario: z.string(),
+  clave: z.string(),
   // _id del permiso al que aplicar las credenciales (antes era el índice en el array de Usuario)
-  idPermiso?: string;
-}
+  idPermiso: z.string().optional(),
+});
+export type IUpdateCredencialesSeguridad = z.infer<
+  typeof UpdateCredencialesSeguridadSchema
+>;
 
+// Populates intra-SCC como z.custom (import type-only): un schema real acá
+// arrastra el shape completo del ciclo y revienta la serialización de
+// declarations (TS7056) acá y en los consumidores NestJS.
+export const PermisoSchema = z.object({
+  _id: z.string().optional(),
+  // Vínculo con el usuario: nombre de usuario normalizado (lowercase/trim).
+  // El permiso puede existir aunque el usuario todavía no esté registrado.
+  nombreUsuario: z.string().optional(),
+  fechaCreacion: z.string().optional(),
+  //
+  nivel: NivelSchema.optional(),
+  // Para nivel Cliente
+  idCliente: z.string().optional(),
+  includeChildren: z.boolean().optional(),
+  idsAncestros: z.array(z.string()).optional(),
+  // Para nivel Grupo
+  idsGrupos: z.array(z.string()).optional(),
+  // Para nivel Entidad
+  tipoEntidad: TipoEntidadPermisoSchema.optional(),
+  idsEntidades: z.array(z.string()).optional(),
+  //
+  activo: z.boolean().optional(), // Si el permiso está activo o no
+  vencimiento: VencimientoPermisoUsuarioSchema.optional(),
+  modulos: z.custom<IModulos>().optional(),
+
+  /**
+   * @deprecated El campo 'roles' está en desuso. Se eliminará en futuras versiones. Los reemplaza "idsRoles" y el virtual "Rols"
+   */
+  roles: z.array(z.custom<Rol>()).optional(),
+
+  idsRoles: z.array(z.string()).optional(), // IDs de los roles asignados al permiso
+
+  credencialesSeguridad: CredencialesSeguridadSchema.optional(), // Credenciales del sistema de seguridad (AES encriptadas)
+  tieneCredencialesSeguridad: z.boolean().optional(), // Virtual: true si el permiso tiene credenciales configuradas
+
+  // Virtual
+  usuario: z.custom<IUsuario>().optional(), // Usuario vinculado, populado por nombreUsuario
+  cliente: ClienteSchema.optional(),
+  ancestros: z.array(ClienteSchema).optional(),
+  grupos: z.array(z.custom<IGrupo>()).optional(),
+  activos: z.array(z.custom<IActivo>()).optional(), // Entidades pobladas según el tipoEntidad
+  luminarias: z.array(z.custom<ILuminaria>()).optional(), // Entidades pobladas según el tipoEntidad
+  alarmas: z.array(z.custom<IDispositivoAlarma>()).optional(), // Entidades pobladas según el tipoEntidad
+  rols: z.array(RolSchema).optional(), // Roles poblados según idsRoles
+});
+
+/**
+ * Interface hand-written (misma forma que el schema): los tipos de entidad del
+ * SCC no usan z.infer para no arrastrar el ciclo en el declaration emit.
+ */
 export interface IPermiso {
   _id?: string;
   // Vínculo con el usuario: nombre de usuario normalizado (lowercase/trim).
@@ -94,10 +158,36 @@ type OmitirVirtuals =
 
 type OmitirCreate = '_id' | 'fechaCreacion' | OmitirVirtuals;
 
+export const CreatePermisoSchema = PermisoSchema.omit({
+  _id: true,
+  fechaCreacion: true,
+  usuario: true,
+  cliente: true,
+  ancestros: true,
+  grupos: true,
+  activos: true,
+  luminarias: true,
+  alarmas: true,
+  rols: true,
+  tieneCredencialesSeguridad: true,
+});
 export interface ICreatePermiso
   extends Omit<Partial<IPermiso>, OmitirCreate> {}
 
 type OmitirUpdate = '_id' | 'fechaCreacion' | OmitirVirtuals;
 
+export const UpdatePermisoSchema = PermisoSchema.omit({
+  _id: true,
+  fechaCreacion: true,
+  usuario: true,
+  cliente: true,
+  ancestros: true,
+  grupos: true,
+  activos: true,
+  luminarias: true,
+  alarmas: true,
+  rols: true,
+  tieneCredencialesSeguridad: true,
+});
 export interface IUpdatePermiso
   extends Omit<Partial<IPermiso>, OmitirUpdate> {}

--- a/src/interfaces/personal-salud.ts
+++ b/src/interfaces/personal-salud.ts
@@ -1,30 +1,32 @@
-import { ICliente } from './cliente';
+import { z } from 'zod';
+import { ClienteSchema } from './cliente';
 
-export interface IPersonalSalud {
-  _id?: string;
-  idCliente?: string;
-  idsAncestros?: string[];
+export const PersonalSaludSchema = z.object({
+  _id: z.string().optional(),
+  idCliente: z.string().optional(),
+  idsAncestros: z.array(z.string()).optional(),
 
-  fechaCreacion?: string;
-  nombre?: string; // Nombre completo
-  rol?: 'Médico' | 'Enfermero';
-  matricula?: string; // Matrícula profesional
-  dni?: string;
-  telefono?: string;
-  email?: string;
-  activo?: boolean; // Disponibilidad laboral
+  fechaCreacion: z.string().optional(),
+  nombre: z.string().optional(), // Nombre completo
+  rol: z.enum(['Médico', 'Enfermero']).optional(),
+  matricula: z.string().optional(), // Matrícula profesional
+  dni: z.string().optional(),
+  telefono: z.string().optional(),
+  email: z.string().optional(),
+  activo: z.boolean().optional(), // Disponibilidad laboral
 
   //Populate
-  cliente?: ICliente;
-  ancestros?: ICliente[];
-}
+  cliente: ClienteSchema.optional(),
+  ancestros: z.array(ClienteSchema).optional(),
+});
+export type IPersonalSalud = z.infer<typeof PersonalSaludSchema>;
 
-type OmitirCreate = '_id';
+export const CreatePersonalSaludSchema = PersonalSaludSchema.omit({
+  _id: true,
+});
+export type ICreatePersonalSalud = z.infer<typeof CreatePersonalSaludSchema>;
 
-export interface ICreatePersonalSalud
-  extends Omit<Partial<IPersonalSalud>, OmitirCreate> {}
-
-type OmitirUpdate = '_id';
-
-export interface IUpdatePersonalSalud
-  extends Omit<Partial<IPersonalSalud>, OmitirUpdate> {}
+export const UpdatePersonalSaludSchema = PersonalSaludSchema.omit({
+  _id: true,
+});
+export type IUpdatePersonalSalud = z.infer<typeof UpdatePersonalSaludSchema>;

--- a/src/interfaces/prediccion-cercana.ts
+++ b/src/interfaces/prediccion-cercana.ts
@@ -1,65 +1,71 @@
-import { ICoordenadas } from '../auxiliares';
-import { IParada } from './recorrido';
+import { z } from 'zod';
+import { CoordenadasSchema } from '../auxiliares';
+import { ParadaSchema } from './recorrido';
 
 /**
  * Interfaz para la predicción de llegada de un vehículo a una parada
  */
-export interface ICercana {
+export const CercanaSchema = z.object({
   /**
    * Tiempo estimado de llegada en segundos (solo viaje)
    */
-  tiempo?: number;
+  tiempo: z.number().optional(),
   /**
    * Tiempo procesado en segundos (viaje + tiempos de parada)
    */
-  tiempoProcesado?: number;
+  tiempoProcesado: z.number().optional(),
   /**
    * Paradas restantes antes de llegar al destino
    */
-  paradasRestantes?: IParada[];
+  paradasRestantes: z.array(ParadaSchema).optional(),
   /**
    * Distancia en metros hasta la parada destino
    */
-  distancia?: number;
+  distancia: z.number().optional(),
   /**
    * Geometría de la ruta calculada
    */
-  ruta?: ICoordenadas[];
+  ruta: z.array(CoordenadasSchema).optional(),
   /**
    * Información del vehículo
    */
-  vehiculo?: {
-    /**
-     * Ubicación actual del vehículo
-     */
-    ubicacionActual?: ICoordenadas;
-    /**
-     * Identificación del vehículo
-     */
-    identificacion?: string;
-    /**
-     * Dominio del vehículo (patente)
-     */
-    dominio?: string;
-  };
+  vehiculo: z
+    .object({
+      /**
+       * Ubicación actual del vehículo
+       */
+      ubicacionActual: CoordenadasSchema.optional(),
+      /**
+       * Identificación del vehículo
+       */
+      identificacion: z.string().optional(),
+      /**
+       * Dominio del vehículo (patente)
+       */
+      dominio: z.string().optional(),
+    })
+    .optional(),
   /**
    * Información del último trackeo registrado
    */
-  trackeo?: {
-    /**
-     * Fecha del último trackeo
-     */
-    fecha?: string;
-    /**
-     * Nombre de la última parada registrada
-     */
-    parada?: string;
-  };
+  trackeo: z
+    .object({
+      /**
+       * Fecha del último trackeo
+       */
+      fecha: z.string().optional(),
+      /**
+       * Nombre de la última parada registrada
+       */
+      parada: z.string().optional(),
+    })
+    .optional(),
   /**
    * Mensaje en caso de no haber vehículos disponibles
    */
-  mensaje?: string;
-}
+  mensaje: z.string().optional(),
+});
+export type ICercana = z.infer<typeof CercanaSchema>;
 
 /**
  * Interfaz para la respuesta del endpoint de predicciones cercanas
@@ -69,57 +75,60 @@ export interface ICercana {
  * cercanas (radio 50m), mostrando solo la parada más cercana por recorrido.
  * La predicción es opcional y solo está presente cuando hay vehículos disponibles.
  */
-export interface IPrediccionCercana {
+export const PrediccionCercanaSchema = z.object({
   /**
    * Información de la parada más cercana del recorrido
    */
-  parada: IParada;
+  parada: ParadaSchema,
   /**
    * Información resumida del recorrido
    */
-  recorrido: {
+  recorrido: z.object({
     /**
      * ID del recorrido
      */
-    _id: string;
+    _id: z.string(),
     /**
      * Nombre/número del recorrido
      */
-    nombre: string;
+    nombre: z.string(),
     /**
      * Destino del recorrido
      */
-    destino?: string;
+    destino: z.string().optional(),
     /**
      * Color del recorrido (para UI)
      */
-    color?: string;
+    color: z.string().optional(),
     /**
      * Nombre de la flota/línea (ej: "518")
      */
-    nombreFlota?: string;
+    nombreFlota: z.string().optional(),
     /**
      * Información del grupo/línea al que pertenece el recorrido
      */
-    grupo?: {
-      /**
-       * ID del grupo
-       */
-      _id?: string;
-      /**
-       * Nombre del grupo/línea
-       */
-      nombre?: string;
-      /**
-       * Color del grupo/línea
-       */
-      color?: string;
-    };
-  };
+    grupo: z
+      .object({
+        /**
+         * ID del grupo
+         */
+        _id: z.string().optional(),
+        /**
+         * Nombre del grupo/línea
+         */
+        nombre: z.string().optional(),
+        /**
+         * Color del grupo/línea
+         */
+        color: z.string().optional(),
+      })
+      .optional(),
+  }),
   /**
    * Predicción de llegada del próximo vehículo (opcional)
    * Solo presente cuando hay un vehículo disponible en el recorrido.
    * Si no hay predicción, el totem puede mostrar "No disponible" o similar.
    */
-  prediccion?: ICercana;
-}
+  prediccion: CercanaSchema.optional(),
+});
+export type IPrediccionCercana = z.infer<typeof PrediccionCercanaSchema>;

--- a/src/interfaces/proveedor.ts
+++ b/src/interfaces/proveedor.ts
@@ -1,27 +1,35 @@
-import { ICoordenadas } from '../auxiliares';
-import { ICliente } from './cliente';
+import { z } from 'zod';
+import { CoordenadasSchema } from '../auxiliares';
+import { ClienteSchema } from './cliente';
 
-export type TipoProveedor = 'Mecanico' | 'Combustible' | 'Otro';
-export type CategoriaProveedor = 'Colectivo' | 'Vehiculo';
-export interface IProveedor {
-  _id?: string;
-  categoria?: CategoriaProveedor;
-  tipos?: TipoProveedor[];
-  idCliente?: string;
-  idsAncestros?: string[];
-  nombre?: string;
-  ubicacion?: ICoordenadas;
+export const TipoProveedorSchema = z.enum(['Mecanico', 'Combustible', 'Otro']);
+export type TipoProveedor = z.infer<typeof TipoProveedorSchema>;
+
+export const CategoriaProveedorSchema = z.enum(['Colectivo', 'Vehiculo']);
+export type CategoriaProveedor = z.infer<typeof CategoriaProveedorSchema>;
+
+export const ProveedorSchema = z.object({
+  _id: z.string().optional(),
+  categoria: CategoriaProveedorSchema.optional(),
+  tipos: z.array(TipoProveedorSchema).optional(),
+  idCliente: z.string().optional(),
+  idsAncestros: z.array(z.string()).optional(),
+  nombre: z.string().optional(),
+  ubicacion: CoordenadasSchema.optional(),
   // Populate
-  cliente?: ICliente;
-  ancestros?: ICliente[];
-}
+  cliente: ClienteSchema.optional(),
+  ancestros: z.array(ClienteSchema).optional(),
+});
+export type IProveedor = z.infer<typeof ProveedorSchema>;
 
-type OmitirCreate = '_id' | 'cliente';
+export const CreateProveedorSchema = ProveedorSchema.omit({
+  _id: true,
+  cliente: true,
+});
+export type ICreateProveedor = z.infer<typeof CreateProveedorSchema>;
 
-export interface ICreateProveedor
-  extends Omit<Partial<IProveedor>, OmitirCreate> {}
-
-type OmitirUpdate = '_id' | 'cliente';
-
-export interface IUpdateProveedor
-  extends Omit<Partial<IProveedor>, OmitirUpdate> {}
+export const UpdateProveedorSchema = ProveedorSchema.omit({
+  _id: true,
+  cliente: true,
+});
+export type IUpdateProveedor = z.infer<typeof UpdateProveedorSchema>;

--- a/src/interfaces/puesta.ts
+++ b/src/interfaces/puesta.ts
@@ -1,8 +1,9 @@
-import { IGeoJSONPoint } from '../auxiliares';
-import { ICliente } from './cliente';
-import { IConfigPerfil } from './config-perfil';
-import { IGrupo } from './grupo';
-import { ILuminaria } from './luminaria';
+import { z } from 'zod';
+import { GeoJSONPointSchema, IGeoJSONPoint } from '../auxiliares';
+import { ClienteSchema, ICliente } from './cliente';
+import type { IConfigPerfil } from './config-perfil';
+import type { IGrupo } from './grupo';
+import type { ILuminaria } from './luminaria';
 
 /**
  * Puesta = soporte físico / punto de luz del alumbrado (columna, poste, ménsula de fachada, colgante).
@@ -11,29 +12,55 @@ import { ILuminaria } from './luminaria';
  * Es OPCIONAL en el sistema: solo se usa para clientes con
  * `cliente.config.moduloLuminarias.usaPuestas`. La luminaria adquiere la `ubicacion` desde su puesta.
  */
+export const PuestaSchema = z.object({
+  _id: z.string().optional(),
+  idCliente: z.string().optional(),
+  idsAncestros: z.array(z.string()).optional(),
+  fechaCreacion: z.string().optional(),
+
+  identificacion: z.string().optional(),
+  ubicacion: GeoJSONPointSchema.optional(), // fuente de verdad de la georreferencia, es la que adquieren las luminarias asignadas a esta puesta
+  direccion: z.string().optional(),
+
+  idsGrupos: z.array(z.string()).optional(),
+  idsPerfilConfig: z.array(z.string()).optional(), // Perfil(es) a nivel puesta
+
+  // Virtuals
+  // Populates intra-SCC como z.custom (import type-only): un schema real acá
+  // arrastra el shape completo del ciclo y revienta la serialización de
+  // declarations (TS7056) acá y en los consumidores NestJS.
+  luminarias: z.array(z.custom<ILuminaria>()).optional(), // luminaria.idPuesta == puesta._id
+  grupos: z.array(z.custom<IGrupo>()).optional(),
+  perfilConfigs: z.array(z.custom<IConfigPerfil>()).optional(),
+  cliente: ClienteSchema.optional(),
+  ancestros: z.array(ClienteSchema).optional(),
+});
+
+/**
+ * Interface hand-written (misma forma que z.infer<typeof PuestaSchema>).
+ * NO usar z.infer acá: el ciclo puesta ↔ luminaria a través de dos z.infer
+ * mutuamente recursivos dispara TS2589; la interface corta el ciclo porque
+ * TS la resuelve lazy.
+ */
 export interface IPuesta {
   _id?: string;
   idCliente?: string;
   idsAncestros?: string[];
   fechaCreacion?: string;
-
   identificacion?: string;
-  ubicacion?: IGeoJSONPoint; // fuente de verdad de la georreferencia, es la que adquieren las luminarias asignadas a esta puesta
+  ubicacion?: IGeoJSONPoint;
   direccion?: string;
-
   idsGrupos?: string[];
-  idsPerfilConfig?: string[]; // Perfil(es) a nivel puesta
-
+  idsPerfilConfig?: string[];
   // Virtuals
-  luminarias?: ILuminaria[]; // luminaria.idPuesta == puesta._id
+  luminarias?: ILuminaria[];
   grupos?: IGrupo[];
   perfilConfigs?: IConfigPerfil[];
   cliente?: ICliente;
   ancestros?: ICliente[];
 }
 
-////// CREATE
-type OmitirCreate =
+type OmitirCreateUpdate =
   | '_id'
   | 'fechaCreacion'
   | 'idsAncestros'
@@ -43,17 +70,28 @@ type OmitirCreate =
   | 'cliente'
   | 'ancestros';
 
-export interface ICreatePuesta extends Omit<Partial<IPuesta>, OmitirCreate> {}
+////// CREATE
+export const CreatePuestaSchema = PuestaSchema.omit({
+  _id: true,
+  fechaCreacion: true,
+  idsAncestros: true,
+  luminarias: true,
+  grupos: true,
+  perfilConfigs: true,
+  cliente: true,
+  ancestros: true,
+});
+export type ICreatePuesta = Omit<IPuesta, OmitirCreateUpdate>;
 
 ////// UPDATE
-type OmitirUpdate =
-  | '_id'
-  | 'fechaCreacion'
-  | 'idsAncestros'
-  | 'luminarias'
-  | 'grupos'
-  | 'perfilConfigs'
-  | 'cliente'
-  | 'ancestros';
-
-export interface IUpdatePuesta extends Omit<Partial<IPuesta>, OmitirUpdate> {}
+export const UpdatePuestaSchema = PuestaSchema.omit({
+  _id: true,
+  fechaCreacion: true,
+  idsAncestros: true,
+  luminarias: true,
+  grupos: true,
+  perfilConfigs: true,
+  cliente: true,
+  ancestros: true,
+});
+export type IUpdatePuesta = Omit<IPuesta, OmitirCreateUpdate>;

--- a/src/interfaces/recordatorio.ts
+++ b/src/interfaces/recordatorio.ts
@@ -1,24 +1,33 @@
-import { IActivo } from './activo';
-import { ICliente } from './cliente';
-import { IDocumentacion } from './documentacion';
-import { IUsuario } from './usuario';
+import { z } from 'zod';
+import { ActivoSchema } from './activo';
+import { ClienteSchema } from './cliente';
+import { DocumentacionSchema } from './documentacion';
+import { UsuarioSchema } from './usuario';
 
-export type TipoRecordatorio = 'km' | 'fecha';
-export type CategoriaRecordatorio = 'Colectivo' | 'Vehiculo';
-export type SubcategoriaRecordatorio =
-  | 'Cambio de aceite y filtro'
-  | 'Cambio de aceite de caja'
-  | 'Cambio de líquido refrigerante'
-  | 'Cambio de filtro de combustible'
-  | 'Cambio de filtro de aire'
-  | 'Cambio de filtro de habitáculo'
-  | 'Cambio de batería'
-  | 'Cambio de cubiertas'
-  | 'Cambio de luces'
-  | 'Cambio de líquido de frenos'
-  | 'Cambio de pastillas de freno'
-  | 'Cambio de bujías'
-  | 'Otro';
+export const TipoRecordatorioSchema = z.enum(['km', 'fecha']);
+export type TipoRecordatorio = z.infer<typeof TipoRecordatorioSchema>;
+
+export const CategoriaRecordatorioSchema = z.enum(['Colectivo', 'Vehiculo']);
+export type CategoriaRecordatorio = z.infer<typeof CategoriaRecordatorioSchema>;
+
+export const SubcategoriaRecordatorioSchema = z.enum([
+  'Cambio de aceite y filtro',
+  'Cambio de aceite de caja',
+  'Cambio de líquido refrigerante',
+  'Cambio de filtro de combustible',
+  'Cambio de filtro de aire',
+  'Cambio de filtro de habitáculo',
+  'Cambio de batería',
+  'Cambio de cubiertas',
+  'Cambio de luces',
+  'Cambio de líquido de frenos',
+  'Cambio de pastillas de freno',
+  'Cambio de bujías',
+  'Otro',
+]);
+export type SubcategoriaRecordatorio = z.infer<
+  typeof SubcategoriaRecordatorioSchema
+>;
 
 //RECORDATORIOS DE MANTENIMIENTO
 //- Se generan desde los módulos de vehículos o colectivos en el front end
@@ -36,43 +45,48 @@ export type SubcategoriaRecordatorio =
 //- La documentación de licencia/seguro es para choferes y conductores, se crean desde el listado de choferes/conductores en la acción documentos
 
 //💡💡💡 Creo que esto de los recordatorios debería ser mas genérico porque podría servir para otras entidades. Además, actualmente es confuso porque se mezclan recordatorios de mantenimiento con los de documentación. Podríamos agregar un campo "tipo" que indique si es un recordatorio de mantenimiento o de documentación, y así podríamos tener campos específicos para cada tipo sin que queden confusos.
-export interface IRecordatorio {
-  _id?: string;
-  categoria?: CategoriaRecordatorio;
-  subcategoria?: SubcategoriaRecordatorio;
-  idCliente?: string;
-  idsAncestros?: string[];
-  idUsuario?: string;
-  tipo?: TipoRecordatorio[];
-  notificado?: boolean;
-  fechaLimite?: string;
-  fechaCreacion?: string;
-  kmLimite?: number;
-  idActivo?: string;
-  idDocumentacion?: string;
-  detallesDelMantenimiento?: string;
-  repetible?: boolean;
-  frecuenciaKm?: number;
-  frecuenciaDia?: number;
+export const RecordatorioSchema = z.object({
+  _id: z.string().optional(),
+  categoria: CategoriaRecordatorioSchema.optional(),
+  subcategoria: SubcategoriaRecordatorioSchema.optional(),
+  idCliente: z.string().optional(),
+  idsAncestros: z.array(z.string()).optional(),
+  idUsuario: z.string().optional(),
+  tipo: z.array(TipoRecordatorioSchema).optional(),
+  notificado: z.boolean().optional(),
+  fechaLimite: z.string().optional(),
+  fechaCreacion: z.string().optional(),
+  kmLimite: z.number().optional(),
+  idActivo: z.string().optional(),
+  idDocumentacion: z.string().optional(),
+  detallesDelMantenimiento: z.string().optional(),
+  repetible: z.boolean().optional(),
+  frecuenciaKm: z.number().optional(),
+  frecuenciaDia: z.number().optional(),
 
   // Populate
-  cliente?: ICliente;
-  ancestros?: ICliente[];
-  usuario?: IUsuario;
-  activo?: IActivo;
-  documentacion?: IDocumentacion;
-}
+  cliente: ClienteSchema.optional(),
+  ancestros: z.array(ClienteSchema).optional(),
+  usuario: UsuarioSchema.optional(),
+  activo: ActivoSchema.optional(),
+  documentacion: DocumentacionSchema.optional(),
+});
+export type IRecordatorio = z.infer<typeof RecordatorioSchema>;
 
-type OmitirCreate = '_id' | 'cliente' | 'activo' | 'documentacion' | 'usuario';
+export const CreateRecordatorioSchema = RecordatorioSchema.omit({
+  _id: true,
+  cliente: true,
+  activo: true,
+  documentacion: true,
+  usuario: true,
+});
+export type ICreateRecordatorio = z.infer<typeof CreateRecordatorioSchema>;
 
-export interface ICreateRecordatorio extends Omit<
-  Partial<IRecordatorio>,
-  OmitirCreate
-> {}
-
-type OmitirUpdate = '_id' | 'cliente' | 'activo' | 'documentacion' | 'usuario';
-
-export interface IUpdateRecordatorio extends Omit<
-  Partial<IRecordatorio>,
-  OmitirUpdate
-> {}
+export const UpdateRecordatorioSchema = RecordatorioSchema.omit({
+  _id: true,
+  cliente: true,
+  activo: true,
+  documentacion: true,
+  usuario: true,
+});
+export type IUpdateRecordatorio = z.infer<typeof UpdateRecordatorioSchema>;

--- a/src/interfaces/recorrido.ts
+++ b/src/interfaces/recorrido.ts
@@ -1,44 +1,87 @@
+import { z } from 'zod';
 import {
+  CoordenadaOLSchema,
+  CoordenadasSchema,
+  GeoJSONLineStringSchema,
+  GeoJSONPointSchema,
   ICoordenadaOL,
   ICoordenadas,
   IGeoJSONLineString,
-  IGeoJSONPoint,
 } from '../auxiliares';
-import { ICliente } from './cliente';
-import { IGrupo } from './grupo';
-import { IUbicacion } from './ubicacion';
+import { ClienteSchema, ICliente } from './cliente';
+import type { IGrupo } from './grupo';
+import type { IUbicacion } from './ubicacion';
 
-export type ITipoParada = 'refugio' | 'parada';
+export const TipoParadaSchema = z.enum(['refugio', 'parada']);
+export type ITipoParada = z.infer<typeof TipoParadaSchema>;
 
-export interface IParada {
-  _id?: string;
+export const ParadaSchema = z.object({
+  _id: z.string().optional(),
   /**
    * @deprecated Se usa ubicacionOl.
    */
-  ubicacion?: ICoordenadas;
-  ubicacionOl?: ICoordenadaOL;
-  geojson?: IGeoJSONPoint;
-  nombre?: string;
-  direccion?: string;
-  destino?: string;
-  por?: string;
-  subida?: boolean;
-  bajada?: boolean;
-  tipo?: ITipoParada;
+  ubicacion: CoordenadasSchema.optional(),
+  ubicacionOl: CoordenadaOLSchema.optional(),
+  geojson: GeoJSONPointSchema.optional(),
+  nombre: z.string().optional(),
+  direccion: z.string().optional(),
+  destino: z.string().optional(),
+  por: z.string().optional(),
+  subida: z.boolean().optional(),
+  bajada: z.boolean().optional(),
+  tipo: TipoParadaSchema.optional(),
   /**
    * Tiempo que se suma al recorrido, es lo que se estima que tarda el colectivo en esa parada
    */
-  tiempoParada?: number;
-}
+  tiempoParada: z.number().optional(),
+});
+export type IParada = z.infer<typeof ParadaSchema>;
 
-export interface IFranjaHoraria {
-  dia?: number; // Número de 0 a 6, siendo 0 el domingo
-  desde?: string;
-  hasta?: string;
-  frecuenciaMinutos?: number;
-}
+export const FranjaHorariaSchema = z.object({
+  dia: z.number().optional(), // Número de 0 a 6, siendo 0 el domingo
+  desde: z.string().optional(),
+  hasta: z.string().optional(),
+  frecuenciaMinutos: z.number().optional(),
+});
+export type IFranjaHoraria = z.infer<typeof FranjaHorariaSchema>;
 
-export type ICategoriaRecorrido = 'Colectivo' | 'Vehiculo';
+export const CategoriaRecorridoSchema = z.enum(['Colectivo', 'Vehiculo']);
+export type ICategoriaRecorrido = z.infer<typeof CategoriaRecorridoSchema>;
+
+// Populates intra-SCC como z.custom (import type-only): un schema real acá
+// arrastra el shape completo del ciclo y revienta la serialización de
+// declarations (TS7056) acá y en los consumidores NestJS.
+export const RecorridoSchema = z.object({
+  _id: z.string().optional(),
+  idCliente: z.string().optional(),
+  idsAncestros: z.array(z.string()).optional(),
+  //
+  categoria: CategoriaRecorridoSchema.optional(),
+  idExterno: z.string().optional(),
+  idGrupo: z.string().optional(),
+  nombreFlota: z.string().optional(),
+  nombre: z.string().optional(),
+  geojson: GeoJSONLineStringSchema.optional(),
+  paradas: z.array(ParadaSchema).optional(),
+  franjaHoraria: z.array(FranjaHorariaSchema).optional(),
+  destino: z.string().optional(),
+  por: z.string().optional(),
+  color: z.string().optional(),
+  duracion: z.number().optional(),
+  idsUbicaciones: z.array(z.string()).optional(),
+  // Populate
+  cliente: ClienteSchema.optional(),
+  ancestros: z.array(ClienteSchema).optional(),
+  grupo: z.custom<IGrupo>().optional(),
+  recorrido: z.array(CoordenadasSchema).optional(),
+  recorridoOl: z.array(CoordenadaOLSchema).optional(),
+  ubicaciones: z.array(z.custom<IUbicacion>()).optional(),
+});
+
+/**
+ * Interface hand-written (misma forma que el schema): los tipos de entidad del
+ * SCC no usan z.infer porque los ciclos de aliases mutuos disparan TS2589.
+ */
 export interface IRecorrido {
   _id?: string;
   idCliente?: string;
@@ -66,6 +109,17 @@ export interface IRecorrido {
   ubicaciones?: IUbicacion[];
 }
 
+export const CreateRecorridoSchema = RecorridoSchema.omit({
+  _id: true,
+  cliente: true,
+  grupo: true,
+  recorrido: true,
+  recorridoOl: true,
+  ubicaciones: true,
+}).extend({
+  recorridoOl: z.array(CoordenadaOLSchema).optional(),
+});
+
 type OmitirCreate =
   | '_id'
   | 'cliente'
@@ -78,6 +132,17 @@ export interface ICreateRecorrido
   extends Omit<Partial<IRecorrido>, OmitirCreate> {
   recorridoOl?: ICoordenadaOL[];
 }
+
+export const UpdateRecorridoSchema = RecorridoSchema.omit({
+  _id: true,
+  cliente: true,
+  grupo: true,
+  recorrido: true,
+  recorridoOl: true,
+  ubicaciones: true,
+}).extend({
+  recorridoOl: z.array(CoordenadaOLSchema).optional(),
+});
 
 type OmitirUpdate =
   | '_id'

--- a/src/interfaces/reporte-generico.ts
+++ b/src/interfaces/reporte-generico.ts
@@ -1,231 +1,274 @@
 // reporte-generico.ts
-import { IGeoJSONPoint } from '../auxiliares';
-import { IActivo } from './activo';
-import { ICliente } from './cliente';
-import { IDispositivoLorawan } from './dispositivo-lorawan';
-import { IGrupo } from './grupo';
-import { ILuminaria } from './luminaria';
-import { IRecorrido } from './recorrido';
-import { ITracker } from './tracker';
-import { IUsuario } from './usuario';
+import { z } from 'zod';
+import { GeoJSONPointSchema } from '../auxiliares';
+import type { IActivo } from './activo';
+import { ClienteSchema, ICliente } from './cliente';
+import type { IDispositivoLorawan } from './dispositivo-lorawan';
+import type { IGrupo } from './grupo';
+import type { ILuminaria } from './luminaria';
+import type { IRecorrido } from './recorrido';
+import type { ITracker } from './tracker';
+import type { IUsuario } from './usuario';
 
-export type TipoTriangulacion = 'GNSS' | 'Wifi';
+export const TipoTriangulacionSchema = z.enum(['GNSS', 'Wifi']);
+export type TipoTriangulacion = z.infer<typeof TipoTriangulacionSchema>;
 
-export type ModoForzado =
-  | 'No Forzado'
-  | 'Forzado Encendido'
-  | 'Forzado Apagado';
+export const ModoForzadoSchema = z.enum([
+  'No Forzado',
+  'Forzado Encendido',
+  'Forzado Apagado',
+]);
+export type ModoForzado = z.infer<typeof ModoForzadoSchema>;
 
-export type IModoLuminaria =
-  | 'Indeterminado'
-  | 'Fotocélula'
-  | 'Astronómico'
-  | 'Por Defecto'
-  | 'Manual';
+export const ModoLuminariaSchema = z.enum([
+  'Indeterminado',
+  'Fotocélula',
+  'Astronómico',
+  'Por Defecto',
+  'Manual',
+]);
+export type IModoLuminaria = z.infer<typeof ModoLuminariaSchema>;
 
 /* ────────────────────────────────────────────────
  *  TIPOS BASE
  * ────────────────────────────────────────────────*/
 
-export type TipoValoresReporte =
-  | 'Luminaria GPE Periódico'
-  | 'Luminaria GPE Energía'
-  | 'Luminaria Wellness'
-  | 'Luminaria ACTIS FING Estado'
-  | 'Luminaria ACTIS FING Energía'
-  | 'Tracker 4G'
-  | 'Tracker 4G Combustible'
-  | 'Tracker 4G Temperatura'
-  | 'Tracker T1000B'
-  | 'Tracker Qualcomm'
-  | 'Tracker Telefono';
-export type TipoEntidadReporte =
-  | 'Luminaria'
-  | 'Colectivo'
-  | 'Activo'
-  | 'Tracker'
-  | 'Vehiculo';
+export const TipoValoresReporteSchema = z.enum([
+  'Luminaria GPE Periódico',
+  'Luminaria GPE Energía',
+  'Luminaria Wellness',
+  'Luminaria ACTIS FING Estado',
+  'Luminaria ACTIS FING Energía',
+  'Tracker 4G',
+  'Tracker 4G Combustible',
+  'Tracker 4G Temperatura',
+  'Tracker T1000B',
+  'Tracker Qualcomm',
+  'Tracker Telefono',
+]);
+export type TipoValoresReporte = z.infer<typeof TipoValoresReporteSchema>;
+
+export const TipoEntidadReporteSchema = z.enum([
+  'Luminaria',
+  'Colectivo',
+  'Activo',
+  'Tracker',
+  'Vehiculo',
+]);
+export type TipoEntidadReporte = z.infer<typeof TipoEntidadReporteSchema>;
 
 /* ────────────────────────────────────────────────
  *  REPORTES POR TIPO
  * ────────────────────────────────────────────────*/
 
-export interface IReporteLuminariaGPE {
-  turnOnOffStatus?: boolean;
-  modo?: IModoLuminaria;
-  estadoRele?: boolean;
-  dimmerHabilitado?: boolean;
-  energiaExterna?: boolean;
-  potencia?: number;
-  voltaje?: number;
-  dimmingValue?: number;
-  fCnt?: number;
-  alarmas?: string[];
-  esDeDia?: boolean;
-  horaAmanecer?: string;
-  horaAtardecer?: string;
-  tiempoEncendida?: number; // En horas
-}
+export const ReporteLuminariaGPESchema = z.object({
+  turnOnOffStatus: z.boolean().optional(),
+  modo: ModoLuminariaSchema.optional(),
+  estadoRele: z.boolean().optional(),
+  dimmerHabilitado: z.boolean().optional(),
+  energiaExterna: z.boolean().optional(),
+  potencia: z.number().optional(),
+  voltaje: z.number().optional(),
+  dimmingValue: z.number().optional(),
+  fCnt: z.number().optional(),
+  alarmas: z.array(z.string()).optional(),
+  esDeDia: z.boolean().optional(),
+  horaAmanecer: z.string().optional(),
+  horaAtardecer: z.string().optional(),
+  tiempoEncendida: z.number().optional(), // En horas
+});
+export type IReporteLuminariaGPE = z.infer<typeof ReporteLuminariaGPESchema>;
 
-export interface IReporteLuminariaGPEEnergia {
-  corriente?: number;
-  voltaje?: number;
-  potencia?: number;
-  energia?: number;
-  energiaTotal?: number;
-  factorPotencia?: number;
-  fCnt?: number;
-  esDeDia?: boolean;
-  horaAmanecer?: string;
-  horaAtardecer?: string;
-  alarmas?: string[];
-}
+export const ReporteLuminariaGPEEnergiaSchema = z.object({
+  corriente: z.number().optional(),
+  voltaje: z.number().optional(),
+  potencia: z.number().optional(),
+  energia: z.number().optional(),
+  energiaTotal: z.number().optional(),
+  factorPotencia: z.number().optional(),
+  fCnt: z.number().optional(),
+  esDeDia: z.boolean().optional(),
+  horaAmanecer: z.string().optional(),
+  horaAtardecer: z.string().optional(),
+  alarmas: z.array(z.string()).optional(),
+});
+export type IReporteLuminariaGPEEnergia = z.infer<
+  typeof ReporteLuminariaGPEEnergiaSchema
+>;
 
-export interface IReporteLuminariaWellness {
-  dimmingValue?: number;
-  turnOnOffStatus?: boolean;
-  voltage?: number;
-  current?: number;
-  activePower?: number;
-  reactivePower?: number;
-  activePowerTotal?: number;
-  reactivePowerTotal?: number;
-  temperature?: number;
-  lumenes?: number;
-  modo?: IModoLuminaria;
-  modoForzado?: ModoForzado;
-  alarmas?: string[];
-}
+export const ReporteLuminariaWellnessSchema = z.object({
+  dimmingValue: z.number().optional(),
+  turnOnOffStatus: z.boolean().optional(),
+  voltage: z.number().optional(),
+  current: z.number().optional(),
+  activePower: z.number().optional(),
+  reactivePower: z.number().optional(),
+  activePowerTotal: z.number().optional(),
+  reactivePowerTotal: z.number().optional(),
+  temperature: z.number().optional(),
+  lumenes: z.number().optional(),
+  modo: ModoLuminariaSchema.optional(),
+  modoForzado: ModoForzadoSchema.optional(),
+  alarmas: z.array(z.string()).optional(),
+});
+export type IReporteLuminariaWellness = z.infer<
+  typeof ReporteLuminariaWellnessSchema
+>;
 
 // ===== ACTIS FING =====
 // Reporte de estado (Puerto 131: 1 byte - encendido/apagado, motivo, nivel dimming)
-export interface IReporteLuminariaACTISEstado {
-  turnOnOffStatus?: boolean;
-  modo?: IModoLuminaria;
-  estadoRele?: boolean;
-  dimmingValue?: number;
-  fCnt?: number;
-  esDeDia?: boolean;
-  horaAmanecer?: string;
-  horaAtardecer?: string;
-  tiempoEncendida?: number; // En horas
-  alarmas?: string[];
-}
+export const ReporteLuminariaACTISEstadoSchema = z.object({
+  turnOnOffStatus: z.boolean().optional(),
+  modo: ModoLuminariaSchema.optional(),
+  estadoRele: z.boolean().optional(),
+  dimmingValue: z.number().optional(),
+  fCnt: z.number().optional(),
+  esDeDia: z.boolean().optional(),
+  horaAmanecer: z.string().optional(),
+  horaAtardecer: z.string().optional(),
+  tiempoEncendida: z.number().optional(), // En horas
+  alarmas: z.array(z.string()).optional(),
+});
+export type IReporteLuminariaACTISEstado = z.infer<
+  typeof ReporteLuminariaACTISEstadoSchema
+>;
 
 // Reporte de energía (Puerto 130: 3 bytes - voltaje delta, corriente, factor de potencia)
-export interface IReporteLuminariaACTISEnergia {
-  corriente?: number;
-  voltaje?: number;
-  potencia?: number;
-  factorPotencia?: number;
-  fCnt?: number;
-  esDeDia?: boolean;
-  horaAmanecer?: string;
-  horaAtardecer?: string;
-  alarmas?: string[];
-  energiaTotal?: number; // kWh acumulado total calculado por integración temporal
-}
+export const ReporteLuminariaACTISEnergiaSchema = z.object({
+  corriente: z.number().optional(),
+  voltaje: z.number().optional(),
+  potencia: z.number().optional(),
+  factorPotencia: z.number().optional(),
+  fCnt: z.number().optional(),
+  esDeDia: z.boolean().optional(),
+  horaAmanecer: z.string().optional(),
+  horaAtardecer: z.string().optional(),
+  alarmas: z.array(z.string()).optional(),
+  energiaTotal: z.number().optional(), // kWh acumulado total calculado por integración temporal
+});
+export type IReporteLuminariaACTISEnergia = z.infer<
+  typeof ReporteLuminariaACTISEnergiaSchema
+>;
 
-export interface IReporteTracker {
-  fechaDevice?: string;
-  geojson?: IGeoJSONPoint;
-  snappedGeojson?: IGeoJSONPoint;
-  snapDivergence?: number; // Diferencia entre posición original y "snapped" en metros
-  direccion?: string;
-  velocidad?: number;
-  orientacion?: number;
-  ignicion?: boolean;
-  raw?: string; // Crudo para diagnóstico o datos adicionales no estructurados
-}
-
-export interface IReporteTracker4G extends IReporteTracker {
-  uniqueId?: string;
-  odometro?: number;
-  triperoState?: 'STOPPED' | 'IDLE' | 'MOVING' | 'UNKNOWN' | 'OFFLINE';
-  triperoStateDuration?: number;
-  triperoCurrentTripId?: string;
-  triperoCurrentTripDistance?: number;
-  // Telemetría OBD/CAN del vehículo (ej: Queclink GV350CEU, reporte ERI con
-  // <ERI Mask> bit 2). Presente solo cuando el equipo está cableado al CAN bus.
-  obd?: IReporteTrackerOBD;
-}
+export const ReporteTrackerSchema = z.object({
+  fechaDevice: z.string().optional(),
+  geojson: GeoJSONPointSchema.optional(),
+  snappedGeojson: GeoJSONPointSchema.optional(),
+  snapDivergence: z.number().optional(), // Diferencia entre posición original y "snapped" en metros
+  direccion: z.string().optional(),
+  velocidad: z.number().optional(),
+  orientacion: z.number().optional(),
+  ignicion: z.boolean().optional(),
+  raw: z.string().optional(), // Crudo para diagnóstico o datos adicionales no estructurados
+});
+export type IReporteTracker = z.infer<typeof ReporteTrackerSchema>;
 
 /**
  * Telemetría OBD leída del CAN bus del vehículo (bloque CAN Data del reporte ERI
  * de Queclink). Todos los campos son opcionales: el equipo sólo envía los que su
- * <CAN Bus Report Mask> habilita y que el vehículo expone. La firma de índice
+ * <CAN Bus Report Mask> habilita y que el vehículo expone. El catchall
  * cubre los campos menos comunes (camión/tacógrafo/eléctrico) sin enumerarlos.
  */
-export interface IReporteTrackerOBD {
-  vin?: string; // Número de chasis
-  ignicionKey?: number; // Estado de ignición leído del CAN (0-2)
-  distanciaTotal?: number; // Odómetro del vehículo
-  distanciaTotalFuente?: 'dashboard' | 'impulsos';
-  combustibleUsadoTotal?: number; // Combustible consumido acumulado
-  combustibleUsadoTotalUnidad?: 'L' | 'K';
-  rpm?: number; // Revoluciones del motor
-  velocidad?: number; // Velocidad del vehículo (km/h) según CAN
-  temperaturaRefrigerante?: number; // °C
-  consumoCombustible?: number; // L/100km o L/h
-  nivelCombustible?: number; // Nivel de combustible
-  nivelCombustibleUnidad?: 'L' | '%';
-  autonomia?: number; // Km estimados con el combustible restante (hm)
-  pedalAcelerador?: number; // % de presión del pedal
-  horasMotor?: number; // Horas totales de motor
-  tiempoConduccion?: number; // Horas en marcha
-  tiempoRalenti?: number; // Horas en ralentí
-  combustibleRalenti?: number; // Combustible consumido en ralentí
-  combustibleRalentiUnidad?: 'L' | 'K';
-  temperaturaAmbiente?: number; // °C
-  dtc?: string[]; // Códigos de falla activos (DTC)
-  canMaskRaw?: string; // <CAN Bus Report Mask> crudo (diagnóstico)
-  _parcial?: boolean; // true si quedó un sub-bloque sin parsear (ver rawTail)
-  rawTail?: string; // Resto crudo del bloque CAN no decodificado
-  [campo: string]: unknown; // Campos extra (ejes, tacógrafo, eléctrico, etc.)
-}
+export const ReporteTrackerOBDSchema = z
+  .object({
+    vin: z.string().optional(), // Número de chasis
+    ignicionKey: z.number().optional(), // Estado de ignición leído del CAN (0-2)
+    distanciaTotal: z.number().optional(), // Odómetro del vehículo
+    distanciaTotalFuente: z.enum(['dashboard', 'impulsos']).optional(),
+    combustibleUsadoTotal: z.number().optional(), // Combustible consumido acumulado
+    combustibleUsadoTotalUnidad: z.enum(['L', 'K']).optional(),
+    rpm: z.number().optional(), // Revoluciones del motor
+    velocidad: z.number().optional(), // Velocidad del vehículo (km/h) según CAN
+    temperaturaRefrigerante: z.number().optional(), // °C
+    consumoCombustible: z.number().optional(), // L/100km o L/h
+    nivelCombustible: z.number().optional(), // Nivel de combustible
+    nivelCombustibleUnidad: z.enum(['L', '%']).optional(),
+    autonomia: z.number().optional(), // Km estimados con el combustible restante (hm)
+    pedalAcelerador: z.number().optional(), // % de presión del pedal
+    horasMotor: z.number().optional(), // Horas totales de motor
+    tiempoConduccion: z.number().optional(), // Horas en marcha
+    tiempoRalenti: z.number().optional(), // Horas en ralentí
+    combustibleRalenti: z.number().optional(), // Combustible consumido en ralentí
+    combustibleRalentiUnidad: z.enum(['L', 'K']).optional(),
+    temperaturaAmbiente: z.number().optional(), // °C
+    dtc: z.array(z.string()).optional(), // Códigos de falla activos (DTC)
+    canMaskRaw: z.string().optional(), // <CAN Bus Report Mask> crudo (diagnóstico)
+    _parcial: z.boolean().optional(), // true si quedó un sub-bloque sin parsear (ver rawTail)
+    rawTail: z.string().optional(), // Resto crudo del bloque CAN no decodificado
+  })
+  .catchall(z.unknown()); // Campos extra (ejes, tacógrafo, eléctrico, etc.)
+export type IReporteTrackerOBD = z.infer<typeof ReporteTrackerOBDSchema>;
 
-export interface IReporteTrackerT1000B extends IReporteTracker {
-  devEui?: string;
-  bateria?: number;
-  tipoTriangulacion?: TipoTriangulacion;
-}
+export const ReporteTracker4GSchema = ReporteTrackerSchema.extend({
+  uniqueId: z.string().optional(),
+  odometro: z.number().optional(),
+  triperoState: z
+    .enum(['STOPPED', 'IDLE', 'MOVING', 'UNKNOWN', 'OFFLINE'])
+    .optional(),
+  triperoStateDuration: z.number().optional(),
+  triperoCurrentTripId: z.string().optional(),
+  triperoCurrentTripDistance: z.number().optional(),
+  // Telemetría OBD/CAN del vehículo (ej: Queclink GV350CEU, reporte ERI con
+  // <ERI Mask> bit 2). Presente solo cuando el equipo está cableado al CAN bus.
+  obd: ReporteTrackerOBDSchema.optional(),
+});
+export type IReporteTracker4G = z.infer<typeof ReporteTracker4GSchema>;
 
-export interface IReporteTrackerQualcomm extends IReporteTracker {
-  bateria?: number;
-  tipoTriangulacion?: TipoTriangulacion;
-}
+export const ReporteTrackerT1000BSchema = ReporteTrackerSchema.extend({
+  devEui: z.string().optional(),
+  bateria: z.number().optional(),
+  tipoTriangulacion: TipoTriangulacionSchema.optional(),
+});
+export type IReporteTrackerT1000B = z.infer<typeof ReporteTrackerT1000BSchema>;
 
-export interface IReporteTrackerTelefono extends IReporteTracker {
-  deviceId?: string;
-}
+export const ReporteTrackerQualcommSchema = ReporteTrackerSchema.extend({
+  bateria: z.number().optional(),
+  tipoTriangulacion: TipoTriangulacionSchema.optional(),
+});
+export type IReporteTrackerQualcomm = z.infer<
+  typeof ReporteTrackerQualcommSchema
+>;
 
-export interface IReporteTrackerTemperatura {
-  uniqueId?: string;
-  temperatura?: number; // °C con signo (ej: +20.5, -5.2)
-  tramaRaw?: string; // Trama completa para diagnóstico
-  geojson?: IGeoJSONPoint; // Última posición conocida (≤5 min)
-}
+export const ReporteTrackerTelefonoSchema = ReporteTrackerSchema.extend({
+  deviceId: z.string().optional(),
+});
+export type IReporteTrackerTelefono = z.infer<
+  typeof ReporteTrackerTelefonoSchema
+>;
 
-export interface IReporteTrackerCombustible {
-  uniqueId?: string;
+export const ReporteTrackerTemperaturaSchema = z.object({
+  uniqueId: z.string().optional(),
+  temperatura: z.number().optional(), // °C con signo (ej: +20.5, -5.2)
+  tramaRaw: z.string().optional(), // Trama completa para diagnóstico
+  geojson: GeoJSONPointSchema.optional(), // Última posición conocida (≤5 min)
+});
+export type IReporteTrackerTemperatura = z.infer<
+  typeof ReporteTrackerTemperaturaSchema
+>;
+
+export const ReporteTrackerCombustibleSchema = z.object({
+  uniqueId: z.string().optional(),
   // Nivel por tanque (litros). Solo se incluyen los sensores conectados.
-  nivelCombustible1?: number; // Sensor 1
-  nivelCombustible2?: number; // Sensor 2
-  nivelCombustible3?: number; // Sensor 3
-  nivelCombustible4?: number; // Sensor 4
-  nivelCombustibleTotal?: number; // Suma de sensores conectados (litros)
-  temperaturaCombustible?: number; // °C
-  alarmaAgua?: boolean; // Agua o cortocircuito en varillas
-  ignicionVirtualSensor?: boolean; // Estado motor reportado por el sensor
+  nivelCombustible1: z.number().optional(), // Sensor 1
+  nivelCombustible2: z.number().optional(), // Sensor 2
+  nivelCombustible3: z.number().optional(), // Sensor 3
+  nivelCombustible4: z.number().optional(), // Sensor 4
+  nivelCombustibleTotal: z.number().optional(), // Suma de sensores conectados (litros)
+  temperaturaCombustible: z.number().optional(), // °C
+  alarmaAgua: z.boolean().optional(), // Agua o cortocircuito en varillas
+  ignicionVirtualSensor: z.boolean().optional(), // Estado motor reportado por el sensor
   // Variación (solo en tramas FVAR)
-  variacionCombustible?: number; // Litros con signo (+carga / -descarga)
-  idSensorVariacion?: number; // ID del sensor que detectó la variación
-  nivelPostVariacion?: number; // Litros en tanque después de la variación
+  variacionCombustible: z.number().optional(), // Litros con signo (+carga / -descarga)
+  idSensorVariacion: z.number().optional(), // ID del sensor que detectó la variación
+  nivelPostVariacion: z.number().optional(), // Litros en tanque después de la variación
   // Debug / diagnóstico
-  debugValue?: string; // Valor lógico crudo del sensor
-  tramaRaw?: string; // Trama completa para diagnóstico
-  geojson?: IGeoJSONPoint; // Última posición conocida (≤5 min)
-}
+  debugValue: z.string().optional(), // Valor lógico crudo del sensor
+  tramaRaw: z.string().optional(), // Trama completa para diagnóstico
+  geojson: GeoJSONPointSchema.optional(), // Última posición conocida (≤5 min)
+});
+export type IReporteTrackerCombustible = z.infer<
+  typeof ReporteTrackerCombustibleSchema
+>;
 
 /* ────────────────────────────────────────────────
  *  MAPA DE TIPOS DE REPORTE → DATOS
@@ -255,6 +298,10 @@ export type ValoresReporte<T extends keyof MapaValoresReporte> = {
 
 /* ────────────────────────────────────────────────
  *  BASE DEL REPORTE (GENÉRICO)
+ *
+ *  Tipo legacy hand-written: el discriminante `tipoReporte` es OPCIONAL acá,
+ *  pero REQUERIDO en los schemas Zod de abajo (contrato de validación más
+ *  estricto para datos nuevos). Por eso este tipo NO se deriva con z.infer.
  * ────────────────────────────────────────────────*/
 
 export interface IReporteBase<T extends keyof MapaValoresReporte> {
@@ -372,3 +419,114 @@ export type IUpdateReporteGenerico =
   | ({ tipoReporte: 'Tracker Telefono' } & Partial<
       Omit<IReporteBase<'Tracker Telefono'>, Omitir | 'tipoReporte'>
     >);
+
+/* ────────────────────────────────────────────────
+ *  SCHEMAS ZOD (nuevos, discriminante REQUERIDO)
+ *
+ *  Para validación runtime y JSON Schema de datos nuevos. A diferencia de los
+ *  tipos legacy de arriba, acá `tipoReporte` es obligatorio (z.discriminatedUnion
+ *  lo exige). Los populates hacia el SCC van como getters (ciclo de imports).
+ * ────────────────────────────────────────────────*/
+
+// Populates intra-SCC como z.custom (import type-only): un schema real acá
+// arrastra el shape completo del ciclo y revienta la serialización de
+// declarations (TS7056) acá y en los consumidores NestJS.
+const camposComunesReporte = {
+  _id: z.string().optional(),
+  fechaCreacion: z.string().optional(),
+  expireAt: z.string().optional(),
+  idCliente: z.string().optional(),
+  idsAncestros: z.array(z.string()).optional(),
+  idEntidad: z.string().optional(),
+  idsAsignados: z.array(z.string()).optional(),
+  tipoEntidad: TipoEntidadReporteSchema.optional(),
+  cliente: ClienteSchema.optional(),
+  ancestros: z.array(ClienteSchema).optional(),
+  dispositivoLora: z.custom<IDispositivoLorawan>().optional(),
+  tracker: z.custom<ITracker>().optional(),
+  grupos: z.array(z.custom<IGrupo>()).optional(),
+  activo: z.custom<IActivo>().optional(),
+  recorrido: z.custom<IRecorrido>().optional(),
+  usuario: z.custom<IUsuario>().optional(),
+  luminaria: z.custom<ILuminaria>().optional(),
+};
+
+const varianteReporte = <T extends TipoValoresReporte, V extends z.ZodRawShape>(
+  tipo: T,
+  valores: z.ZodObject<V>,
+) =>
+  z.object({
+    ...camposComunesReporte,
+    tipoReporte: z.literal(tipo),
+    valores: valores.extend({ timestamp: z.string().optional() }).optional(),
+  });
+
+const vRepLumGPE = varianteReporte('Luminaria GPE Periódico', ReporteLuminariaGPESchema);
+const vRepLumGPEEnergia = varianteReporte('Luminaria GPE Energía', ReporteLuminariaGPEEnergiaSchema);
+const vRepLumWellness = varianteReporte('Luminaria Wellness', ReporteLuminariaWellnessSchema);
+const vRepLumACTISEstado = varianteReporte('Luminaria ACTIS FING Estado', ReporteLuminariaACTISEstadoSchema);
+const vRepLumACTISEnergia = varianteReporte('Luminaria ACTIS FING Energía', ReporteLuminariaACTISEnergiaSchema);
+const vRepTracker4G = varianteReporte('Tracker 4G', ReporteTracker4GSchema);
+const vRepTrackerT1000B = varianteReporte('Tracker T1000B', ReporteTrackerT1000BSchema);
+const vRepTrackerQualcomm = varianteReporte('Tracker Qualcomm', ReporteTrackerQualcommSchema);
+const vRepTrackerCombustible = varianteReporte('Tracker 4G Combustible', ReporteTrackerCombustibleSchema);
+const vRepTrackerTemperatura = varianteReporte('Tracker 4G Temperatura', ReporteTrackerTemperaturaSchema);
+const vRepTrackerTelefono = varianteReporte('Tracker Telefono', ReporteTrackerTelefonoSchema);
+
+export const ReporteGenericoSchema = z.discriminatedUnion('tipoReporte', [
+  vRepLumGPE,
+  vRepLumGPEEnergia,
+  vRepLumWellness,
+  vRepLumACTISEstado,
+  vRepLumACTISEnergia,
+  vRepTracker4G,
+  vRepTrackerT1000B,
+  vRepTrackerQualcomm,
+  vRepTrackerCombustible,
+  vRepTrackerTemperatura,
+  vRepTrackerTelefono,
+]);
+
+// Mismo set que el type Omitir de arriba
+const omitirCreateUpdateReporte = {
+  _id: true,
+  idsAncestros: true,
+  cliente: true,
+  ancestros: true,
+  dispositivoLora: true,
+  tracker: true,
+  grupos: true,
+  activo: true,
+  recorrido: true,
+  usuario: true,
+  luminaria: true,
+} as const;
+
+export const CreateReporteGenericoSchema = z.discriminatedUnion('tipoReporte', [
+  vRepLumGPE.omit(omitirCreateUpdateReporte),
+  vRepLumGPEEnergia.omit(omitirCreateUpdateReporte),
+  vRepLumWellness.omit(omitirCreateUpdateReporte),
+  vRepLumACTISEstado.omit(omitirCreateUpdateReporte),
+  vRepLumACTISEnergia.omit(omitirCreateUpdateReporte),
+  vRepTracker4G.omit(omitirCreateUpdateReporte),
+  vRepTrackerT1000B.omit(omitirCreateUpdateReporte),
+  vRepTrackerQualcomm.omit(omitirCreateUpdateReporte),
+  vRepTrackerCombustible.omit(omitirCreateUpdateReporte),
+  vRepTrackerTemperatura.omit(omitirCreateUpdateReporte),
+  vRepTrackerTelefono.omit(omitirCreateUpdateReporte),
+]);
+
+// Update: parcial pero con el discriminante requerido de nuevo (patrón UpdatePermisoSchema de acceso-modelos)
+export const UpdateReporteGenericoSchema = z.discriminatedUnion('tipoReporte', [
+  vRepLumGPE.omit(omitirCreateUpdateReporte).partial().extend({ tipoReporte: z.literal('Luminaria GPE Periódico') }),
+  vRepLumGPEEnergia.omit(omitirCreateUpdateReporte).partial().extend({ tipoReporte: z.literal('Luminaria GPE Energía') }),
+  vRepLumWellness.omit(omitirCreateUpdateReporte).partial().extend({ tipoReporte: z.literal('Luminaria Wellness') }),
+  vRepLumACTISEstado.omit(omitirCreateUpdateReporte).partial().extend({ tipoReporte: z.literal('Luminaria ACTIS FING Estado') }),
+  vRepLumACTISEnergia.omit(omitirCreateUpdateReporte).partial().extend({ tipoReporte: z.literal('Luminaria ACTIS FING Energía') }),
+  vRepTracker4G.omit(omitirCreateUpdateReporte).partial().extend({ tipoReporte: z.literal('Tracker 4G') }),
+  vRepTrackerT1000B.omit(omitirCreateUpdateReporte).partial().extend({ tipoReporte: z.literal('Tracker T1000B') }),
+  vRepTrackerQualcomm.omit(omitirCreateUpdateReporte).partial().extend({ tipoReporte: z.literal('Tracker Qualcomm') }),
+  vRepTrackerCombustible.omit(omitirCreateUpdateReporte).partial().extend({ tipoReporte: z.literal('Tracker 4G Combustible') }),
+  vRepTrackerTemperatura.omit(omitirCreateUpdateReporte).partial().extend({ tipoReporte: z.literal('Tracker 4G Temperatura') }),
+  vRepTrackerTelefono.omit(omitirCreateUpdateReporte).partial().extend({ tipoReporte: z.literal('Tracker Telefono') }),
+]);

--- a/src/interfaces/resumen-datos.ts
+++ b/src/interfaces/resumen-datos.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod';
 import { ClienteSchema, ICliente } from './cliente';
+import { PuntoCoord } from '../auxiliares/geojson';
 
 export const AgrupacionTiempoSchema = z.enum([
   'Diario',
@@ -135,7 +136,7 @@ export type ICombustibleHorarioVehiculo = z.infer<
 
 const PuntoGeojsonSchema = z.object({
   type: z.literal('Point'),
-  coordinates: z.tuple([z.number(), z.number()]),
+  coordinates: PuntoCoord,
 });
 
 export const EventoCargaCombustibleSchema = z.object({

--- a/src/interfaces/resumen-datos.ts
+++ b/src/interfaces/resumen-datos.ts
@@ -1,212 +1,282 @@
-import { ICliente } from './cliente';
+import { z } from 'zod';
+import { ClienteSchema, ICliente } from './cliente';
 
-export type AgrupacionTiempo =
-  | 'Diario'
-  | 'Semanal'
-  | 'Mensual'
-  | 'Anual'
-  | 'Horario';
-export type AgrupacionResumen = 'Cliente' | 'Grupo' | 'Individual';
-export type TipoResumenDatos =
-  | 'Consumo Mensual Luminarias'
-  | 'Encendido Diario Luminarias'
-  | 'Informe Diario Luminarias'
-  | 'Consumo Mensual Combustible Vehículos'
-  | 'Temperatura Horaria Vehículos'
-  | 'Combustible Horario Vehículos'
-  | 'Informe Cargas Combustible'
-  | 'Informe Eventos Sospechosos Combustible'
-  | 'Informe Mensual Flota Combustible'
-  | 'Gastos del Cliente';
-export type TipoEntidadResumen = 'Luminaria' | 'Puesta' | 'Vehículo' | 'Alarma';
-export type MonedaResumen = 'ARS' | 'USD';
+export const AgrupacionTiempoSchema = z.enum([
+  'Diario',
+  'Semanal',
+  'Mensual',
+  'Anual',
+  'Horario',
+]);
+export type AgrupacionTiempo = z.infer<typeof AgrupacionTiempoSchema>;
+
+export const AgrupacionResumenSchema = z.enum([
+  'Cliente',
+  'Grupo',
+  'Individual',
+]);
+export type AgrupacionResumen = z.infer<typeof AgrupacionResumenSchema>;
+
+export const TipoResumenDatosSchema = z.enum([
+  'Consumo Mensual Luminarias',
+  'Encendido Diario Luminarias',
+  'Informe Diario Luminarias',
+  'Consumo Mensual Combustible Vehículos',
+  'Temperatura Horaria Vehículos',
+  'Combustible Horario Vehículos',
+  'Informe Cargas Combustible',
+  'Informe Eventos Sospechosos Combustible',
+  'Informe Mensual Flota Combustible',
+  'Gastos del Cliente',
+]);
+export type TipoResumenDatos = z.infer<typeof TipoResumenDatosSchema>;
+
+export const TipoEntidadResumenSchema = z.enum([
+  'Luminaria',
+  'Puesta',
+  'Vehículo',
+  'Alarma',
+]);
+export type TipoEntidadResumen = z.infer<typeof TipoEntidadResumenSchema>;
+
+export const MonedaResumenSchema = z.enum(['ARS', 'USD']);
+export type MonedaResumen = z.infer<typeof MonedaResumenSchema>;
+
 /* ────────────────────────────────────────────────
  *  RESÚMENES
  * ────────────────────────────────────────────────*/
 
-export interface IConsumoMensualLuminarias {
-  consumoTotal?: number;
-  totalDispositivos?: number;
-}
+export const ConsumoMensualLuminariasSchema = z.object({
+  consumoTotal: z.number().optional(),
+  totalDispositivos: z.number().optional(),
+});
+export type IConsumoMensualLuminarias = z.infer<
+  typeof ConsumoMensualLuminariasSchema
+>;
 
-export interface IEncendidoDiarioLuminarias {
-  tiempoEncendidoTotal?: number;
-  totalDispositivos?: number;
-  tiempoEncendidoPromedio?: number;
-}
+export const EncendidoDiarioLuminariasSchema = z.object({
+  tiempoEncendidoTotal: z.number().optional(),
+  totalDispositivos: z.number().optional(),
+  tiempoEncendidoPromedio: z.number().optional(),
+});
+export type IEncendidoDiarioLuminarias = z.infer<
+  typeof EncendidoDiarioLuminariasSchema
+>;
 
-export interface IInformeDiarioLuminarias {
+export const InformeDiarioLuminariasSchema = z.object({
   // Generales
-  totalLuminarias?: number;
+  totalLuminarias: z.number().optional(),
 
   // Encendido / Apagado (de ultimoReportePeriodico.valores.turnOnOffStatus)
-  luminariasEncendidas?: number;
-  luminariasApagadas?: number;
-  sinDatoEncendido?: number; // Sin reporte periódico reciente
+  luminariasEncendidas: z.number().optional(),
+  luminariasApagadas: z.number().optional(),
+  sinDatoEncendido: z.number().optional(), // Sin reporte periódico reciente
 
   // Conectividad (fechaUltimaComunicacion dentro de las últimas 24h)
-  luminariasConectadas?: number;
-  luminariasDesconectadas?: number;
+  luminariasConectadas: z.number().optional(),
+  luminariasDesconectadas: z.number().optional(),
 
   // Estado operativo (campo `estado` de la luminaria)
-  luminariasOperativas?: number;
-  luminariasEnMantenimiento?: number;
-  sinEstado?: number; // Sin campo `estado` asignado
+  luminariasOperativas: z.number().optional(),
+  luminariasEnMantenimiento: z.number().optional(),
+  sinEstado: z.number().optional(), // Sin campo `estado` asignado
 
   // Consumo energético del día en kWh (reservado para implementación futura)
-  consumoTotal?: number;
+  consumoTotal: z.number().optional(),
 
   // Alertas (de ultimoReportePeriodico.valores.alarmas)
-  luminariasConAlarmas?: number;
-  tiposAlarmas?: Record<string, number>; // { 'Sobre voltaje': 2, 'Fallo LED': 1 }
+  luminariasConAlarmas: z.number().optional(),
+  tiposAlarmas: z.record(z.string(), z.number()).optional(), // { 'Sobre voltaje': 2, 'Fallo LED': 1 }
 
   // Cortes de energía (luminarias GPE con energiaExterna === false en último reporte)
-  luminariasConCortesEnergia?: number;
-}
+  luminariasConCortesEnergia: z.number().optional(),
+});
+export type IInformeDiarioLuminarias = z.infer<
+  typeof InformeDiarioLuminariasSchema
+>;
 
-export interface ITemperaturaHorariaVehiculo {
-  temperaturaPromedio?: number; // °C promedio de la hora
-  temperaturaMin?: number; // °C mínima de la hora
-  temperaturaMax?: number; // °C máxima de la hora
-  cantidadReportes?: number; // cantidad de reportes procesados
-}
+export const TemperaturaHorariaVehiculoSchema = z.object({
+  temperaturaPromedio: z.number().optional(), // °C promedio de la hora
+  temperaturaMin: z.number().optional(), // °C mínima de la hora
+  temperaturaMax: z.number().optional(), // °C máxima de la hora
+  cantidadReportes: z.number().optional(), // cantidad de reportes procesados
+});
+export type ITemperaturaHorariaVehiculo = z.infer<
+  typeof TemperaturaHorariaVehiculoSchema
+>;
 
-export interface ICombustibleHorarioVehiculo {
+export const CombustibleHorarioVehiculoSchema = z.object({
   // Total (suma de sensores conectados)
-  nivelPromedio?: number; // nivel promedio de la hora
-  nivelMin?: number; // nivel mínimo de la hora
-  nivelMax?: number; // nivel máximo de la hora
+  nivelPromedio: z.number().optional(), // nivel promedio de la hora
+  nivelMin: z.number().optional(), // nivel mínimo de la hora
+  nivelMax: z.number().optional(), // nivel máximo de la hora
   // Por sensor (1-4). Se omiten si el sensor no reportó en la hora.
-  nivelPromedio1?: number;
-  nivelMin1?: number;
-  nivelMax1?: number;
-  nivelPromedio2?: number;
-  nivelMin2?: number;
-  nivelMax2?: number;
-  nivelPromedio3?: number;
-  nivelMin3?: number;
-  nivelMax3?: number;
-  nivelPromedio4?: number;
-  nivelMin4?: number;
-  nivelMax4?: number;
-  cantidadReportes?: number; // cantidad de reportes procesados (del Total)
-}
+  nivelPromedio1: z.number().optional(),
+  nivelMin1: z.number().optional(),
+  nivelMax1: z.number().optional(),
+  nivelPromedio2: z.number().optional(),
+  nivelMin2: z.number().optional(),
+  nivelMax2: z.number().optional(),
+  nivelPromedio3: z.number().optional(),
+  nivelMin3: z.number().optional(),
+  nivelMax3: z.number().optional(),
+  nivelPromedio4: z.number().optional(),
+  nivelMin4: z.number().optional(),
+  nivelMax4: z.number().optional(),
+  cantidadReportes: z.number().optional(), // cantidad de reportes procesados (del Total)
+});
+export type ICombustibleHorarioVehiculo = z.infer<
+  typeof CombustibleHorarioVehiculoSchema
+>;
 
 /* ────────────────────────────────────────────────
  *  COMBUSTIBLE — CARGAS
  * ────────────────────────────────────────────────*/
 
-export interface IEventoCargaCombustible {
-  idActivo?: string;
-  nombreActivo?: string;
-  fecha?: string; // ISO timestamp del evento
-  litrosCargados?: number; // variacionCombustible (positivo)
-  nivelPostCarga?: number; // nivelPostVariacion
-  odometro?: number;
-  geojson?: { type: 'Point'; coordinates: [number, number] };
-  direccion?: string;
-  idSensor?: number;
-}
+const PuntoGeojsonSchema = z.object({
+  type: z.literal('Point'),
+  coordinates: z.tuple([z.number(), z.number()]),
+});
 
-export interface IInformeCargasCombustible {
-  totalCargas?: number;
-  totalLitrosCargados?: number;
-  vehiculosConCarga?: number;
-  cargas?: IEventoCargaCombustible[];
-}
+export const EventoCargaCombustibleSchema = z.object({
+  idActivo: z.string().optional(),
+  nombreActivo: z.string().optional(),
+  fecha: z.string().optional(), // ISO timestamp del evento
+  litrosCargados: z.number().optional(), // variacionCombustible (positivo)
+  nivelPostCarga: z.number().optional(), // nivelPostVariacion
+  odometro: z.number().optional(),
+  geojson: PuntoGeojsonSchema.optional(),
+  direccion: z.string().optional(),
+  idSensor: z.number().optional(),
+});
+export type IEventoCargaCombustible = z.infer<
+  typeof EventoCargaCombustibleSchema
+>;
+
+export const InformeCargasCombustibleSchema = z.object({
+  totalCargas: z.number().optional(),
+  totalLitrosCargados: z.number().optional(),
+  vehiculosConCarga: z.number().optional(),
+  cargas: z.array(EventoCargaCombustibleSchema).optional(),
+});
+export type IInformeCargasCombustible = z.infer<
+  typeof InformeCargasCombustibleSchema
+>;
 
 /* ────────────────────────────────────────────────
  *  COMBUSTIBLE — EVENTOS SOSPECHOSOS (DESCARGAS)
  * ────────────────────────────────────────────────*/
 
-export interface IEventoDescargaCombustible {
-  idActivo?: string;
-  nombreActivo?: string;
-  fecha?: string;
-  litrosDescargados?: number; // |variacionCombustible|
-  nivelAntes?: number;
-  nivelDespues?: number; // nivelPostVariacion
-  odometro?: number;
-  geojson?: { type: 'Point'; coordinates: [number, number] };
-  direccion?: string;
-  idSensor?: number;
-}
+export const EventoDescargaCombustibleSchema = z.object({
+  idActivo: z.string().optional(),
+  nombreActivo: z.string().optional(),
+  fecha: z.string().optional(),
+  litrosDescargados: z.number().optional(), // |variacionCombustible|
+  nivelAntes: z.number().optional(),
+  nivelDespues: z.number().optional(), // nivelPostVariacion
+  odometro: z.number().optional(),
+  geojson: PuntoGeojsonSchema.optional(),
+  direccion: z.string().optional(),
+  idSensor: z.number().optional(),
+});
+export type IEventoDescargaCombustible = z.infer<
+  typeof EventoDescargaCombustibleSchema
+>;
 
-export interface IInformeEventosSospechosos {
-  totalEventos?: number;
-  totalLitrosDescargados?: number;
-  vehiculosAfectados?: number;
-  eventos?: IEventoDescargaCombustible[];
-}
+export const InformeEventosSospechososSchema = z.object({
+  totalEventos: z.number().optional(),
+  totalLitrosDescargados: z.number().optional(),
+  vehiculosAfectados: z.number().optional(),
+  eventos: z.array(EventoDescargaCombustibleSchema).optional(),
+});
+export type IInformeEventosSospechosos = z.infer<
+  typeof InformeEventosSospechososSchema
+>;
 
 /* ────────────────────────────────────────────────
  *  COMBUSTIBLE — MENSUAL DE FLOTA
  * ────────────────────────────────────────────────*/
 
-export interface IEstadisticaVehiculoCombustible {
-  idActivo?: string;
-  nombreActivo?: string;
-  kmRecorridos?: number;
-  litrosCargados?: number;
-  rendimientoL100km?: number; // L/100km (null si sin datos de odómetro)
-  cantidadCargas?: number;
-  cantidadEventosSospechosos?: number;
-}
+export const EstadisticaVehiculoCombustibleSchema = z.object({
+  idActivo: z.string().optional(),
+  nombreActivo: z.string().optional(),
+  kmRecorridos: z.number().optional(),
+  litrosCargados: z.number().optional(),
+  rendimientoL100km: z.number().optional(), // L/100km (null si sin datos de odómetro)
+  cantidadCargas: z.number().optional(),
+  cantidadEventosSospechosos: z.number().optional(),
+});
+export type IEstadisticaVehiculoCombustible = z.infer<
+  typeof EstadisticaVehiculoCombustibleSchema
+>;
 
-export interface IInformeMensualFlotaCombustible {
-  totalVehiculos?: number;
-  kmTotales?: number;
-  litrosTotales?: number;
-  rendimientoPromedio?: number;
-  cantidadCargas?: number;
-  cantidadEventosSospechosos?: number;
-  vehiculos?: IEstadisticaVehiculoCombustible[];
-}
+export const InformeMensualFlotaCombustibleSchema = z.object({
+  totalVehiculos: z.number().optional(),
+  kmTotales: z.number().optional(),
+  litrosTotales: z.number().optional(),
+  rendimientoPromedio: z.number().optional(),
+  cantidadCargas: z.number().optional(),
+  cantidadEventosSospechosos: z.number().optional(),
+  vehiculos: z.array(EstadisticaVehiculoCombustibleSchema).optional(),
+});
+export type IInformeMensualFlotaCombustible = z.infer<
+  typeof InformeMensualFlotaCombustibleSchema
+>;
 
-export interface IConsumoCombustibleVehiculos {
-  kmRecorridos?: number; //km (obtenidos del odómetro de los reportes)
-  consumoRuta?: number; // litros cada 100 km (ruta) — snapshot del vehículo individual
-  consumoCiudad?: number; // litros cada 100 km (ciudad) — snapshot del vehículo individual
-  consumoEstimado?: number; // litros (según km y promedio de consumoRuta/consumoCiudad)
-  consumoDeclarado?: number; // litros (según lo cargado en los servicios del vehículo)
-  consumoReal?: number; // litros (según caídas de nivel del sensor, de 'Combustible Horario Vehículos')
-  vehiculosConsiderados?: number; // Vehículos totales analizados (mínimamente tenían odómetro)
-  vehiculosConConsumo?: number; // Vehículos que tenían consumo promedio y valores de odómetro
-}
+export const ConsumoCombustibleVehiculosSchema = z.object({
+  kmRecorridos: z.number().optional(), //km (obtenidos del odómetro de los reportes)
+  consumoRuta: z.number().optional(), // litros cada 100 km (ruta) — snapshot del vehículo individual
+  consumoCiudad: z.number().optional(), // litros cada 100 km (ciudad) — snapshot del vehículo individual
+  consumoEstimado: z.number().optional(), // litros (según km y promedio de consumoRuta/consumoCiudad)
+  consumoDeclarado: z.number().optional(), // litros (según lo cargado en los servicios del vehículo)
+  consumoReal: z.number().optional(), // litros (según caídas de nivel del sensor, de 'Combustible Horario Vehículos')
+  vehiculosConsiderados: z.number().optional(), // Vehículos totales analizados (mínimamente tenían odómetro)
+  vehiculosConConsumo: z.number().optional(), // Vehículos que tenían consumo promedio y valores de odómetro
+});
+export type IConsumoCombustibleVehiculos = z.infer<
+  typeof ConsumoCombustibleVehiculosSchema
+>;
+
 /* ────────────────────────────────────────────────
  *  GASTOS DEL CLIENTE
  * ────────────────────────────────────────────────*/
 
 /** Cantidad de dispositivos de una categoría (sin costo). */
-export interface IDetalleGastoCategoria {
-  cantidadTotal?: number; // dispositivos totales del cliente (ej. 100)
-  cantidadFacturada?: number; // los considerados/activos en el período (ej. 10)
-}
+export const DetalleGastoCategoriaSchema = z.object({
+  cantidadTotal: z.number().optional(), // dispositivos totales del cliente (ej. 100)
+  cantidadFacturada: z.number().optional(), // los considerados/activos en el período (ej. 10)
+});
+export type IDetalleGastoCategoria = z.infer<
+  typeof DetalleGastoCategoriaSchema
+>;
 
 /** Cantidad de dispositivos facturados de una categoría para un hijo. */
-export interface IGastoHijoCategoria {
-  cantidad?: number; // dispositivos facturados del hijo
-}
+export const GastoHijoCategoriaSchema = z.object({
+  cantidad: z.number().optional(), // dispositivos facturados del hijo
+});
+export type IGastoHijoCategoria = z.infer<typeof GastoHijoCategoriaSchema>;
 
 /** Dispositivos que aportó un hijo directo en el período del resumen. */
-export interface IGastoHijoResumen {
-  idCliente?: string;
-  nombre?: string;
-  total?: number; // suma de cantidades facturadas de las 3 categorías
+export const GastoHijoResumenSchema = z.object({
+  idCliente: z.string().optional(),
+  nombre: z.string().optional(),
+  total: z.number().optional(), // suma de cantidades facturadas de las 3 categorías
   // Desglose por categoría (cantidad facturada)
-  trackers?: IGastoHijoCategoria;
-  alarmas?: IGastoHijoCategoria;
-  camaras?: IGastoHijoCategoria;
-}
+  trackers: GastoHijoCategoriaSchema.optional(),
+  alarmas: GastoHijoCategoriaSchema.optional(),
+  camaras: GastoHijoCategoriaSchema.optional(),
+});
+export type IGastoHijoResumen = z.infer<typeof GastoHijoResumenSchema>;
 
-export interface IResumenGastosCliente {
-  trackers?: IDetalleGastoCategoria;
-  alarmas?: IDetalleGastoCategoria;
-  camaras?: IDetalleGastoCategoria;
-  total?: number; // suma de cantidadFacturada de las 3 categorías (dispositivos)
+export const ResumenGastosClienteSchema = z.object({
+  trackers: DetalleGastoCategoriaSchema.optional(),
+  alarmas: DetalleGastoCategoriaSchema.optional(),
+  camaras: DetalleGastoCategoriaSchema.optional(),
+  total: z.number().optional(), // suma de cantidadFacturada de las 3 categorías (dispositivos)
   /** Desglose por hijo directo (no bonificado, no raíz independiente). */
-  hijos?: IGastoHijoResumen[];
-}
+  hijos: z.array(GastoHijoResumenSchema).optional(),
+});
+export type IResumenGastosCliente = z.infer<typeof ResumenGastosClienteSchema>;
 
 /* ────────────────────────────────────────────────
  *  MAPA DE TIPO DE RESUMEN
@@ -250,86 +320,123 @@ export interface IResumenDatosBase<T extends keyof MapaResumenDatos> {
   ancestros?: ICliente[];
 }
 
+// Campos comunes a todas las variantes (sin tipo/resumen, que discriminan)
+const ResumenDatosCamposSchema = z.object({
+  _id: z.string().optional(),
+  idCliente: z.string().optional(),
+  idsAncestros: z.array(z.string()).optional(),
+  fechaCreacion: z.string().optional(),
+
+  tipoEntidad: TipoEntidadResumenSchema.optional(),
+  agrupacion: AgrupacionResumenSchema.optional(),
+  agrupacionTiempo: AgrupacionTiempoSchema.optional(),
+  idsAsignados: z.array(z.string()).optional(),
+  periodoInicio: z.string().optional(),
+  periodoFin: z.string().optional(),
+  cerrado: z.boolean().optional(), //indica que el resumen ya no se va a actualizar más
+
+  //Populate
+  cliente: ClienteSchema.optional(),
+  ancestros: z.array(ClienteSchema).optional(),
+});
+
+const VarianteConsumoMensualLuminarias = ResumenDatosCamposSchema.extend({
+  tipo: z.literal('Consumo Mensual Luminarias').optional(),
+  resumen: ConsumoMensualLuminariasSchema.optional(),
+});
+const VarianteEncendidoDiarioLuminarias = ResumenDatosCamposSchema.extend({
+  tipo: z.literal('Encendido Diario Luminarias').optional(),
+  resumen: EncendidoDiarioLuminariasSchema.optional(),
+});
+const VarianteInformeDiarioLuminarias = ResumenDatosCamposSchema.extend({
+  tipo: z.literal('Informe Diario Luminarias').optional(),
+  resumen: InformeDiarioLuminariasSchema.optional(),
+});
+const VarianteConsumoMensualCombustibleVehiculos =
+  ResumenDatosCamposSchema.extend({
+    tipo: z.literal('Consumo Mensual Combustible Vehículos').optional(),
+    resumen: ConsumoCombustibleVehiculosSchema.optional(),
+  });
+const VarianteTemperaturaHorariaVehiculos = ResumenDatosCamposSchema.extend({
+  tipo: z.literal('Temperatura Horaria Vehículos').optional(),
+  resumen: TemperaturaHorariaVehiculoSchema.optional(),
+});
+const VarianteCombustibleHorarioVehiculos = ResumenDatosCamposSchema.extend({
+  tipo: z.literal('Combustible Horario Vehículos').optional(),
+  resumen: CombustibleHorarioVehiculoSchema.optional(),
+});
+const VarianteInformeCargasCombustible = ResumenDatosCamposSchema.extend({
+  tipo: z.literal('Informe Cargas Combustible').optional(),
+  resumen: InformeCargasCombustibleSchema.optional(),
+});
+const VarianteInformeEventosSospechososCombustible =
+  ResumenDatosCamposSchema.extend({
+    tipo: z.literal('Informe Eventos Sospechosos Combustible').optional(),
+    resumen: InformeEventosSospechososSchema.optional(),
+  });
+const VarianteInformeMensualFlotaCombustible = ResumenDatosCamposSchema.extend(
+  {
+    tipo: z.literal('Informe Mensual Flota Combustible').optional(),
+    resumen: InformeMensualFlotaCombustibleSchema.optional(),
+  },
+);
+const VarianteGastosDelCliente = ResumenDatosCamposSchema.extend({
+  tipo: z.literal('Gastos del Cliente').optional(),
+  resumen: ResumenGastosClienteSchema.optional(),
+});
+
 /* ────────────────────────────────────────────────
  *  TIPO DISCRIMINADO
  * ────────────────────────────────────────────────*/
 
-export type IResumenDatos =
-  | IResumenDatosBase<'Consumo Mensual Luminarias'>
-  | IResumenDatosBase<'Encendido Diario Luminarias'>
-  | IResumenDatosBase<'Informe Diario Luminarias'>
-  | IResumenDatosBase<'Consumo Mensual Combustible Vehículos'>
-  | IResumenDatosBase<'Temperatura Horaria Vehículos'>
-  | IResumenDatosBase<'Combustible Horario Vehículos'>
-  | IResumenDatosBase<'Informe Cargas Combustible'>
-  | IResumenDatosBase<'Informe Eventos Sospechosos Combustible'>
-  | IResumenDatosBase<'Informe Mensual Flota Combustible'>
-  | IResumenDatosBase<'Gastos del Cliente'>;
+export const ResumenDatosSchema = z.union([
+  VarianteConsumoMensualLuminarias,
+  VarianteEncendidoDiarioLuminarias,
+  VarianteInformeDiarioLuminarias,
+  VarianteConsumoMensualCombustibleVehiculos,
+  VarianteTemperaturaHorariaVehiculos,
+  VarianteCombustibleHorarioVehiculos,
+  VarianteInformeCargasCombustible,
+  VarianteInformeEventosSospechososCombustible,
+  VarianteInformeMensualFlotaCombustible,
+  VarianteGastosDelCliente,
+]);
+export type IResumenDatos = z.infer<typeof ResumenDatosSchema>;
 
 /* ────────────────────────────────────────────────
  *  CREATE / UPDATE
  * ────────────────────────────────────────────────*/
 
-type OmitirCreate = '_id' | 'cliente' | 'ancestros';
+const camposOmitidos: { _id: true; cliente: true; ancestros: true } = {
+  _id: true,
+  cliente: true,
+  ancestros: true,
+};
 
-export type ICreateResumenDatos =
-  | Omit<Partial<IResumenDatosBase<'Consumo Mensual Luminarias'>>, OmitirCreate>
-  | Omit<
-      Partial<IResumenDatosBase<'Encendido Diario Luminarias'>>,
-      OmitirCreate
-    >
-  | Omit<Partial<IResumenDatosBase<'Informe Diario Luminarias'>>, OmitirCreate>
-  | Omit<
-      Partial<IResumenDatosBase<'Consumo Mensual Combustible Vehículos'>>,
-      OmitirCreate
-    >
-  | Omit<
-      Partial<IResumenDatosBase<'Temperatura Horaria Vehículos'>>,
-      OmitirCreate
-    >
-  | Omit<
-      Partial<IResumenDatosBase<'Combustible Horario Vehículos'>>,
-      OmitirCreate
-    >
-  | Omit<Partial<IResumenDatosBase<'Informe Cargas Combustible'>>, OmitirCreate>
-  | Omit<
-      Partial<IResumenDatosBase<'Informe Eventos Sospechosos Combustible'>>,
-      OmitirCreate
-    >
-  | Omit<
-      Partial<IResumenDatosBase<'Informe Mensual Flota Combustible'>>,
-      OmitirCreate
-    >
-  | Omit<Partial<IResumenDatosBase<'Gastos del Cliente'>>, OmitirCreate>;
+export const CreateResumenDatosSchema = z.union([
+  VarianteConsumoMensualLuminarias.omit(camposOmitidos),
+  VarianteEncendidoDiarioLuminarias.omit(camposOmitidos),
+  VarianteInformeDiarioLuminarias.omit(camposOmitidos),
+  VarianteConsumoMensualCombustibleVehiculos.omit(camposOmitidos),
+  VarianteTemperaturaHorariaVehiculos.omit(camposOmitidos),
+  VarianteCombustibleHorarioVehiculos.omit(camposOmitidos),
+  VarianteInformeCargasCombustible.omit(camposOmitidos),
+  VarianteInformeEventosSospechososCombustible.omit(camposOmitidos),
+  VarianteInformeMensualFlotaCombustible.omit(camposOmitidos),
+  VarianteGastosDelCliente.omit(camposOmitidos),
+]);
+export type ICreateResumenDatos = z.infer<typeof CreateResumenDatosSchema>;
 
-type OmitirUpdate = '_id' | 'cliente' | 'ancestros';
-
-export type IUpdateResumenDatos =
-  | Omit<Partial<IResumenDatosBase<'Consumo Mensual Luminarias'>>, OmitirUpdate>
-  | Omit<
-      Partial<IResumenDatosBase<'Encendido Diario Luminarias'>>,
-      OmitirUpdate
-    >
-  | Omit<Partial<IResumenDatosBase<'Informe Diario Luminarias'>>, OmitirUpdate>
-  | Omit<
-      Partial<IResumenDatosBase<'Consumo Mensual Combustible Vehículos'>>,
-      OmitirUpdate
-    >
-  | Omit<
-      Partial<IResumenDatosBase<'Temperatura Horaria Vehículos'>>,
-      OmitirUpdate
-    >
-  | Omit<
-      Partial<IResumenDatosBase<'Combustible Horario Vehículos'>>,
-      OmitirUpdate
-    >
-  | Omit<Partial<IResumenDatosBase<'Informe Cargas Combustible'>>, OmitirUpdate>
-  | Omit<
-      Partial<IResumenDatosBase<'Informe Eventos Sospechosos Combustible'>>,
-      OmitirUpdate
-    >
-  | Omit<
-      Partial<IResumenDatosBase<'Informe Mensual Flota Combustible'>>,
-      OmitirUpdate
-    >
-  | Omit<Partial<IResumenDatosBase<'Gastos del Cliente'>>, OmitirUpdate>;
+export const UpdateResumenDatosSchema = z.union([
+  VarianteConsumoMensualLuminarias.omit(camposOmitidos),
+  VarianteEncendidoDiarioLuminarias.omit(camposOmitidos),
+  VarianteInformeDiarioLuminarias.omit(camposOmitidos),
+  VarianteConsumoMensualCombustibleVehiculos.omit(camposOmitidos),
+  VarianteTemperaturaHorariaVehiculos.omit(camposOmitidos),
+  VarianteCombustibleHorarioVehiculos.omit(camposOmitidos),
+  VarianteInformeCargasCombustible.omit(camposOmitidos),
+  VarianteInformeEventosSospechososCombustible.omit(camposOmitidos),
+  VarianteInformeMensualFlotaCombustible.omit(camposOmitidos),
+  VarianteGastosDelCliente.omit(camposOmitidos),
+]);
+export type IUpdateResumenDatos = z.infer<typeof UpdateResumenDatosSchema>;

--- a/src/interfaces/road-speed-cache.ts
+++ b/src/interfaces/road-speed-cache.ts
@@ -1,35 +1,35 @@
-import { IGeoJSONPoint } from '../auxiliares';
+import { z } from 'zod';
+import { GeoJSONPointSchema } from '../auxiliares';
 
 // Versión reducida para enviar límites de velocidad entre gestion-api-gestion y gestion-api-eventos
-export interface ISpeedLimitResult {
-  maxspeed?: number; // km/h
-  unidad?: string;
-  desconocido?: boolean;
-  confianza?: 'explicito' | 'inferido';
-  fuente?: 'tomtom' | 'osm' | 'fallback';
-}
-export interface IRoadSpeedCache {
-  _id?: string;
-  fechaCreacion?: string;
-  geojson?: IGeoJSONPoint;
-  geohash?: string;
-  maxspeed?: number; // km/h ya normalizado
-  unidad?: string; // 'km/h' | 'mph' (unidad original de la fuente)
-  desconocido?: boolean; // true si no se pudo determinar ningún límite usable
-  confianza?: string; // 'explicito' | 'inferido' (informativo, no configurable)
-  fuente?: string; // 'tomtom' | 'osm' | 'fallback'
-}
+export const SpeedLimitResultSchema = z.object({
+  maxspeed: z.number().optional(), // km/h
+  unidad: z.string().optional(),
+  desconocido: z.boolean().optional(),
+  confianza: z.enum(['explicito', 'inferido']).optional(),
+  fuente: z.enum(['tomtom', 'osm', 'fallback']).optional(),
+});
+export type ISpeedLimitResult = z.infer<typeof SpeedLimitResultSchema>;
 
-type OmitirCreate = '_id';
+export const RoadSpeedCacheSchema = z.object({
+  _id: z.string().optional(),
+  fechaCreacion: z.string().optional(),
+  geojson: GeoJSONPointSchema.optional(),
+  geohash: z.string().optional(),
+  maxspeed: z.number().optional(), // km/h ya normalizado
+  unidad: z.string().optional(), // 'km/h' | 'mph' (unidad original de la fuente)
+  desconocido: z.boolean().optional(), // true si no se pudo determinar ningún límite usable
+  confianza: z.string().optional(), // 'explicito' | 'inferido' (informativo, no configurable)
+  fuente: z.string().optional(), // 'tomtom' | 'osm' | 'fallback'
+});
+export type IRoadSpeedCache = z.infer<typeof RoadSpeedCacheSchema>;
 
-export interface ICreateRoadSpeedCache extends Omit<
-  Partial<IRoadSpeedCache>,
-  OmitirCreate
-> {}
+export const CreateRoadSpeedCacheSchema = RoadSpeedCacheSchema.omit({
+  _id: true,
+});
+export type ICreateRoadSpeedCache = z.infer<typeof CreateRoadSpeedCacheSchema>;
 
-type OmitirUpdate = '_id';
-
-export interface IUpdateRoadSpeedCache extends Omit<
-  Partial<IRoadSpeedCache>,
-  OmitirUpdate
-> {}
+export const UpdateRoadSpeedCacheSchema = RoadSpeedCacheSchema.omit({
+  _id: true,
+});
+export type IUpdateRoadSpeedCache = z.infer<typeof UpdateRoadSpeedCacheSchema>;

--- a/src/interfaces/rol.ts
+++ b/src/interfaces/rol.ts
@@ -1,403 +1,411 @@
-import { ICliente } from './cliente';
+import { z } from 'zod';
+import { ClienteSchema } from './cliente';
 
-export type AccionesRol =
+export const AccionesRolSchema = z.enum([
   // *******************************************
   // EVENTOS
   // *******************************************
-  | 'Eventos - Ver eventos'
-  | 'Eventos - Atender eventos'
-  | 'Eventos - Finalizar eventos'
+  'Eventos - Ver eventos',
+  'Eventos - Atender eventos',
+  'Eventos - Finalizar eventos',
   // Ver en el listado los eventos que otro operador ya está atendiendo
   // (sin esta acción, en modo atención simple, se ocultan)
-  | 'Eventos - Ver eventos en atención'
+  'Eventos - Ver eventos en atención',
   // *******************************************
   // LOGS
   // *******************************************
-  | 'Logs - Ver logs http'
-  | 'Logs - Ver logs eventos lora'
-  | 'Logs - Ver logs despachos'
-  | 'Logs - Ver logs eventos trackers test'
-  | 'Logs - Ver logs reenvios'
-  | 'Logs - Ver métricas downlinks'
+  'Logs - Ver logs http',
+  'Logs - Ver logs eventos lora',
+  'Logs - Ver logs despachos',
+  'Logs - Ver logs eventos trackers test',
+  'Logs - Ver logs reenvios',
+  'Logs - Ver métricas downlinks',
   // *******************************************
   // MODULO ADMINISTRACIÓN
   // *******************************************
   // Clientes
-  | 'Administración - Ver clientes'
-  | 'Administración - Crear clientes'
-  | 'Administración - Editar clientes'
-  | 'Administración - Eliminar clientes'
-  | 'Administración - Deshabilitar / habilitar clientes'
+  'Administración - Ver clientes',
+  'Administración - Crear clientes',
+  'Administración - Editar clientes',
+  'Administración - Eliminar clientes',
+  'Administración - Deshabilitar / habilitar clientes',
   // Usuarios
-  | 'Administración - Ver usuarios'
-  | 'Administración - Crear usuarios'
-  | 'Administración - Editar usuarios'
-  | 'Administración - Eliminar usuarios'
+  'Administración - Ver usuarios',
+  'Administración - Crear usuarios',
+  'Administración - Editar usuarios',
+  'Administración - Eliminar usuarios',
   // Técnicos
-  | 'Administración - Ver técnicos'
-  | 'Administración - Crear técnicos'
-  | 'Administración - Editar técnicos'
-  | 'Administración - Eliminar técnicos'
+  'Administración - Ver técnicos',
+  'Administración - Crear técnicos',
+  'Administración - Editar técnicos',
+  'Administración - Eliminar técnicos',
   // Dispositivos Lorawan
-  | 'Administración - Ver dispositivos Lorawan'
-  | 'Administración - Crear dispositivos Lorawan'
-  | 'Administración - Editar dispositivos Lorawan'
-  | 'Administración - Eliminar dispositivos Lorawan'
+  'Administración - Ver dispositivos Lorawan',
+  'Administración - Crear dispositivos Lorawan',
+  'Administración - Editar dispositivos Lorawan',
+  'Administración - Eliminar dispositivos Lorawan',
   // Gateways
-  | 'Administración - Ver gateways'
-  | 'Administración - Crear gateways'
-  | 'Administración - Editar gateways'
-  | 'Administración - Eliminar gateways'
+  'Administración - Ver gateways',
+  'Administración - Crear gateways',
+  'Administración - Editar gateways',
+  'Administración - Eliminar gateways',
   // Botones Ble
-  | 'Administración - Ver botones Ble'
-  | 'Administración - Eliminar botones Ble'
+  'Administración - Ver botones Ble',
+  'Administración - Eliminar botones Ble',
   // Trackers
-  | 'Administración - Ver trackers'
-  | 'Administración - Crear trackers'
-  | 'Administración - Editar trackers'
-  | 'Administración - Eliminar trackers'
+  'Administración - Ver trackers',
+  'Administración - Crear trackers',
+  'Administración - Editar trackers',
+  'Administración - Eliminar trackers',
   // Servicios Ofrecidos
-  | 'Administración - Ver servicios ofrecidos'
-  | 'Administración - Crear servicios ofrecidos'
-  | 'Administración - Editar servicios ofrecidos'
-  | 'Administración - Eliminar servicios ofrecidos'
+  'Administración - Ver servicios ofrecidos',
+  'Administración - Crear servicios ofrecidos',
+  'Administración - Editar servicios ofrecidos',
+  'Administración - Eliminar servicios ofrecidos',
   // Apikeys
-  | 'Administración - Ver apikeys'
-  | 'Administración - Crear apikeys'
-  | 'Administración - Editar apikeys'
-  | 'Administración - Eliminar apikeys'
+  'Administración - Ver apikeys',
+  'Administración - Crear apikeys',
+  'Administración - Editar apikeys',
+  'Administración - Eliminar apikeys',
   // Config. de reenvios
-  | 'Administración - Ver configuraciones de reenvíos'
-  | 'Administración - Crear configuraciones de reenvíos'
-  | 'Administración - Editar configuraciones de reenvíos'
-  | 'Administración - Eliminar configuraciones de reenvíos'
+  'Administración - Ver configuraciones de reenvíos',
+  'Administración - Crear configuraciones de reenvíos',
+  'Administración - Editar configuraciones de reenvíos',
+  'Administración - Eliminar configuraciones de reenvíos',
   // Integraciones
-  | 'Administración - Ver integraciones'
-  | 'Administración - Crear integraciones'
+  'Administración - Ver integraciones',
+  'Administración - Crear integraciones',
   // Roles
-  | 'Administración - Ver roles'
-  | 'Administración - Crear roles'
-  | 'Administración - Editar roles'
-  | 'Administración - Eliminar roles'
+  'Administración - Ver roles',
+  'Administración - Crear roles',
+  'Administración - Editar roles',
+  'Administración - Eliminar roles',
   // Eventos Personalizados
-  | 'Administración - Ver eventos personalizados'
-  | 'Administración - Crear eventos personalizados'
-  | 'Administración - Editar eventos personalizados'
-  | 'Administración - Eliminar eventos personalizados'
+  'Administración - Ver eventos personalizados',
+  'Administración - Crear eventos personalizados',
+  'Administración - Editar eventos personalizados',
+  'Administración - Eliminar eventos personalizados',
   // Categorías Eventos
-  | 'Administración - Ver categorias eventos'
-  | 'Administración - Crear categorias eventos'
-  | 'Administración - Editar categorias eventos'
-  | 'Administración - Eliminar categorias eventos'
+  'Administración - Ver categorias eventos',
+  'Administración - Crear categorias eventos',
+  'Administración - Editar categorias eventos',
+  'Administración - Eliminar categorias eventos',
   // Tipos de Eventos (listado categorias)
-  | 'Administración - Ver listado categorias'
-  | 'Administración - Crear listado categorias'
-  | 'Administración - Editar listado categorias'
-  | 'Administración - Eliminar listado categorias'
+  'Administración - Ver listado categorias',
+  'Administración - Crear listado categorias',
+  'Administración - Editar listado categorias',
+  'Administración - Eliminar listado categorias',
   // Inactividad de usuarios
-  | 'Administración - Ver inactividad usuarios'
+  'Administración - Ver inactividad usuarios',
   // *******************************************
   // CONFIGURACIONES
   // *******************************************
-  | 'Configuraciones - Configurar cliente'
-  | 'Configuraciones - Crear codigos alarmas'
-  | 'Configuraciones - Editar codigos alarmas'
-  | 'Configuraciones - Eliminar codigos alarmas'
-  | 'Configuraciones - Crear modelos alarmas'
-  | 'Configuraciones - Editar modelos alarmas'
-  | 'Configuraciones - Eliminar modelos alarmas'
-  | 'Configuraciones - Crear codigos comunicadores'
-  | 'Configuraciones - Editar codigos comunicadores'
-  | 'Configuraciones - Eliminar codigos comunicadores'
-  | 'Configuraciones - Crear modelos comunicadores'
-  | 'Configuraciones - Editar modelos comunicadores'
-  | 'Configuraciones - Eliminar modelos comunicadores'
-  | 'Configuraciones - Crear modelos cámaras'
-  | 'Configuraciones - Editar modelos cámaras'
-  | 'Configuraciones - Eliminar modelos cámaras'
-  | 'Configuraciones - Crear codigos sirenas'
-  | 'Configuraciones - Editar codigos sirenas'
-  | 'Configuraciones - Eliminar codigos sirenas'
-  | 'Configuraciones - Crear modelos sirenas'
-  | 'Configuraciones - Editar modelos sirenas'
-  | 'Configuraciones - Eliminar modelos sirenas'
-  | 'Configuraciones - Crear modelos luminarias'
-  | 'Configuraciones - Editar modelos luminarias'
-  | 'Configuraciones - Eliminar modelos luminarias'
-  | 'Configuraciones - Crear perfiles luminarias'
-  | 'Configuraciones - Editar perfiles luminarias'
-  | 'Configuraciones - Eliminar perfiles luminarias'
-  | 'Configuraciones - Crear codigos dispositivos lorawan'
-  | 'Configuraciones - Editar codigos dispositivos lorawan'
-  | 'Configuraciones - Eliminar codigos dispositivos lorawan'
-  | 'Configuraciones - Crear modelos dispositivos lorawan'
-  | 'Configuraciones - Editar modelos dispositivos lorawan'
-  | 'Configuraciones - Eliminar modelos dispositivos lorawan'
-  | 'Configuraciones - Crear codigos botones BLE'
-  | 'Configuraciones - Editar codigos botones BLE'
-  | 'Configuraciones - Eliminar codigos botones BLE'
-  | 'Configuraciones - Crear modelos botones BLE'
-  | 'Configuraciones - Editar modelos botones BLE'
-  | 'Configuraciones - Eliminar modelos botones BLE'
-  | 'Configuraciones - Crear codigos trackers'
-  | 'Configuraciones - Editar codigos trackers'
-  | 'Configuraciones - Eliminar codigos trackers'
-  | 'Configuraciones - Crear modelos trackers'
-  | 'Configuraciones - Editar modelos trackers'
-  | 'Configuraciones - Eliminar modelos trackers'
-  | 'Configuraciones - Crear iconos vehículos'
-  | 'Configuraciones - Editar iconos vehículos'
-  | 'Configuraciones - Eliminar iconos vehículos'
+  'Configuraciones - Configurar cliente',
+  'Configuraciones - Crear codigos alarmas',
+  'Configuraciones - Editar codigos alarmas',
+  'Configuraciones - Eliminar codigos alarmas',
+  'Configuraciones - Crear modelos alarmas',
+  'Configuraciones - Editar modelos alarmas',
+  'Configuraciones - Eliminar modelos alarmas',
+  'Configuraciones - Crear codigos comunicadores',
+  'Configuraciones - Editar codigos comunicadores',
+  'Configuraciones - Eliminar codigos comunicadores',
+  'Configuraciones - Crear modelos comunicadores',
+  'Configuraciones - Editar modelos comunicadores',
+  'Configuraciones - Eliminar modelos comunicadores',
+  'Configuraciones - Crear modelos cámaras',
+  'Configuraciones - Editar modelos cámaras',
+  'Configuraciones - Eliminar modelos cámaras',
+  'Configuraciones - Crear codigos sirenas',
+  'Configuraciones - Editar codigos sirenas',
+  'Configuraciones - Eliminar codigos sirenas',
+  'Configuraciones - Crear modelos sirenas',
+  'Configuraciones - Editar modelos sirenas',
+  'Configuraciones - Eliminar modelos sirenas',
+  'Configuraciones - Crear modelos luminarias',
+  'Configuraciones - Editar modelos luminarias',
+  'Configuraciones - Eliminar modelos luminarias',
+  'Configuraciones - Crear perfiles luminarias',
+  'Configuraciones - Editar perfiles luminarias',
+  'Configuraciones - Eliminar perfiles luminarias',
+  'Configuraciones - Crear codigos dispositivos lorawan',
+  'Configuraciones - Editar codigos dispositivos lorawan',
+  'Configuraciones - Eliminar codigos dispositivos lorawan',
+  'Configuraciones - Crear modelos dispositivos lorawan',
+  'Configuraciones - Editar modelos dispositivos lorawan',
+  'Configuraciones - Eliminar modelos dispositivos lorawan',
+  'Configuraciones - Crear codigos botones BLE',
+  'Configuraciones - Editar codigos botones BLE',
+  'Configuraciones - Eliminar codigos botones BLE',
+  'Configuraciones - Crear modelos botones BLE',
+  'Configuraciones - Editar modelos botones BLE',
+  'Configuraciones - Eliminar modelos botones BLE',
+  'Configuraciones - Crear codigos trackers',
+  'Configuraciones - Editar codigos trackers',
+  'Configuraciones - Eliminar codigos trackers',
+  'Configuraciones - Crear modelos trackers',
+  'Configuraciones - Editar modelos trackers',
+  'Configuraciones - Eliminar modelos trackers',
+  'Configuraciones - Crear iconos vehículos',
+  'Configuraciones - Editar iconos vehículos',
+  'Configuraciones - Eliminar iconos vehículos',
   // *******************************************
   // MODULO SERVICIO TECNICO
   // *******************************************
-  | 'Servicio Técnico - Ver solicitudes'
-  | 'Servicio Técnico - Crear solicitudes'
-  | 'Servicio Técnico - Editar solicitudes'
-  | 'Servicio Técnico - Eliminar solicitudes'
-  | 'Servicio Técnico - Reasignar solicitudes'
-  | 'Servicio Técnico - Atender solicitudes'
-  | 'Servicio Técnico - Ver pedidos de materiales'
-  | 'Servicio Técnico - Gestionar pedidos de materiales'
+  'Servicio Técnico - Ver solicitudes',
+  'Servicio Técnico - Crear solicitudes',
+  'Servicio Técnico - Editar solicitudes',
+  'Servicio Técnico - Eliminar solicitudes',
+  'Servicio Técnico - Reasignar solicitudes',
+  'Servicio Técnico - Atender solicitudes',
+  'Servicio Técnico - Ver pedidos de materiales',
+  'Servicio Técnico - Gestionar pedidos de materiales',
   // *******************************************
   // MODULO ALARMAS
   // *******************************************
-  | 'Alarmas - Crear'
-  | 'Alarmas - Editar'
-  | 'Alarmas - Eliminar'
-  | 'Alarmas - Exportar eventos'
-  | 'Alarmas - Dar de alta'
-  | 'Alarmas - Actualizar imágenes'
-  | 'Alarmas - Cambiar de cliente'
-  | 'Alarmas - Configurar comunicador'
-  | 'Alarmas - Solicitar servicio técnico'
-  | 'Alarmas - Cambiar estado de cuenta'
-  | 'Alarmas - Cambiar modo desactivado'
-  | 'Alarmas - Editar control horario'
-  | 'Alarmas - Editar contactos '
-  | 'Alarmas - Editar notas'
-  | 'Alarmas - Asignar cámaras'
-  | 'Alarmas - Enviar comandos'
+  'Alarmas - Crear',
+  'Alarmas - Editar',
+  'Alarmas - Eliminar',
+  'Alarmas - Exportar eventos',
+  'Alarmas - Dar de alta',
+  'Alarmas - Actualizar imágenes',
+  'Alarmas - Cambiar de cliente',
+  'Alarmas - Configurar comunicador',
+  'Alarmas - Solicitar servicio técnico',
+  'Alarmas - Cambiar estado de cuenta',
+  'Alarmas - Cambiar modo desactivado',
+  'Alarmas - Editar control horario',
+  'Alarmas - Editar contactos ',
+  'Alarmas - Editar notas',
+  'Alarmas - Asignar cámaras',
+  'Alarmas - Enviar comandos',
   // *******************************************
   // MODULO VEHÍCULOS
   // *******************************************
   // Vehículos
-  | 'Vehículos - Crear'
-  | 'Vehículos - Editar'
-  | 'Vehículos - Eliminar'
-  | 'Vehículos - Exportar eventos'
-  | 'Vehículos - Exportar Reportes'
-  | 'Vehículos - Dar de alta'
-  | 'Vehículos - Actualizar imágenes'
-  | 'Vehículos - Modo estacionado'
-  | 'Vehículos - Cambiar modo desactivado'
-  | 'Vehículos - Cambiar de cliente'
-  | 'Vehículos - Solicitar servicio técnico'
-  | 'Vehículos - Enviar comandos'
-  | 'Vehículos - Editar contactos '
-  | 'Vehículos - Editar notas'
-  | 'Vehículos - Editar documentos vehículo'
+  'Vehículos - Crear',
+  'Vehículos - Editar',
+  'Vehículos - Eliminar',
+  'Vehículos - Exportar eventos',
+  'Vehículos - Exportar Reportes',
+  'Vehículos - Dar de alta',
+  'Vehículos - Actualizar imágenes',
+  'Vehículos - Modo estacionado',
+  'Vehículos - Cambiar modo desactivado',
+  'Vehículos - Cambiar de cliente',
+  'Vehículos - Solicitar servicio técnico',
+  'Vehículos - Enviar comandos',
+  'Vehículos - Editar contactos ',
+  'Vehículos - Editar notas',
+  'Vehículos - Editar documentos vehículo',
   // Conductores
-  | 'Vehículos - Crear conductor'
-  | 'Vehículos - Editar conductor'
-  | 'Vehículos - Eliminar conductor'
-  | 'Vehículos - Asignar conductor'
-  | 'Vehículos - Crear documentos conductor'
-  | 'Vehículos - Editar documentos conductor'
-  | 'Vehículos - Eliminar documentos conductor'
+  'Vehículos - Crear conductor',
+  'Vehículos - Editar conductor',
+  'Vehículos - Eliminar conductor',
+  'Vehículos - Asignar conductor',
+  'Vehículos - Crear documentos conductor',
+  'Vehículos - Editar documentos conductor',
+  'Vehículos - Eliminar documentos conductor',
   // zonas, recorridos, flotas, recordatorios, servicios y proveedores
-  | 'Vehículos - Crear zonas'
-  | 'Vehículos - Editar zonas'
-  | 'Vehículos - Eliminar zonas'
-  | 'Vehículos - Crear recorridos'
-  | 'Vehículos - Editar recorridos'
-  | 'Vehículos - Eliminar recorridos'
-  | 'Vehículos - Crear flotas'
-  | 'Vehículos - Editar flotas'
-  | 'Vehículos - Eliminar flotas'
-  | 'Vehículos - Crear recordatorios'
-  | 'Vehículos - Editar recordatorios'
-  | 'Vehículos - Eliminar recordatorios'
-  | 'Vehículos - Crear servicios'
-  | 'Vehículos - Editar servicios'
-  | 'Vehículos - Eliminar servicios'
-  | 'Vehículos - Crear proveedores'
-  | 'Vehículos - Editar proveedores'
-  | 'Vehículos - Eliminar proveedores'
+  'Vehículos - Crear zonas',
+  'Vehículos - Editar zonas',
+  'Vehículos - Eliminar zonas',
+  'Vehículos - Crear recorridos',
+  'Vehículos - Editar recorridos',
+  'Vehículos - Eliminar recorridos',
+  'Vehículos - Crear flotas',
+  'Vehículos - Editar flotas',
+  'Vehículos - Eliminar flotas',
+  'Vehículos - Crear recordatorios',
+  'Vehículos - Editar recordatorios',
+  'Vehículos - Eliminar recordatorios',
+  'Vehículos - Crear servicios',
+  'Vehículos - Editar servicios',
+  'Vehículos - Eliminar servicios',
+  'Vehículos - Crear proveedores',
+  'Vehículos - Editar proveedores',
+  'Vehículos - Eliminar proveedores',
   // *******************************************
   // MODULO LUMINARIAS
   // *******************************************
-  | 'Luminarias - Crear'
-  | 'Luminarias - Editar'
-  | 'Luminarias - Eliminar'
-  | 'Luminarias - Enviar comandos'
-  | 'Luminarias - Solicitar servicio técnico'
-  | 'Luminarias - Editar contactos '
-  | 'Luminarias - Editar notas'
+  'Luminarias - Crear',
+  'Luminarias - Editar',
+  'Luminarias - Eliminar',
+  'Luminarias - Enviar comandos',
+  'Luminarias - Solicitar servicio técnico',
+  'Luminarias - Editar contactos ',
+  'Luminarias - Editar notas',
   // Agrupaciones
-  | 'Luminarias - Crear agrupaciones'
-  | 'Luminarias - Editar agrupaciones'
-  | 'Luminarias - Eliminar agrupaciones'
+  'Luminarias - Crear agrupaciones',
+  'Luminarias - Editar agrupaciones',
+  'Luminarias - Eliminar agrupaciones',
   //Puestas
-  | 'Luminarias - Crear puestas'
-  | 'Luminarias - Editar puestas'
-  | 'Luminarias - Eliminar puestas'
+  'Luminarias - Crear puestas',
+  'Luminarias - Editar puestas',
+  'Luminarias - Eliminar puestas',
   // *******************************************
   // MODULO ACTIVOS
   // *******************************************
   // Activos
-  | 'Activos - Crear'
-  | 'Activos - Editar'
-  | 'Activos - Eliminar'
-  | 'Activos - Exportar eventos'
-  | 'Activos - Exportar Reportes'
+  'Activos - Crear',
+  'Activos - Editar',
+  'Activos - Eliminar',
+  'Activos - Exportar eventos',
+  'Activos - Exportar Reportes',
   // | 'Activos - Dar de alta' // No esta implementado pero quizá se implemente en un futuro
   // | 'Activos - Actualizar imágenes' // No esta implementado pero quizá se implemente en un futuro
-  | 'Activos - Cambiar modo desactivado'
-  | 'Activos - Cambiar de cliente'
-  | 'Activos - Cambiar estado de cuenta'
-  | 'Activos - Solicitar servicio técnico'
+  'Activos - Cambiar modo desactivado',
+  'Activos - Cambiar de cliente',
+  'Activos - Cambiar estado de cuenta',
+  'Activos - Solicitar servicio técnico',
   // | 'Activos - Enviar comandos' // No esta implementado pero quizá se implemente en un futuro
-  | 'Activos - Editar contactos '
-  | 'Activos - Editar notas'
+  'Activos - Editar contactos ',
+  'Activos - Editar notas',
   // Ubicaciones, agrupaciones
-  | 'Activos - Crear ubicaciones'
-  | 'Activos - Editar ubicaciones'
-  | 'Activos - Eliminar ubicaciones'
-  | 'Activos - Crear agrupaciones'
-  | 'Activos - Editar agrupaciones'
-  | 'Activos - Eliminar agrupaciones'
+  'Activos - Crear ubicaciones',
+  'Activos - Editar ubicaciones',
+  'Activos - Eliminar ubicaciones',
+  'Activos - Crear agrupaciones',
+  'Activos - Editar agrupaciones',
+  'Activos - Eliminar agrupaciones',
   // *******************************************
   // MODULO TRASNPORTE PUBLICO / COLECTIVOS
   // *******************************************
   // Colectivos
-  | 'Colectivos - Crear'
-  | 'Colectivos - Editar'
-  | 'Colectivos - Eliminar'
-  | 'Colectivos - Exportar eventos'
-  | 'Colectivos - Exportar Reportes'
+  'Colectivos - Crear',
+  'Colectivos - Editar',
+  'Colectivos - Eliminar',
+  'Colectivos - Exportar eventos',
+  'Colectivos - Exportar Reportes',
   // | 'Colectivos - Dar de alta' // No esta implementado pero quizá se implemente en un futuro
   // | 'Colectivos - Actualizar imágenes' // No esta implementado pero quizá se implemente en un futuro
-  | 'Colectivos - Cambiar modo desactivado'
+  'Colectivos - Cambiar modo desactivado',
   // | 'Colectivos - Cambiar de cliente' // No esta implementado pero quizá se implemente en un futuro
-  | 'Colectivos - Solicitar servicio técnico'
-  | 'Colectivos - Setear odómetro'
+  'Colectivos - Solicitar servicio técnico',
+  'Colectivos - Setear odómetro',
   // | 'Colectivos - Enviar comandos' // No esta implementado pero quizá se implemente en un futuro
-  | 'Colectivos - Editar contactos '
-  | 'Colectivos - Editar notas'
-  | 'Colectivos - Editar documentos colectivo'
+  'Colectivos - Editar contactos ',
+  'Colectivos - Editar notas',
+  'Colectivos - Editar documentos colectivo',
   // Recorridos, terminales, líneas, choferes, cronogramas, recordatorios, servicios y proveedores
-  | 'Colectivos - Crear recorridos'
-  | 'Colectivos - Editar recorridos'
-  | 'Colectivos - Eliminar recorridos'
-  | 'Colectivos - Crear terminales'
-  | 'Colectivos - Editar terminales'
-  | 'Colectivos - Eliminar terminales'
-  | 'Colectivos - Crear líneas'
-  | 'Colectivos - Editar líneas'
-  | 'Colectivos - Eliminar líneas'
-  | 'Colectivos - Crear choferes'
-  | 'Colectivos - Editar choferes'
-  | 'Colectivos - Eliminar choferes'
-  | 'Colectivos - Crear cronogramas'
-  | 'Colectivos - Editar cronogramas'
-  | 'Colectivos - Eliminar cronogramas'
-  | 'Colectivos - Crear recordatorios'
-  | 'Colectivos - Editar recordatorios'
-  | 'Colectivos - Eliminar recordatorios'
-  | 'Colectivos - Crear servicios'
-  | 'Colectivos - Editar servicios'
-  | 'Colectivos - Eliminar servicios'
-  | 'Colectivos - Crear proveedores'
-  | 'Colectivos - Editar proveedores'
-  | 'Colectivos - Eliminar proveedores'
+  'Colectivos - Crear recorridos',
+  'Colectivos - Editar recorridos',
+  'Colectivos - Eliminar recorridos',
+  'Colectivos - Crear terminales',
+  'Colectivos - Editar terminales',
+  'Colectivos - Eliminar terminales',
+  'Colectivos - Crear líneas',
+  'Colectivos - Editar líneas',
+  'Colectivos - Eliminar líneas',
+  'Colectivos - Crear choferes',
+  'Colectivos - Editar choferes',
+  'Colectivos - Eliminar choferes',
+  'Colectivos - Crear cronogramas',
+  'Colectivos - Editar cronogramas',
+  'Colectivos - Eliminar cronogramas',
+  'Colectivos - Crear recordatorios',
+  'Colectivos - Editar recordatorios',
+  'Colectivos - Eliminar recordatorios',
+  'Colectivos - Crear servicios',
+  'Colectivos - Editar servicios',
+  'Colectivos - Eliminar servicios',
+  'Colectivos - Crear proveedores',
+  'Colectivos - Editar proveedores',
+  'Colectivos - Eliminar proveedores',
   // *******************************************
   // MODULO EMERGENCIAS MÉDICAS
   // *******************************************
   // Emergencias Médicas
-  | 'Emergencias Médicas - Crear'
-  | 'Emergencias Médicas - Importar'
-  | 'Emergencias Médicas - Editar'
-  | 'Emergencias Médicas - Eliminar'
-  | 'Emergencias Médicas - Reasignar'
-  | 'Emergencias Médicas - Finalizar'
-  | 'Emergencias Médicas - Cancelar'
+  'Emergencias Médicas - Crear',
+  'Emergencias Médicas - Importar',
+  'Emergencias Médicas - Editar',
+  'Emergencias Médicas - Eliminar',
+  'Emergencias Médicas - Reasignar',
+  'Emergencias Médicas - Finalizar',
+  'Emergencias Médicas - Cancelar',
   // Hospitales, centros médicos, personal de salud, solicitantes, pacientes
-  | 'Emergencias Médicas - Crear hospitales'
-  | 'Emergencias Médicas - Editar hospitales'
-  | 'Emergencias Médicas - Eliminar hospitales'
-  | 'Emergencias Médicas - Crear centros médicos'
-  | 'Emergencias Médicas - Editar centros médicos'
-  | 'Emergencias Médicas - Eliminar centros médicos'
-  | 'Emergencias Médicas - Crear personal de salud'
-  | 'Emergencias Médicas - Editar personal de salud'
-  | 'Emergencias Médicas - Eliminar personal de salud'
-  | 'Emergencias Médicas - Crear solicitantes'
-  | 'Emergencias Médicas - Editar solicitantes'
-  | 'Emergencias Médicas - Eliminar solicitantes'
-  | 'Emergencias Médicas - Crear pacientes'
-  | 'Emergencias Médicas - Editar pacientes'
-  | 'Emergencias Médicas - Eliminar pacientes'
+  'Emergencias Médicas - Crear hospitales',
+  'Emergencias Médicas - Editar hospitales',
+  'Emergencias Médicas - Eliminar hospitales',
+  'Emergencias Médicas - Crear centros médicos',
+  'Emergencias Médicas - Editar centros médicos',
+  'Emergencias Médicas - Eliminar centros médicos',
+  'Emergencias Médicas - Crear personal de salud',
+  'Emergencias Médicas - Editar personal de salud',
+  'Emergencias Médicas - Eliminar personal de salud',
+  'Emergencias Médicas - Crear solicitantes',
+  'Emergencias Médicas - Editar solicitantes',
+  'Emergencias Médicas - Eliminar solicitantes',
+  'Emergencias Médicas - Crear pacientes',
+  'Emergencias Médicas - Editar pacientes',
+  'Emergencias Médicas - Eliminar pacientes',
   // *******************************************
   // MODULO SIRENAS MUNICIPALES
   // *******************************************
   // Sirenas Municipales
-  | 'Sirenas Municipales - Sincronizar'
-  | 'Sirenas Municipales - Editar'
-  | 'Sirenas Municipales - Eliminar'
-  | 'Sirenas Municipales - Solicitar servicio técnico'
-  | 'Sirenas Municipales - Asignar cámaras'
+  'Sirenas Municipales - Sincronizar',
+  'Sirenas Municipales - Editar',
+  'Sirenas Municipales - Eliminar',
+  'Sirenas Municipales - Solicitar servicio técnico',
+  'Sirenas Municipales - Asignar cámaras',
   // *******************************************
   // MODULO CÁMARAS
   // *******************************************
   // Cámaras
-  | 'Cámaras - Crear cámara'
-  | 'Cámaras - Editar cámara'
-  | 'Cámaras - Eliminar cámara'
-  | 'Cámaras - Solicitar servicio técnico'
-  | 'Cámaras - Ver streaming'
-  | 'Cámaras - Descargar grabaciones'
+  'Cámaras - Crear cámara',
+  'Cámaras - Editar cámara',
+  'Cámaras - Eliminar cámara',
+  'Cámaras - Solicitar servicio técnico',
+  'Cámaras - Ver streaming',
+  'Cámaras - Descargar grabaciones',
   // *******************************************
   // MÓDULO AUDITORÍAS
   // *******************************************
-  | 'Auditorías - Ver auditorías'
+  'Auditorías - Ver auditorías',
   // *******************************************
   // MODULO ALERTAS SEGURIDAD
   // *******************************************
-  | 'Alertas Seguridad - Crear'
-  | 'Alertas Seguridad - Atender'
-  | 'Alertas Seguridad - Derivar'
-  | 'Alertas Seguridad - Exportar';
+  'Alertas Seguridad - Crear',
+  'Alertas Seguridad - Atender',
+  'Alertas Seguridad - Derivar',
+  'Alertas Seguridad - Exportar',
+]);
+export type AccionesRol = z.infer<typeof AccionesRolSchema>;
 
-export type FuncionesRol =
-  | 'Técnico' // Para elegir técnicos en solicitudes de servicio técnico y para vista especial en la app mobile
-  | 'Conductor' // Asignable a vehiculos (no colectivos)
-  | 'Chofer' // Asignable a colectivos
-  | 'Móvil Emergencias Médicas'; // Funciones especiales para emergencias medicas
+export const FuncionesRolSchema = z.enum([
+  'Técnico', // Para elegir técnicos en solicitudes de servicio técnico y para vista especial en la app mobile
+  'Conductor', // Asignable a vehiculos (no colectivos)
+  'Chofer', // Asignable a colectivos
+  'Móvil Emergencias Médicas', // Funciones especiales para emergencias medicas
+]);
+export type FuncionesRol = z.infer<typeof FuncionesRolSchema>;
 
-export interface IRol {
-  _id?: string;
+export const RolSchema = z.object({
+  _id: z.string().optional(),
   //
-  idCliente?: string;
-  idsAncestros?: string[];
-  default?: boolean;
-  global?: boolean;
+  idCliente: z.string().optional(),
+  idsAncestros: z.array(z.string()).optional(),
+  default: z.boolean().optional(),
+  global: z.boolean().optional(),
 
-  nombre?: string;
-  acciones?: AccionesRol[];
-  funciones?: FuncionesRol[];
+  nombre: z.string().optional(),
+  acciones: z.array(AccionesRolSchema).optional(),
+  funciones: z.array(FuncionesRolSchema).optional(),
 
   //Populate
-  cliente?: ICliente;
-  ancestros?: ICliente[];
-}
+  cliente: ClienteSchema.optional(),
+  ancestros: z.array(ClienteSchema).optional(),
+});
+export type IRol = z.infer<typeof RolSchema>;
 
-type OmitirCreate = '_id' | 'cliente';
+export const CreateRolSchema = RolSchema.omit({ _id: true, cliente: true });
+export type ICreateRol = z.infer<typeof CreateRolSchema>;
 
-export interface ICreateRol extends Omit<Partial<IRol>, OmitirCreate> {}
+export const UpdateRolSchema = RolSchema.omit({ _id: true, cliente: true });
+export type IUpdateRol = z.infer<typeof UpdateRolSchema>;
 
-type OmitirUpdate = '_id' | 'cliente';
-
-export interface IUpdateRol extends Omit<Partial<IRol>, OmitirUpdate> {}
-
-export interface IRolCache extends Omit<IRol, 'cliente' | 'ancestros'> {}
+export const RolCacheSchema = RolSchema.omit({
+  cliente: true,
+  ancestros: true,
+});
+export type IRolCache = z.infer<typeof RolCacheSchema>;

--- a/src/interfaces/sendgrid.ts
+++ b/src/interfaces/sendgrid.ts
@@ -1,38 +1,48 @@
 // EMAIL
 
-import { IModuloSendgrid } from './cliente';
+import { z } from 'zod';
+import { ModuloSendgridSchema } from './cliente';
 
-export interface IEmailDataBase {
-  sid: string;
-  subject?: string;
-}
+export const EmailDataBaseSchema = z.object({
+  sid: z.string(),
+  subject: z.string().optional(),
+});
+export type IEmailDataBase = z.infer<typeof EmailDataBaseSchema>;
 
-export interface IEmailGenerico extends IEmailDataBase {
-  [key: string]: string | undefined;
-}
+export const EmailGenericoSchema = EmailDataBaseSchema.catchall(
+  z.string().optional(),
+);
+export type IEmailGenerico = z.infer<typeof EmailGenericoSchema>;
 
-export interface IEmailResetPassword extends IEmailDataBase {
-  token: string;
-}
+export const EmailResetPasswordSchema = EmailDataBaseSchema.extend({
+  token: z.string(),
+});
+export type IEmailResetPassword = z.infer<typeof EmailResetPasswordSchema>;
 
-export interface IEmailNuevoUsuario extends IEmailDataBase {
-  usuario: string;
-  password: string;
-}
+export const EmailNuevoUsuarioSchema = EmailDataBaseSchema.extend({
+  usuario: z.string(),
+  password: z.string(),
+});
+export type IEmailNuevoUsuario = z.infer<typeof EmailNuevoUsuarioSchema>;
 
-export interface IEmailCambioPassword extends IEmailDataBase {
-  codigo: string;
-}
+export const EmailCambioPasswordSchema = EmailDataBaseSchema.extend({
+  codigo: z.string(),
+});
+export type IEmailCambioPassword = z.infer<typeof EmailCambioPasswordSchema>;
 
-export interface IEmailTwilio {
-  email?: string;
-  datos?:
-    | IEmailGenerico
-    | IEmailResetPassword
-    | IEmailNuevoUsuario
-    | IEmailCambioPassword;
-  idCliente?: string;
-  usuario?: string;
-  twilio?: IModuloSendgrid;
-  extra?: Record<string, any>;
-}
+export const EmailTwilioSchema = z.object({
+  email: z.string().optional(),
+  datos: z
+    .union([
+      EmailGenericoSchema,
+      EmailResetPasswordSchema,
+      EmailNuevoUsuarioSchema,
+      EmailCambioPasswordSchema,
+    ])
+    .optional(),
+  idCliente: z.string().optional(),
+  usuario: z.string().optional(),
+  twilio: ModuloSendgridSchema.optional(),
+  extra: z.record(z.string(), z.any()).optional(),
+});
+export type IEmailTwilio = z.infer<typeof EmailTwilioSchema>;

--- a/src/interfaces/servicio-contratado.ts
+++ b/src/interfaces/servicio-contratado.ts
@@ -1,24 +1,32 @@
-import { ICliente } from './cliente';
+import { z } from 'zod';
+import { ClienteSchema } from './cliente';
 
-export interface IServicioContratado {
-  _id?: string;
-  idCliente?: string;
-  idsAncestros?: string[];
-  nombre?: string;
-  icono?: string;
-  costo?: number;
-  global?: boolean;
+export const ServicioContratadoSchema = z.object({
+  _id: z.string().optional(),
+  idCliente: z.string().optional(),
+  idsAncestros: z.array(z.string()).optional(),
+  nombre: z.string().optional(),
+  icono: z.string().optional(),
+  costo: z.number().optional(),
+  global: z.boolean().optional(),
   // Populate
-  cliente?: ICliente;
-  ancestros?: ICliente[];
-}
+  cliente: ClienteSchema.optional(),
+  ancestros: z.array(ClienteSchema).optional(),
+});
+export type IServicioContratado = z.infer<typeof ServicioContratadoSchema>;
 
-type OmitirCreate = '_id' | 'cliente';
+export const CreateServicioContratadoSchema = ServicioContratadoSchema.omit({
+  _id: true,
+  cliente: true,
+});
+export type ICreateServicioContratado = z.infer<
+  typeof CreateServicioContratadoSchema
+>;
 
-export interface ICreateServicioContratado
-  extends Omit<Partial<IServicioContratado>, OmitirCreate> {}
-
-type OmitirUpdate = '_id' | 'cliente';
-
-export interface IUpdateServicioContratado
-  extends Omit<Partial<IServicioContratado>, OmitirUpdate> {}
+export const UpdateServicioContratadoSchema = ServicioContratadoSchema.omit({
+  _id: true,
+  cliente: true,
+});
+export type IUpdateServicioContratado = z.infer<
+  typeof UpdateServicioContratadoSchema
+>;

--- a/src/interfaces/servicio.ts
+++ b/src/interfaces/servicio.ts
@@ -1,61 +1,77 @@
-import { ICoordenadas } from '../auxiliares';
-import { IActivo } from './activo';
-import { ICliente } from './cliente';
-import { IProveedor } from './proveedor';
-import { IUsuario } from './usuario';
+import { z } from 'zod';
+import { ActivoSchema } from './activo';
+import { ClienteSchema } from './cliente';
+import { ProveedorSchema } from './proveedor';
+import { UsuarioSchema } from './usuario';
 
-export type TipoServicio = 'Gasto' | 'Mantenimiento' | 'Combustible';
-export type CategoriaServicio = 'Colectivo' | 'Vehiculo';
-export type SubcategoriaServicio =
-  | 'Cambio de aceite y filtro'
-  | 'Cambio de aceite de caja'
-  | 'Cambio de líquido refrigerante'
-  | 'Cambio de filtro de combustible'
-  | 'Cambio de filtro de aire'
-  | 'Cambio de filtro de habitáculo'
-  | 'Cambio de batería'
-  | 'Cambio de cubiertas'
-  | 'Cambio de luces'
-  | 'Cambio de líquido de frenos'
-  | 'Cambio de pastillas de freno'
-  | 'Cambio de bujías'
-  | 'Otro';
-export interface IServicio {
-  _id?: string;
-  tipo?: TipoServicio;
-  categoria?: CategoriaServicio;
-  subcategoria?: SubcategoriaServicio;
-  idCliente?: string;
-  idsAncestros?: string[];
-  idActivo?: string;
-  fechaRealizacion?: string;
-  fechaCreacion?: string;
-  nombreChofer?: string;
-  detalles?: string;
-  kmDelMantenimiento?: number;
-  costo?: number;
-  litrosCargados?: number;
-  idProveedor?: string;
-  fotos?: string[];
-  idUsuario?: string;
+export const TipoServicioSchema = z.enum([
+  'Gasto',
+  'Mantenimiento',
+  'Combustible',
+]);
+export type TipoServicio = z.infer<typeof TipoServicioSchema>;
+
+export const CategoriaServicioSchema = z.enum(['Colectivo', 'Vehiculo']);
+export type CategoriaServicio = z.infer<typeof CategoriaServicioSchema>;
+
+export const SubcategoriaServicioSchema = z.enum([
+  'Cambio de aceite y filtro',
+  'Cambio de aceite de caja',
+  'Cambio de líquido refrigerante',
+  'Cambio de filtro de combustible',
+  'Cambio de filtro de aire',
+  'Cambio de filtro de habitáculo',
+  'Cambio de batería',
+  'Cambio de cubiertas',
+  'Cambio de luces',
+  'Cambio de líquido de frenos',
+  'Cambio de pastillas de freno',
+  'Cambio de bujías',
+  'Otro',
+]);
+export type SubcategoriaServicio = z.infer<typeof SubcategoriaServicioSchema>;
+
+export const ServicioSchema = z.object({
+  _id: z.string().optional(),
+  tipo: TipoServicioSchema.optional(),
+  categoria: CategoriaServicioSchema.optional(),
+  subcategoria: SubcategoriaServicioSchema.optional(),
+  idCliente: z.string().optional(),
+  idsAncestros: z.array(z.string()).optional(),
+  idActivo: z.string().optional(),
+  fechaRealizacion: z.string().optional(),
+  fechaCreacion: z.string().optional(),
+  nombreChofer: z.string().optional(),
+  detalles: z.string().optional(),
+  kmDelMantenimiento: z.number().optional(),
+  costo: z.number().optional(),
+  litrosCargados: z.number().optional(),
+  idProveedor: z.string().optional(),
+  fotos: z.array(z.string()).optional(),
+  idUsuario: z.string().optional(),
   // Populate
-  cliente?: ICliente;
-  ancestros?: ICliente[];
-  proveedor?: IProveedor;
-  activo?: IActivo;
-  usuario?: IUsuario;
-}
+  cliente: ClienteSchema.optional(),
+  ancestros: z.array(ClienteSchema).optional(),
+  proveedor: ProveedorSchema.optional(),
+  activo: ActivoSchema.optional(),
+  usuario: UsuarioSchema.optional(),
+});
+export type IServicio = z.infer<typeof ServicioSchema>;
 
-type OmitirCreate = '_id' | 'cliente' | 'activo' | 'proveedor' | 'usuario';
+export const CreateServicioSchema = ServicioSchema.omit({
+  _id: true,
+  cliente: true,
+  activo: true,
+  proveedor: true,
+  usuario: true,
+});
+export type ICreateServicio = z.infer<typeof CreateServicioSchema>;
 
-export interface ICreateServicio extends Omit<
-  Partial<IServicio>,
-  OmitirCreate
-> {}
-
-type OmitirUpdate = '_id' | 'cliente' | 'activo' | 'proveedor' | 'usuario';
-
-export interface IUpdateServicio extends Omit<
-  Partial<IServicio>,
-  OmitirUpdate
-> {}
+export const UpdateServicioSchema = ServicioSchema.omit({
+  _id: true,
+  cliente: true,
+  activo: true,
+  proveedor: true,
+  usuario: true,
+});
+export type IUpdateServicio = z.infer<typeof UpdateServicioSchema>;

--- a/src/interfaces/sirena.ts
+++ b/src/interfaces/sirena.ts
@@ -1,41 +1,54 @@
-import { IGeoJSONPoint } from '../auxiliares';
-import { ICamara } from './camara';
-import { ICliente } from './cliente';
-import { IModeloDispositivo } from './modelo-dispositivo';
+import { z } from 'zod';
+import { GeoJSONPointSchema } from '../auxiliares';
+import { CamaraSchema } from './camara';
+import { ClienteSchema } from './cliente';
+import { ModeloDispositivoSchema } from './modelo-dispositivo';
 
-export type EstadoSirena = 'Online' | 'Offline';
+export const EstadoSirenaSchema = z.enum(['Online', 'Offline']);
+export type EstadoSirena = z.infer<typeof EstadoSirenaSchema>;
 
-export interface ISirena {
-  _id?: string;
+export const SirenaSchema = z.object({
+  _id: z.string().optional(),
   /// Cosas de IRIX
-  idCliente?: string;
-  idsAncestros?: string[];
-  fechaCreacion?: string;
-  idModelo?: string;
-  idsAsignados?: string[]; // Camaras, sensores, etc
+  idCliente: z.string().optional(),
+  idsAncestros: z.array(z.string()).optional(),
+  fechaCreacion: z.string().optional(),
+  idModelo: z.string().optional(),
+  idsAsignados: z.array(z.string()).optional(), // Camaras, sensores, etc
 
   // Datos de sincronizacion de seguridad
-  idExterno?: string; /// El _id que tiene la sirena en seguridad
-  chipId?: string; /// El chipId de la sirena en seguridad
-  fechaSincronizacion?: string;
-  ubicacion?: IGeoJSONPoint;
-  direccion?: string;
-  activa?: boolean;
-  estado?: EstadoSirena;
-  tipo?: string;
-  onlineDesde?: string;
-  offlineDesde?: string;
-  iccidSim?: string;
-  telefono?: string;
+  idExterno: z.string().optional(), /// El _id que tiene la sirena en seguridad
+  chipId: z.string().optional(), /// El chipId de la sirena en seguridad
+  fechaSincronizacion: z.string().optional(),
+  ubicacion: GeoJSONPointSchema.optional(),
+  direccion: z.string().optional(),
+  activa: z.boolean().optional(),
+  estado: EstadoSirenaSchema.optional(),
+  tipo: z.string().optional(),
+  onlineDesde: z.string().optional(),
+  offlineDesde: z.string().optional(),
+  iccidSim: z.string().optional(),
+  telefono: z.string().optional(),
 
   /// Populates
-  cliente?: ICliente;
-  camaras?: ICamara[];
-  modelo?: IModeloDispositivo;
-}
+  cliente: ClienteSchema.optional(),
+  camaras: z.array(CamaraSchema).optional(),
+  modelo: ModeloDispositivoSchema.optional(),
+});
+export type ISirena = z.infer<typeof SirenaSchema>;
 
-type Omitir = '_id' | 'cliente' | 'camaras' | 'modelo';
+export const CreateSirenaSchema = SirenaSchema.omit({
+  _id: true,
+  cliente: true,
+  camaras: true,
+  modelo: true,
+});
+export type ICreateSirena = z.infer<typeof CreateSirenaSchema>;
 
-export interface ICreateSirena extends Omit<Partial<ISirena>, Omitir> {}
-
-export interface IUpdateSirena extends Omit<Partial<ISirena>, Omitir> {}
+export const UpdateSirenaSchema = SirenaSchema.omit({
+  _id: true,
+  cliente: true,
+  camaras: true,
+  modelo: true,
+});
+export type IUpdateSirena = z.infer<typeof UpdateSirenaSchema>;

--- a/src/interfaces/soap.ts
+++ b/src/interfaces/soap.ts
@@ -1,106 +1,121 @@
-import { ICliente } from './cliente';
+import { z } from 'zod';
+import { ClienteSchema } from './cliente';
 
-export interface ISoap {
-  _id?: string;
-  idCliente?: string;
-  idsAncestros?: string[];
-  fechaCreacion?: string;
+export const SoapAltaSchema = z.object({
+  grupoEconomico: z.number().optional(),
+  empresa: z.number().optional(),
+  linea: z.number().optional(),
+  nroInterno: z.number().optional(),
+  legajoChofer: z.number().optional(),
+  salidaDateTime: z.string().optional(),
+  codigoRamal: z.number().optional(),
+  sentido: z.number().optional(),
+  llegadaDateTime: z.string().optional(),
+  numeroVueltaTurno: z.number().optional(),
+  idDiagramaDaz: z.number().optional(),
+  idTurnoDaz: z.number().optional(),
+  turno: z.string().optional(),
+  seccionadoCsv: z.string().optional(),
+});
+export type ISoapAlta = z.infer<typeof SoapAltaSchema>;
 
-  alta?: ISoapAlta;
-  create?: ISoapCreate;
-  altaChofer?: ISoapAltaChofer;
-  obtenerChoferes?: ISoapObtenerChoferes;
-  altaPorMinuta?: ISoapAltaPorMinuta;
-  altaPorMinutaChofer?: ISoapAltaPorMinutaChofer;
-  baja?: ISoapBaja;
+export const SoapCreateSchema = z.object({
+  grupoEconomico: z.instanceof(Int16Array).optional(),
+  empresa: z.instanceof(Int16Array).optional(),
+  linea: z.instanceof(Int16Array).optional(),
+  nroInterno: z.instanceof(Int16Array).optional(),
+  legajoChofer: z.instanceof(Int16Array).optional(),
+  salida: z.string().optional(), //dateTimeInt16Array;
+  codigoRamal: z.instanceof(Int16Array).optional(),
+  sentido: z.instanceof(Int16Array).optional(),
+  llegada: z.string().optional(), //dateTimeInt16Array;
+  numeroVueltaTurno: z.instanceof(Int16Array).optional(),
+  idDiagramaDaz: z.instanceof(Int16Array).optional(),
+  idTurnoDaz: z.instanceof(Int16Array).optional(),
+  turno: z.number().optional(), //charInt16Array;
+  seccionado: z.string().optional(), //ArrayOfKeyValuePairOfInt32DateTimeInt16Array;
+});
+export type ISoapCreate = z.infer<typeof SoapCreateSchema>;
+
+export const SoapAltaChoferSchema = z.object({
+  grupoEconomico: z.number().optional(),
+  empresa: z.number().optional(),
+  linea: z.number().optional(),
+  legajoChofer: z.number().optional(),
+  NombreChofer: z.string().optional(),
+});
+export type ISoapAltaChofer = z.infer<typeof SoapAltaChoferSchema>;
+
+export const SoapObtenerChoferesSchema = z.object({
+  grupoEconomico: z.number().optional(),
+  empresa: z.number().optional(),
+  linea: z.number().optional(),
+});
+export type ISoapObtenerChoferes = z.infer<typeof SoapObtenerChoferesSchema>;
+
+export const SoapAltaPorMinutaSchema = z.object({
+  grupoEconomico: z.number().optional(),
+  empresa: z.number().optional(),
+  linea: z.number().optional(),
+  nroInterno: z.number().optional(),
+  legajoChofer: z.number().optional(),
+  salidaDateTime: z.string().optional(),
+  idMinutaSauron: z.number().optional(),
+});
+export type ISoapAltaPorMinuta = z.infer<typeof SoapAltaPorMinutaSchema>;
+
+export const SoapAltaPorMinutaChoferSchema = z.object({
+  grupoEconomico: z.number().optional(),
+  empresa: z.number().optional(),
+  linea: z.number().optional(),
+  nroInterno: z.number().optional(),
+  legajoChofer: z.number().optional(),
+  salidaDateTime: z.string().optional(),
+  idMinutaSauron: z.number().optional(),
+  nombreChofer: z.string().optional(),
+  dniChofer: z.string().optional(),
+});
+export type ISoapAltaPorMinutaChofer = z.infer<
+  typeof SoapAltaPorMinutaChoferSchema
+>;
+
+export const SoapBajaSchema = z.object({
+  idHorarioOjoSauron: z.number().optional(),
+  motivo: z.number().optional(),
+  descripcionMotivo: z.string().optional(),
+  lineaDaz: z.number().optional(),
+  nroInterno: z.number().optional(),
+});
+export type ISoapBaja = z.infer<typeof SoapBajaSchema>;
+
+export const SoapSchema = z.object({
+  _id: z.string().optional(),
+  idCliente: z.string().optional(),
+  idsAncestros: z.array(z.string()).optional(),
+  fechaCreacion: z.string().optional(),
+
+  alta: SoapAltaSchema.optional(),
+  create: SoapCreateSchema.optional(),
+  altaChofer: SoapAltaChoferSchema.optional(),
+  obtenerChoferes: SoapObtenerChoferesSchema.optional(),
+  altaPorMinuta: SoapAltaPorMinutaSchema.optional(),
+  altaPorMinutaChofer: SoapAltaPorMinutaChoferSchema.optional(),
+  baja: SoapBajaSchema.optional(),
 
   // Populate
-  cliente?: ICliente;
-  ancestros?: ICliente[];
-}
+  cliente: ClienteSchema.optional(),
+  ancestros: z.array(ClienteSchema).optional(),
+});
+export type ISoap = z.infer<typeof SoapSchema>;
 
-type OmitirCreate = '_id' | 'cliente';
+export const CreateSoapSchema = SoapSchema.omit({
+  _id: true,
+  cliente: true,
+});
+export type ICreateSoap = z.infer<typeof CreateSoapSchema>;
 
-export interface ICreateSoap extends Omit<Partial<ISoap>, OmitirCreate> {}
-
-type OmitirUpdate = '_id' | 'cliente';
-
-export interface IUpdateSoap extends Omit<Partial<ISoap>, OmitirUpdate> {}
-
-export interface ISoapAlta {
-  grupoEconomico?: number;
-  empresa?: number;
-  linea?: number;
-  nroInterno?: number;
-  legajoChofer?: number;
-  salidaDateTime?: string;
-  codigoRamal?: number;
-  sentido?: number;
-  llegadaDateTime?: string;
-  numeroVueltaTurno?: number;
-  idDiagramaDaz?: number;
-  idTurnoDaz?: number;
-  turno?: string;
-  seccionadoCsv?: string;
-}
-
-export interface ISoapCreate {
-  grupoEconomico?: Int16Array;
-  empresa?: Int16Array;
-  linea?: Int16Array;
-  nroInterno?: Int16Array;
-  legajoChofer?: Int16Array;
-  salida?: string; //dateTimeInt16Array;
-  codigoRamal?: Int16Array;
-  sentido?: Int16Array;
-  llegada?: string; //dateTimeInt16Array;
-  numeroVueltaTurno?: Int16Array;
-  idDiagramaDaz?: Int16Array;
-  idTurnoDaz?: Int16Array;
-  turno?: number; //charInt16Array;
-  seccionado?: string; //ArrayOfKeyValuePairOfInt32DateTimeInt16Array;
-}
-
-export interface ISoapAltaChofer {
-  grupoEconomico?: number;
-  empresa?: number;
-  linea?: number;
-  legajoChofer?: number;
-  NombreChofer?: string;
-}
-
-export interface ISoapObtenerChoferes {
-  grupoEconomico?: number;
-  empresa?: number;
-  linea?: number;
-}
-
-export interface ISoapAltaPorMinuta {
-  grupoEconomico?: number;
-  empresa?: number;
-  linea?: number;
-  nroInterno?: number;
-  legajoChofer?: number;
-  salidaDateTime?: string;
-  idMinutaSauron?: number;
-}
-
-export interface ISoapAltaPorMinutaChofer {
-  grupoEconomico?: number;
-  empresa?: number;
-  linea?: number;
-  nroInterno?: number;
-  legajoChofer?: number;
-  salidaDateTime?: string;
-  idMinutaSauron?: number;
-  nombreChofer?: string;
-  dniChofer?: string;
-}
-
-export interface ISoapBaja {
-  idHorarioOjoSauron?: number;
-  motivo?: number;
-  descripcionMotivo?: string;
-  lineaDaz?: number;
-  nroInterno?: number;
-}
+export const UpdateSoapSchema = SoapSchema.omit({
+  _id: true,
+  cliente: true,
+});
+export type IUpdateSoap = z.infer<typeof UpdateSoapSchema>;

--- a/src/interfaces/tema.ts
+++ b/src/interfaces/tema.ts
@@ -1,86 +1,107 @@
-import { ICliente } from './cliente';
+import { z } from 'zod';
+import { ClienteSchema } from './cliente';
 
-export type IMotorEfectoFullscreen = 'particulas';
+export const MotorEfectoFullscreenSchema = z.enum(['particulas']);
+export type IMotorEfectoFullscreen = z.infer<
+  typeof MotorEfectoFullscreenSchema
+>;
 
-export interface IRangoNumerico {
-  min: number;
-  max: number;
-}
+export const RangoNumericoSchema = z.object({
+  min: z.number(),
+  max: z.number(),
+});
+export type IRangoNumerico = z.infer<typeof RangoNumericoSchema>;
 
-export interface IDiaMes {
-  mes: number; // 0-11
-  dia: number; // 1-31
-}
+export const DiaMesSchema = z.object({
+  mes: z.number(), // 0-11
+  dia: z.number(), // 1-31
+});
+export type IDiaMes = z.infer<typeof DiaMesSchema>;
 
-export interface IRangoRecurrenteAnual {
-  inicio: IDiaMes;
-  fin: IDiaMes;
-}
+export const RangoRecurrenteAnualSchema = z.object({
+  inicio: DiaMesSchema,
+  fin: DiaMesSchema,
+});
+export type IRangoRecurrenteAnual = z.infer<typeof RangoRecurrenteAnualSchema>;
 
-export interface IDecal {
-  urlAsset: string;
-  tamanoPct?: number; // 0-100
-}
+export const DecalSchema = z.object({
+  urlAsset: z.string(),
+  tamanoPct: z.number().optional(), // 0-100
+});
+export type IDecal = z.infer<typeof DecalSchema>;
 
-export interface IEfectoFullscreen {
-  motor: IMotorEfectoFullscreen;
-  spriteUrl: string;
-  cantidad: number; // 1-128
-  velocidad: IRangoNumerico; // segundos por ciclo
-  tamano: IRangoNumerico; // pixeles
-  drift: number; // pixeles laterales (0 = caída recta)
-  paleta?: string[]; // hex tints opcionales
-}
+export const EfectoFullscreenSchema = z.object({
+  motor: MotorEfectoFullscreenSchema,
+  spriteUrl: z.string(),
+  cantidad: z.number(), // 1-128
+  velocidad: RangoNumericoSchema, // segundos por ciclo
+  tamano: RangoNumericoSchema, // pixeles
+  drift: z.number(), // pixeles laterales (0 = caída recta)
+  paleta: z.array(z.string()).optional(), // hex tints opcionales
+});
+export type IEfectoFullscreen = z.infer<typeof EfectoFullscreenSchema>;
 
-export interface ITemaPayload {
-  decalAvatar?: IDecal;
-  decalLogoLogin?: IDecal;
-  decalTopbar?: IDecal;
-  decalLogin?: IDecal;
-  efectoFullscreen?: IEfectoFullscreen;
-}
+export const TemaPayloadSchema = z.object({
+  decalAvatar: DecalSchema.optional(),
+  decalLogoLogin: DecalSchema.optional(),
+  decalTopbar: DecalSchema.optional(),
+  decalLogin: DecalSchema.optional(),
+  efectoFullscreen: EfectoFullscreenSchema.optional(),
+});
+export type ITemaPayload = z.infer<typeof TemaPayloadSchema>;
 
-export interface ITema {
-  _id?: string;
+export const TemaSchema = z.object({
+  _id: z.string().optional(),
   //
-  nombre?: string;
-  descripcion?: string;
-  activa?: boolean;
-  fechaInicio?: string;
-  fechaFin?: string;
-  diasRecurrentes?: IRangoRecurrenteAnual;
-  prioridad?: number; // 0-100
-  global?: boolean;
-  idCliente?: string;
-  idsAncestros?: string[];
-  payload?: ITemaPayload;
-  fechaCreacion?: string;
-  fechaActualizacion?: string;
+  nombre: z.string().optional(),
+  descripcion: z.string().optional(),
+  activa: z.boolean().optional(),
+  fechaInicio: z.string().optional(),
+  fechaFin: z.string().optional(),
+  diasRecurrentes: RangoRecurrenteAnualSchema.optional(),
+  prioridad: z.number().optional(), // 0-100
+  global: z.boolean().optional(),
+  idCliente: z.string().optional(),
+  idsAncestros: z.array(z.string()).optional(),
+  payload: TemaPayloadSchema.optional(),
+  fechaCreacion: z.string().optional(),
+  fechaActualizacion: z.string().optional(),
   // Populate
-  cliente?: ICliente;
-  ancestros?: ICliente[];
-}
+  cliente: ClienteSchema.optional(),
+  ancestros: z.array(ClienteSchema).optional(),
+});
+export type ITema = z.infer<typeof TemaSchema>;
 
-type OmitirCreate = '_id' | 'cliente' | 'ancestros' | 'fechaCreacion' | 'fechaActualizacion';
+export const CreateTemaSchema = TemaSchema.omit({
+  _id: true,
+  cliente: true,
+  ancestros: true,
+  fechaCreacion: true,
+  fechaActualizacion: true,
+});
+export type ICreateTema = z.infer<typeof CreateTemaSchema>;
 
-export interface ICreateTema extends Omit<
-  Partial<ITema>,
-  OmitirCreate
-> {}
+export const UpdateTemaSchema = TemaSchema.omit({
+  _id: true,
+  cliente: true,
+  ancestros: true,
+  fechaCreacion: true,
+  fechaActualizacion: true,
+});
+export type IUpdateTema = z.infer<typeof UpdateTemaSchema>;
 
-type OmitirUpdate = '_id' | 'cliente' | 'ancestros' | 'fechaCreacion' | 'fechaActualizacion';
+export const TemaCacheSchema = TemaSchema.omit({
+  cliente: true,
+  ancestros: true,
+});
+export type ITemaCache = z.infer<typeof TemaCacheSchema>;
 
-export interface IUpdateTema extends Omit<
-  Partial<ITema>,
-  OmitirUpdate
-> {}
-
-export interface ITemaCache extends Omit<
-  ITema,
-  'cliente' | 'ancestros'
-> {}
-
-export interface ITemaPublico extends Omit<
-  ITema,
-  'cliente' | 'ancestros' | 'idCliente' | 'idsAncestros' | 'fechaCreacion' | 'fechaActualizacion'
-> {}
+export const TemaPublicoSchema = TemaSchema.omit({
+  cliente: true,
+  ancestros: true,
+  idCliente: true,
+  idsAncestros: true,
+  fechaCreacion: true,
+  fechaActualizacion: true,
+});
+export type ITemaPublico = z.infer<typeof TemaPublicoSchema>;

--- a/src/interfaces/tipo-evento.ts
+++ b/src/interfaces/tipo-evento.ts
@@ -1,30 +1,42 @@
-import { ICliente } from "./cliente";
+import { z } from "zod";
+import { ClienteSchema } from "./cliente";
 
-export type ICategoriaTipoEvento = "Alarma" | "Tracker" | "Luminaria";
+export const CategoriaTipoEventoSchema = z.enum([
+  "Alarma",
+  "Tracker",
+  "Luminaria",
+]);
+export type ICategoriaTipoEvento = z.infer<typeof CategoriaTipoEventoSchema>;
 
-export interface ITipoEvento {
-  _id?: string;
+export const TipoEventoSchema = z.object({
+  _id: z.string().optional(),
   //
-  nombre?: string;
-  categoria?: ICategoriaTipoEvento;
-  idCliente?: string;
-  idsAncestros?: string[];
-  default?: boolean;
-  global?: boolean;
+  nombre: z.string().optional(),
+  categoria: CategoriaTipoEventoSchema.optional(),
+  idCliente: z.string().optional(),
+  idsAncestros: z.array(z.string()).optional(),
+  default: z.boolean().optional(),
+  global: z.boolean().optional(),
   //Populate
-  cliente?: ICliente;
-  ancestros?: ICliente[];
-}
+  cliente: ClienteSchema.optional(),
+  ancestros: z.array(ClienteSchema).optional(),
+});
+export type ITipoEvento = z.infer<typeof TipoEventoSchema>;
 
-type OmitirCreate = "_id" | "cliente";
+export const CreateTipoEventoSchema = TipoEventoSchema.omit({
+  _id: true,
+  cliente: true,
+});
+export type ICreateTipoEvento = z.infer<typeof CreateTipoEventoSchema>;
 
-export interface ICreateTipoEvento
-  extends Omit<Partial<ITipoEvento>, OmitirCreate> {}
+export const UpdateTipoEventoSchema = TipoEventoSchema.omit({
+  _id: true,
+  cliente: true,
+});
+export type IUpdateTipoEvento = z.infer<typeof UpdateTipoEventoSchema>;
 
-type OmitirUpdate = "_id" | "cliente";
-
-export interface IUpdateTipoEvento
-  extends Omit<Partial<ITipoEvento>, OmitirUpdate> {}
-
-export interface ITipoEventoCache
-  extends Omit<ITipoEvento, "cliente" | "ancestros"> {}
+export const TipoEventoCacheSchema = TipoEventoSchema.omit({
+  cliente: true,
+  ancestros: true,
+});
+export type ITipoEventoCache = z.infer<typeof TipoEventoCacheSchema>;

--- a/src/interfaces/token-push.ts
+++ b/src/interfaces/token-push.ts
@@ -1,23 +1,29 @@
-export type PlataformaTokenPush = 'android' | 'ios';
+import { z } from 'zod';
 
-export interface ITokenPush {
-  _id?: string;
-  fechaCreacion?: string;
-  fechaActualizacion?: string;
-  tokenPush?: string;
-  idUsuario?: string;
+export const PlataformaTokenPushSchema = z.enum(['android', 'ios']);
+export type PlataformaTokenPush = z.infer<typeof PlataformaTokenPushSchema>;
+
+export const TokenPushSchema = z.object({
+  _id: z.string().optional(),
+  fechaCreacion: z.string().optional(),
+  fechaActualizacion: z.string().optional(),
+  tokenPush: z.string().optional(),
+  idUsuario: z.string().optional(),
   // Identificador estable del dispositivo (Android: ANDROID_ID, iOS:
   // identifierForVendor). Permite 1 fila por (idUsuario, idDispositivo):
   // al rotar el FCM token se reemplaza el de ese device (sin huerfanos) y
   // el logout borra limpio por device.
-  idDispositivo?: string;
-  plataforma?: PlataformaTokenPush;
-}
+  idDispositivo: z.string().optional(),
+  plataforma: PlataformaTokenPushSchema.optional(),
+});
+export type ITokenPush = z.infer<typeof TokenPushSchema>;
 
-type OmitirCreate = '_id';
-export interface ICreateTokenPush
-  extends Omit<Partial<ITokenPush>, OmitirCreate> {}
+export const CreateTokenPushSchema = TokenPushSchema.omit({
+  _id: true,
+});
+export type ICreateTokenPush = z.infer<typeof CreateTokenPushSchema>;
 
-type OmitirUpdate = '_id';
-export interface IUpdateTokenPush
-  extends Omit<Partial<ITokenPush>, OmitirUpdate> {}
+export const UpdateTokenPushSchema = TokenPushSchema.omit({
+  _id: true,
+});
+export type IUpdateTokenPush = z.infer<typeof UpdateTokenPushSchema>;

--- a/src/interfaces/token.ts
+++ b/src/interfaces/token.ts
@@ -1,21 +1,25 @@
-import { IClient } from './client';
-import { IUsuario } from './usuario';
+import { z } from 'zod';
+import { ClientSchema } from './client';
+import { UsuarioSchema } from './usuario';
 
-export interface IToken {
-  _id?: string;
-  accessToken?: string;
-  accessTokenExpiresAt?: string;
-  refreshToken?: string;
-  refreshTokenExpiresAt?: string;
-  scope?: string | string[];
-  client?: IClient;
-  user?: IUsuario;
-}
+export const TokenSchema = z.object({
+  _id: z.string().optional(),
+  accessToken: z.string().optional(),
+  accessTokenExpiresAt: z.string().optional(),
+  refreshToken: z.string().optional(),
+  refreshTokenExpiresAt: z.string().optional(),
+  scope: z.union([z.string(), z.array(z.string())]).optional(),
+  client: ClientSchema.optional(),
+  user: UsuarioSchema.optional(),
+});
+export type IToken = z.infer<typeof TokenSchema>;
 
-type OmitirCreate = '_id';
+export const CreateTokenSchema = TokenSchema.omit({
+  _id: true,
+});
+export type ICreateToken = z.infer<typeof CreateTokenSchema>;
 
-export interface ICreateToken extends Omit<Partial<IToken>, OmitirCreate> {}
-
-type OmitirUpdate = '_id';
-
-export interface IUpdateToken extends Omit<Partial<IToken>, OmitirUpdate> {}
+export const UpdateTokenSchema = TokenSchema.omit({
+  _id: true,
+});
+export type IUpdateToken = z.infer<typeof UpdateTokenSchema>;

--- a/src/interfaces/trackeo.ts
+++ b/src/interfaces/trackeo.ts
@@ -1,51 +1,53 @@
-import { IActivo } from './activo';
-import { ICliente } from './cliente';
-import { IGrupo } from './grupo';
-import { IParada, IRecorrido } from './recorrido';
+import { z } from 'zod';
+import { ActivoSchema } from './activo';
+import { ClienteSchema } from './cliente';
+import { GrupoSchema } from './grupo';
+import { ParadaSchema, RecorridoSchema } from './recorrido';
 
-export interface ITrackeo {
-  _id?: string;
+export const TrackeoSchema = z.object({
+  _id: z.string().optional(),
   //
-  idCliente?: string;
-  idsAncestros?: string[];
-  idGrupo?: string;
-  idRecorrido?: string;
-  idActivo?: string;
+  idCliente: z.string().optional(),
+  idsAncestros: z.array(z.string()).optional(),
+  idGrupo: z.string().optional(),
+  idRecorrido: z.string().optional(),
+  idActivo: z.string().optional(),
 
-  fecha?: string;
-  idParada?: string;
-  indiceParada?: number;
-  fechaProximaParada?: string;
-  idProximaParada?: string;
+  fecha: z.string().optional(),
+  idParada: z.string().optional(),
+  indiceParada: z.number().optional(),
+  fechaProximaParada: z.string().optional(),
+  idProximaParada: z.string().optional(),
 
   // Populate
-  cliente?: ICliente;
-  ancestros?: ICliente[];
-  grupo?: IGrupo;
-  activo?: IActivo;
-  recorrido?: IRecorrido;
-  parada?: IParada;
-  proximaParada?: IParada;
-}
+  cliente: ClienteSchema.optional(),
+  ancestros: z.array(ClienteSchema).optional(),
+  grupo: GrupoSchema.optional(),
+  activo: ActivoSchema.optional(),
+  recorrido: RecorridoSchema.optional(),
+  parada: ParadaSchema.optional(),
+  proximaParada: ParadaSchema.optional(),
+});
+export type ITrackeo = z.infer<typeof TrackeoSchema>;
 
-type OmitirCreate =
-  | '_id'
-  | 'cliente'
-  | 'grupo'
-  | 'activo'
-  | 'recorrido'
-  | 'parada'
-  | 'proximaParada';
+export const CreateTrackeoSchema = TrackeoSchema.omit({
+  _id: true,
+  cliente: true,
+  grupo: true,
+  activo: true,
+  recorrido: true,
+  parada: true,
+  proximaParada: true,
+});
+export type ICreateTrackeo = z.infer<typeof CreateTrackeoSchema>;
 
-export interface ICreateTrackeo extends Omit<Partial<ITrackeo>, OmitirCreate> {}
-
-type OmitirUpdate =
-  | '_id'
-  | 'cliente'
-  | 'grupo'
-  | 'activo'
-  | 'recorrido'
-  | 'parada'
-  | 'proximaParada';
-
-export interface IUpdateTrackeo extends Omit<Partial<ITrackeo>, OmitirUpdate> {}
+export const UpdateTrackeoSchema = TrackeoSchema.omit({
+  _id: true,
+  cliente: true,
+  grupo: true,
+  activo: true,
+  recorrido: true,
+  parada: true,
+  proximaParada: true,
+});
+export type IUpdateTrackeo = z.infer<typeof UpdateTrackeoSchema>;

--- a/src/interfaces/tracker.ts
+++ b/src/interfaces/tracker.ts
@@ -1,24 +1,95 @@
-import { IActivo } from './activo';
-import { ICliente, IConfigHorario } from './cliente';
-import { ISim } from './dispositivo-alarma';
-import { estadoCuenta } from './estado-entidad';
-import { IModeloDispositivo } from './modelo-dispositivo';
-import { IServicioContratado } from './servicio-contratado';
+import { z } from 'zod';
+import type { IActivo } from './activo';
+import {
+  ClienteSchema,
+  ConfigHorarioSchema,
+  ICliente,
+  IConfigHorario,
+} from './cliente';
+import type { ISim } from './dispositivo-alarma';
+import type { estadoCuenta } from './estado-entidad';
+import {
+  IModeloDispositivo,
+  ModeloDispositivoSchema,
+} from './modelo-dispositivo';
+import {
+  IServicioContratado,
+  ServicioContratadoSchema,
+} from './servicio-contratado';
 
-export type TipoTracker = 'Qualcomm' | 'GPRS' | 'T1000-B' | 'Telefono';
+export const TipoTrackerSchema = z.enum([
+  'Qualcomm',
+  'GPRS',
+  'T1000-B',
+  'Telefono',
+]);
+export type TipoTracker = z.infer<typeof TipoTrackerSchema>;
 
-export interface IT100bDevice {
-  deveui?: string;
-}
-export interface IQualcommDevice {
+export const T100bDeviceSchema = z.object({
+  deveui: z.string().optional(),
+});
+export type IT100bDevice = z.infer<typeof T100bDeviceSchema>;
+
+export const QualcommDeviceSchema = z.object({
   // Datos de Qualcomm
-  serialNumber?: string;
-}
+  serialNumber: z.string().optional(),
+});
+export type IQualcommDevice = z.infer<typeof QualcommDeviceSchema>;
 
-export interface ITelefono {
-  deviceId?: string;
-}
+export const TelefonoSchema = z.object({
+  deviceId: z.string().optional(),
+});
+export type ITelefono = z.infer<typeof TelefonoSchema>;
 
+// Populates intra-SCC como z.custom (import type-only): un schema real acá
+// arrastra el shape completo del ciclo y revienta la serialización de
+// declarations (TS7056) acá y en los consumidores NestJS.
+export const TrackerSchema = z.object({
+  _id: z.string().optional(),
+  //
+  fechaCreacion: z.string().optional(),
+  fechaAlta: z.string().optional(),
+  imagenes: z.array(z.string()).optional(),
+  idCliente: z.string().optional(),
+  idsAncestros: z.array(z.string()).optional(),
+  idsClientesQuePuedenAtenderEventos: z.array(z.string()).optional(),
+  idsClientesQuePuedenAtenderEventosTecnicos: z.array(z.string()).optional(),
+  puedeSolicitarServicioTecnico: z.boolean().optional(),
+  configHorariosAtencion: z.array(ConfigHorarioSchema).optional(),
+  configHorariosAtencionTecnica: z.array(ConfigHorarioSchema).optional(),
+  idModelo: z.string().optional(),
+  nombre: z.string().optional(),
+  identificacion: z.string().optional(),
+  asignadoA: z.string().optional(),
+  tipo: TipoTrackerSchema.optional(),
+  /**
+   * Id del tracker fisico
+   */
+  uniqueId: z.string().optional(),
+  qualcomm: QualcommDeviceSchema.optional(),
+  t1000b: T100bDeviceSchema.optional(),
+  telefono: TelefonoSchema.optional(),
+  estadoCuenta: z.custom<estadoCuenta>().optional(),
+  numeroAbonado: z.string().optional(),
+  sim1: z.custom<ISim>().optional(),
+  sim2: z.custom<ISim>().optional(),
+  frecReporte: z.number().optional(),
+  // Activa/desactiva remotamente el tracking GPS (solo aplica a tipo='Telefono').
+  trackingActivo: z.boolean().optional(),
+  //
+  idServiciosContratados: z.array(z.string()).optional(),
+  // Populate
+  cliente: ClienteSchema.optional(),
+  ancestros: z.array(ClienteSchema).optional(),
+  activo: z.custom<IActivo>().optional(),
+  modelo: ModeloDispositivoSchema.optional(),
+  serviciosContratados: z.array(ServicioContratadoSchema).optional(),
+});
+
+/**
+ * Interface hand-written (misma forma que el schema): los tipos de entidad del
+ * SCC no usan z.infer para no arrastrar el ciclo en el declaration emit.
+ */
 export interface ITracker {
   _id?: string;
   //
@@ -68,6 +139,13 @@ type OmitirCreate =
   | 'modelo'
   | 'serviciosContratados';
 
+export const CreateTrackerSchema = TrackerSchema.omit({
+  _id: true,
+  cliente: true,
+  activo: true,
+  modelo: true,
+  serviciosContratados: true,
+});
 export interface ICreateTracker extends Omit<Partial<ITracker>, OmitirCreate> {}
 
 type OmitirUpdate =
@@ -77,8 +155,22 @@ type OmitirUpdate =
   | 'modelo'
   | 'serviciosContratados';
 
+export const UpdateTrackerSchema = TrackerSchema.omit({
+  _id: true,
+  cliente: true,
+  activo: true,
+  modelo: true,
+  serviciosContratados: true,
+});
 export interface IUpdateTracker extends Omit<Partial<ITracker>, OmitirUpdate> {}
 
+export const TrackerCacheSchema = TrackerSchema.omit({
+  cliente: true,
+  ancestros: true,
+  activo: true,
+  modelo: true,
+  serviciosContratados: true,
+});
 export interface ITrackerCache extends Omit<
   ITracker,
   'cliente' | 'ancestros' | 'activo' | 'modelo' | 'serviciosContratados'

--- a/src/interfaces/tratamiento-evento.ts
+++ b/src/interfaces/tratamiento-evento.ts
@@ -1,39 +1,45 @@
-import { IUsuario } from './usuario';
+import { z } from 'zod';
+import { UsuarioSchema } from './usuario';
 import {
-  EstadoEvento,
-  EstadoEventoTecnico,
-  IEventoGenerico,
+  EstadoEventoSchema,
+  EstadoEventoTecnicoSchema,
 } from './evento-generico';
+import type { IEventoGenerico } from './evento-generico';
 
-export interface ITratamientoEvento {
-  _id?: string;
+export const TratamientoEventoSchema = z.object({
+  _id: z.string().optional(),
   //
-  nota?: string;
-  notaInterna?: string;
-  imagenes?: string[];
-  fechaCreacion?: string;
-  estado?: EstadoEvento;
+  nota: z.string().optional(),
+  notaInterna: z.string().optional(),
+  imagenes: z.array(z.string()).optional(),
+  fechaCreacion: z.string().optional(),
+  estado: EstadoEventoSchema.optional(),
   // Separados para no hinche las bolas el overlap.
-  estadoTecnico?: EstadoEventoTecnico;
-  esperaHasta?: string;
+  estadoTecnico: EstadoEventoTecnicoSchema.optional(),
+  esperaHasta: z.string().optional(),
   //
-  idsEventos?: string[];
-  idUsuario?: string;
+  idsEventos: z.array(z.string()).optional(),
+  idUsuario: z.string().optional(),
   // Populate
-  eventos?: IEventoGenerico[];
-  usuario?: IUsuario;
-}
+  eventos: z.array(z.custom<IEventoGenerico>()).optional(),
+  usuario: UsuarioSchema.optional(),
+});
+export type ITratamientoEvento = z.infer<typeof TratamientoEventoSchema>;
 
-type OmitirCreate = '_id' | 'eventos' | 'usuario';
+export const CreateTratamientoEventoSchema = TratamientoEventoSchema.omit({
+  _id: true,
+  eventos: true,
+  usuario: true,
+});
+export type ICreateTratamientoEvento = z.infer<
+  typeof CreateTratamientoEventoSchema
+>;
 
-export interface ICreateTratamientoEvento extends Omit<
-  Partial<ITratamientoEvento>,
-  OmitirCreate
-> {}
-
-type OmitirUpdate = '_id' | 'eventos' | 'usuario';
-
-export interface IUpdateTratamientoEvento extends Omit<
-  Partial<ITratamientoEvento>,
-  OmitirUpdate
-> {}
+export const UpdateTratamientoEventoSchema = TratamientoEventoSchema.omit({
+  _id: true,
+  eventos: true,
+  usuario: true,
+});
+export type IUpdateTratamientoEvento = z.infer<
+  typeof UpdateTratamientoEventoSchema
+>;

--- a/src/interfaces/twilio-templates.ts
+++ b/src/interfaces/twilio-templates.ts
@@ -1,3 +1,5 @@
+import { z } from 'zod';
+
 /**
  * Interfaz para el template de Twilio
  *
@@ -6,15 +8,18 @@
  *  @example `${modelo}*${passComunicador},ID=${idComunicador},${apn}=${usuario},PWD=${pwd},IP=${ip},PORT=${port},,,`
  */
 
-export interface ConfigComunicadorNanocomm {
+export const ConfigComunicadorNanocommSchema = z.object({
   // ED5200*1234,ID=6573,igprs.claro.com.ar=clarogprs,PWD=clarogprs999,IP=34.46.185.217,PORT=6000,,,
   // Modelo*PASSComunicador,ID=idComunicador,apn=usuario,PWD=password,IP=server,PORT=portServer,,,
-  modelo?: string;
-  passComunicador?: string;
-  idComunicador?: string;
-  apn?: string;
-  usr?: string;
-  pwd?: string;
-  ip?: string;
-  port?: string;
-}
+  modelo: z.string().optional(),
+  passComunicador: z.string().optional(),
+  idComunicador: z.string().optional(),
+  apn: z.string().optional(),
+  usr: z.string().optional(),
+  pwd: z.string().optional(),
+  ip: z.string().optional(),
+  port: z.string().optional(),
+});
+export type ConfigComunicadorNanocomm = z.infer<
+  typeof ConfigComunicadorNanocommSchema
+>;

--- a/src/interfaces/ubicacion.ts
+++ b/src/interfaces/ubicacion.ts
@@ -1,7 +1,7 @@
 import { z } from 'zod';
 import { GeoJSONSchema, IGeoJSON } from '../auxiliares';
 import { ClienteSchema, ICliente } from './cliente';
-import { TipoEmergenciaSchema } from './emergencias';
+import { TipoEmergenciaSchema, TipoEmergencia } from './emergencias';
 
 /* ────────────────────────────────────────────────
  *  CATEGORÍAS
@@ -39,34 +39,40 @@ export type ICategoriaUbicacion =
 
 //Por ahora estarán vacíos
 export const ValoresUbicacionTerminalSchema = z.object({});
-export type IValoresUbicacionTerminal = z.infer<
-  typeof ValoresUbicacionTerminalSchema
->;
+// Tipo hand-written (no z.infer): participa como valores de un miembro de la
+// union discriminada IUbicacion; z.infer rompe el narrowing por categoria en
+// consumidores (doc Mongoose → IUbicacion). Ver ICategoriaUbicacion.
+export interface IValoresUbicacionTerminal {}
 
 export const ValoresUbicacionDomicilioSchema = z.object({});
-export type IValoresUbicacionDomicilio = z.infer<
-  typeof ValoresUbicacionDomicilioSchema
->;
+// Tipo hand-written (no z.infer): participa como valores de un miembro de la
+// union discriminada IUbicacion; z.infer rompe el narrowing por categoria en
+// consumidores (doc Mongoose → IUbicacion). Ver ICategoriaUbicacion.
+export interface IValoresUbicacionDomicilio {}
 
 export const ValoresUbicacionActivosSchema = z.object({});
-export type IValoresUbicacionActivos = z.infer<
-  typeof ValoresUbicacionActivosSchema
->;
+// Tipo hand-written (no z.infer): participa como valores de un miembro de la
+// union discriminada IUbicacion; z.infer rompe el narrowing por categoria en
+// consumidores (doc Mongoose → IUbicacion). Ver ICategoriaUbicacion.
+export interface IValoresUbicacionActivos {}
 
 export const ValoresUbicacionDestinoEmergenciaSchema = z.object({});
-export type IValoresUbicacionDestinoEmergencia = z.infer<
-  typeof ValoresUbicacionDestinoEmergenciaSchema
->;
+// Tipo hand-written (no z.infer): participa como valores de un miembro de la
+// union discriminada IUbicacion; z.infer rompe el narrowing por categoria en
+// consumidores (doc Mongoose → IUbicacion). Ver ICategoriaUbicacion.
+export interface IValoresUbicacionDestinoEmergencia {}
 
 export const ValoresUbicacionVehiculosSchema = z.object({});
-export type IValoresUbicacionVehiculos = z.infer<
-  typeof ValoresUbicacionVehiculosSchema
->;
+// Tipo hand-written (no z.infer): participa como valores de un miembro de la
+// union discriminada IUbicacion; z.infer rompe el narrowing por categoria en
+// consumidores (doc Mongoose → IUbicacion). Ver ICategoriaUbicacion.
+export interface IValoresUbicacionVehiculos {}
 
 export const ValoresUbicacionLuminariasSchema = z.object({});
-export type IValoresUbicacionLuminarias = z.infer<
-  typeof ValoresUbicacionLuminariasSchema
->;
+// Tipo hand-written (no z.infer): participa como valores de un miembro de la
+// union discriminada IUbicacion; z.infer rompe el narrowing por categoria en
+// consumidores (doc Mongoose → IUbicacion). Ver ICategoriaUbicacion.
+export interface IValoresUbicacionLuminarias {}
 
 export const ValoresUbicacionCentroAtencionSchema = z.object({
   telefono: z.string().optional(),
@@ -76,9 +82,12 @@ export const ValoresUbicacionCentroAtencionSchema = z.object({
   tipoEmergencia: TipoEmergenciaSchema.optional(),
   activo: z.boolean().optional(),
 });
-export type IValoresUbicacionCentroAtencion = z.infer<
-  typeof ValoresUbicacionCentroAtencionSchema
->;
+export interface IValoresUbicacionCentroAtencion {
+  telefono?: string;
+  email?: string;
+  tipoEmergencia?: TipoEmergencia;
+  activo?: boolean;
+}
 
 export const ValoresUbicacionHospitalSchema = z.object({
   telefono: z.string().optional(),
@@ -86,9 +95,12 @@ export const ValoresUbicacionHospitalSchema = z.object({
   gestion: z.enum(['Público', 'Privado', 'Público-privado']).optional(),
   activo: z.boolean().optional(),
 });
-export type IValoresUbicacionHospital = z.infer<
-  typeof ValoresUbicacionHospitalSchema
->;
+export interface IValoresUbicacionHospital {
+  telefono?: string;
+  email?: string;
+  gestion?: 'Público' | 'Privado' | 'Público-privado';
+  activo?: boolean;
+}
 
 /* ────────────────────────────────────────────────
  *  MAPA CATEGORÍA → VALORES

--- a/src/interfaces/ubicacion.ts
+++ b/src/interfaces/ubicacion.ts
@@ -17,7 +17,21 @@ export const CategoriaUbicacionSchema = z.enum([
   'Vehiculos',
   'Luminarias',
 ]);
-export type ICategoriaUbicacion = z.infer<typeof CategoriaUbicacionSchema>;
+// Discriminante de la union IUbicacion: DEBE ser un type alias de literales
+// plano, NO z.infer<typeof CategoriaUbicacionSchema>. TS no reconoce el tipo
+// inferido de z.enum como discriminante válido para narrowear una
+// discriminatedUnion, y los consumidores que tipan un campo Mongoose con
+// ICategoriaUbicacion y lo asignan a IUbicacion (ej. api-datos ubicacion/
+// service.ts) fallan (TS2322). El schema runtime sigue siendo z.enum abajo.
+export type ICategoriaUbicacion =
+  | 'Terminal'
+  | 'Domicilio'
+  | 'Activos'
+  | 'Centro de Atención'
+  | 'Hospital'
+  | 'Destino Emergencia'
+  | 'Vehiculos'
+  | 'Luminarias';
 
 /* ────────────────────────────────────────────────
  *  VALORES POR CATEGORÍA

--- a/src/interfaces/ubicacion.ts
+++ b/src/interfaces/ubicacion.ts
@@ -1,51 +1,80 @@
-import { IGeoJSON } from '../auxiliares';
-import { ICliente } from './cliente';
-import { TipoEmergencia } from './emergencias';
+import { z } from 'zod';
+import { GeoJSONSchema, IGeoJSON } from '../auxiliares';
+import { ClienteSchema, ICliente } from './cliente';
+import { TipoEmergenciaSchema } from './emergencias';
 
 /* ────────────────────────────────────────────────
  *  CATEGORÍAS
  * ────────────────────────────────────────────────*/
 
-export type ICategoriaUbicacion =
-  | 'Terminal'
-  | 'Domicilio'
-  | 'Activos'
-  | 'Centro de Atención'
-  | 'Hospital'
-  | 'Destino Emergencia'
-  | 'Vehiculos'
-  | 'Luminarias';
+export const CategoriaUbicacionSchema = z.enum([
+  'Terminal',
+  'Domicilio',
+  'Activos',
+  'Centro de Atención',
+  'Hospital',
+  'Destino Emergencia',
+  'Vehiculos',
+  'Luminarias',
+]);
+export type ICategoriaUbicacion = z.infer<typeof CategoriaUbicacionSchema>;
 
 /* ────────────────────────────────────────────────
  *  VALORES POR CATEGORÍA
  * ────────────────────────────────────────────────*/
 
 //Por ahora estarán vacíos
-export interface IValoresUbicacionTerminal {}
+export const ValoresUbicacionTerminalSchema = z.object({});
+export type IValoresUbicacionTerminal = z.infer<
+  typeof ValoresUbicacionTerminalSchema
+>;
 
-export interface IValoresUbicacionDomicilio {}
+export const ValoresUbicacionDomicilioSchema = z.object({});
+export type IValoresUbicacionDomicilio = z.infer<
+  typeof ValoresUbicacionDomicilioSchema
+>;
 
-export interface IValoresUbicacionActivos {}
+export const ValoresUbicacionActivosSchema = z.object({});
+export type IValoresUbicacionActivos = z.infer<
+  typeof ValoresUbicacionActivosSchema
+>;
 
-export interface IValoresUbicacionDestinoEmergencia {}
+export const ValoresUbicacionDestinoEmergenciaSchema = z.object({});
+export type IValoresUbicacionDestinoEmergencia = z.infer<
+  typeof ValoresUbicacionDestinoEmergenciaSchema
+>;
 
-export interface IValoresUbicacionVehiculos {}
+export const ValoresUbicacionVehiculosSchema = z.object({});
+export type IValoresUbicacionVehiculos = z.infer<
+  typeof ValoresUbicacionVehiculosSchema
+>;
 
-export interface IValoresUbicacionLuminarias {}
+export const ValoresUbicacionLuminariasSchema = z.object({});
+export type IValoresUbicacionLuminarias = z.infer<
+  typeof ValoresUbicacionLuminariasSchema
+>;
 
-export interface IValoresUbicacionCentroAtencion {
-  telefono?: string;
-  email?: string;
-  tipoEmergencia?: TipoEmergencia;
-  activo?: boolean;
-}
+export const ValoresUbicacionCentroAtencionSchema = z.object({
+  telefono: z.string().optional(),
+  email: z.string().optional(),
+  // Referencia directa (ya no getter): emergencias no tiene imports de valor
+  // intra-SCC en V2, así que este import no forma ciclo runtime.
+  tipoEmergencia: TipoEmergenciaSchema.optional(),
+  activo: z.boolean().optional(),
+});
+export type IValoresUbicacionCentroAtencion = z.infer<
+  typeof ValoresUbicacionCentroAtencionSchema
+>;
 
-export interface IValoresUbicacionHospital {
-  telefono?: string;
-  email?: string;
-  gestion?: 'Público' | 'Privado' | 'Público-privado';
-  activo?: boolean;
-}
+export const ValoresUbicacionHospitalSchema = z.object({
+  telefono: z.string().optional(),
+  email: z.string().optional(),
+  gestion: z.enum(['Público', 'Privado', 'Público-privado']).optional(),
+  activo: z.boolean().optional(),
+});
+export type IValoresUbicacionHospital = z.infer<
+  typeof ValoresUbicacionHospitalSchema
+>;
 
 /* ────────────────────────────────────────────────
  *  MAPA CATEGORÍA → VALORES
@@ -84,10 +113,75 @@ export interface IUbicacionBase<T extends keyof MapaValoresUbicacion> {
   ancestros?: ICliente[];
 }
 
+// Campos comunes a todas las variantes (sin categoria/valores, que discriminan)
+const UbicacionCamposSchema = z.object({
+  _id: z.string().optional(),
+  //
+  idCliente: z.string().optional(),
+  idsAncestros: z.array(z.string()).optional(),
+  identificacion: z.string().optional(),
+  fechaCreacion: z.string().optional(),
+  direccion: z.string().optional(),
+  geojson: GeoJSONSchema.optional(),
+  fotos: z.array(z.string()).optional(),
+  color: z.string().optional(),
+  // Virtuals
+  cliente: ClienteSchema.optional(),
+  ancestros: z.array(ClienteSchema).optional(),
+});
+
+const VarianteUbicacionTerminal = UbicacionCamposSchema.extend({
+  categoria: z.literal('Terminal').optional(),
+  valores: ValoresUbicacionTerminalSchema.optional(),
+});
+const VarianteUbicacionDomicilio = UbicacionCamposSchema.extend({
+  categoria: z.literal('Domicilio').optional(),
+  valores: ValoresUbicacionDomicilioSchema.optional(),
+});
+const VarianteUbicacionActivos = UbicacionCamposSchema.extend({
+  categoria: z.literal('Activos').optional(),
+  valores: ValoresUbicacionActivosSchema.optional(),
+});
+const VarianteUbicacionCentroAtencion = UbicacionCamposSchema.extend({
+  categoria: z.literal('Centro de Atención').optional(),
+  valores: ValoresUbicacionCentroAtencionSchema.optional(),
+});
+const VarianteUbicacionHospital = UbicacionCamposSchema.extend({
+  categoria: z.literal('Hospital').optional(),
+  valores: ValoresUbicacionHospitalSchema.optional(),
+});
+const VarianteUbicacionDestinoEmergencia = UbicacionCamposSchema.extend({
+  categoria: z.literal('Destino Emergencia').optional(),
+  valores: ValoresUbicacionDestinoEmergenciaSchema.optional(),
+});
+const VarianteUbicacionVehiculos = UbicacionCamposSchema.extend({
+  categoria: z.literal('Vehiculos').optional(),
+  valores: ValoresUbicacionVehiculosSchema.optional(),
+});
+const VarianteUbicacionLuminarias = UbicacionCamposSchema.extend({
+  categoria: z.literal('Luminarias').optional(),
+  valores: ValoresUbicacionLuminariasSchema.optional(),
+});
+
 /* ────────────────────────────────────────────────
  *  TIPO DISCRIMINADO - READ
  * ────────────────────────────────────────────────*/
 
+export const UbicacionSchema = z.union([
+  VarianteUbicacionTerminal,
+  VarianteUbicacionDomicilio,
+  VarianteUbicacionActivos,
+  VarianteUbicacionCentroAtencion,
+  VarianteUbicacionHospital,
+  VarianteUbicacionDestinoEmergencia,
+  VarianteUbicacionVehiculos,
+  VarianteUbicacionLuminarias,
+]);
+
+/**
+ * Tipo hand-written (misma forma que el schema): los tipos de entidad del
+ * SCC no usan z.infer porque los ciclos de aliases mutuos disparan TS2589.
+ */
 export type IUbicacion =
   | IUbicacionBase<'Terminal'>
   | IUbicacionBase<'Domicilio'>
@@ -102,6 +196,23 @@ export type IUbicacion =
  *  CREATE / UPDATE
  * ────────────────────────────────────────────────*/
 
+const camposOmitidos: { _id: true; cliente: true; ancestros: true } = {
+  _id: true,
+  cliente: true,
+  ancestros: true,
+};
+
+export const CreateUbicacionSchema = z.union([
+  VarianteUbicacionTerminal.omit(camposOmitidos),
+  VarianteUbicacionDomicilio.omit(camposOmitidos),
+  VarianteUbicacionActivos.omit(camposOmitidos),
+  VarianteUbicacionCentroAtencion.omit(camposOmitidos),
+  VarianteUbicacionHospital.omit(camposOmitidos),
+  VarianteUbicacionDestinoEmergencia.omit(camposOmitidos),
+  VarianteUbicacionVehiculos.omit(camposOmitidos),
+  VarianteUbicacionLuminarias.omit(camposOmitidos),
+]);
+
 type Omitir = '_id' | 'cliente' | 'ancestros';
 
 export type ICreateUbicacion =
@@ -113,6 +224,23 @@ export type ICreateUbicacion =
   | Omit<IUbicacionBase<'Destino Emergencia'>, Omitir>
   | Omit<IUbicacionBase<'Vehiculos'>, Omitir>
   | Omit<IUbicacionBase<'Luminarias'>, Omitir>;
+
+export const UpdateUbicacionSchema = z.union([
+  VarianteUbicacionTerminal.omit(camposOmitidos).required({ categoria: true }),
+  VarianteUbicacionDomicilio.omit(camposOmitidos).required({ categoria: true }),
+  VarianteUbicacionActivos.omit(camposOmitidos).required({ categoria: true }),
+  VarianteUbicacionCentroAtencion.omit(camposOmitidos).required({
+    categoria: true,
+  }),
+  VarianteUbicacionHospital.omit(camposOmitidos).required({ categoria: true }),
+  VarianteUbicacionDestinoEmergencia.omit(camposOmitidos).required({
+    categoria: true,
+  }),
+  VarianteUbicacionVehiculos.omit(camposOmitidos).required({ categoria: true }),
+  VarianteUbicacionLuminarias.omit(camposOmitidos).required({
+    categoria: true,
+  }),
+]);
 
 export type IUpdateUbicacion =
   | ({ categoria: 'Terminal' } & Partial<
@@ -139,8 +267,25 @@ export type IUpdateUbicacion =
   | ({ categoria: 'Luminarias' } & Partial<
       Omit<IUbicacionBase<'Luminarias'>, Omitir | 'categoria'>
     >);
+
 /* ────────────────────────────────────────────────
  *  CACHE (sin virtuals)
  * ────────────────────────────────────────────────*/
+
+const camposOmitidosCache: { cliente: true; ancestros: true } = {
+  cliente: true,
+  ancestros: true,
+};
+
+export const UbicacionCacheSchema = z.union([
+  VarianteUbicacionTerminal.omit(camposOmitidosCache),
+  VarianteUbicacionDomicilio.omit(camposOmitidosCache),
+  VarianteUbicacionActivos.omit(camposOmitidosCache),
+  VarianteUbicacionCentroAtencion.omit(camposOmitidosCache),
+  VarianteUbicacionHospital.omit(camposOmitidosCache),
+  VarianteUbicacionDestinoEmergencia.omit(camposOmitidosCache),
+  VarianteUbicacionVehiculos.omit(camposOmitidosCache),
+  VarianteUbicacionLuminarias.omit(camposOmitidosCache),
+]);
 
 export type IUbicacionCache = Omit<IUbicacion, 'cliente' | 'ancestros'>;

--- a/src/interfaces/usuario.ts
+++ b/src/interfaces/usuario.ts
@@ -1,62 +1,111 @@
-import { ICliente } from './cliente';
-import { IPermiso } from './permiso';
+import { z } from 'zod';
+import { ClienteSchema, ICliente } from './cliente';
+import type { IPermiso } from './permiso';
 
-export type Rol =
-  | 'Administrador'
-  | 'Operador'
-  | 'Conductor'
-  | 'Chofer Colectivo'
-  | 'Consultor'
-  | 'Técnico'
-  | 'Final'
-  | 'Administrador Emergencias' //Puede crear/editar emergencias, hospitales, choferes, solicitantes, centros de atención, destinatarios asistencia, personal de salud.
+// Nota: no se llama RolSchema porque rol.ts ya exporta ese nombre (para el
+// type IRol) y el barrel `export *` daría TS2308.
+export const RolUsuarioSchema = z.enum([
+  'Administrador',
+  'Operador',
+  'Conductor',
+  'Chofer Colectivo',
+  'Consultor',
+  'Técnico',
+  'Final',
+  'Administrador Emergencias', //Puede crear/editar emergencias, hospitales, choferes, solicitantes, centros de atención, destinatarios asistencia, personal de salud.
   // Puede ver todas las solapas del módulo de emergencias.
-  | 'Registrador Emergencias' //Puede crear/editar emergencias y solicitantes
+  'Registrador Emergencias', //Puede crear/editar emergencias y solicitantes
   //Puede ver todas las solapas del módulo emergencias, menos el dashboard con estadísticas
-  | 'Móvil Emergencias'; //Usuario de la aplicación móvil, puede editar los eventos de emergencias (seguimiento)
-//Puede ver todo lo que está en el módulo de emergencias de la aplicación móvil.
+  'Móvil Emergencias', //Usuario de la aplicación móvil, puede editar los eventos de emergencias (seguimiento)
+  //Puede ver todo lo que está en el módulo de emergencias de la aplicación móvil.
+]);
+export type Rol = z.infer<typeof RolUsuarioSchema>;
 
-export interface IModulos {
-  moduloColectivos?: boolean;
-  moduloAlarmasDomiciliarias?: boolean;
-  moduloCamaras?: boolean;
-  moduloLuminarias?: boolean;
-  moduloEmergenciasMedicas?: boolean;
-  moduloEmergenciasBomberos?: boolean;
-  moduloActivos?: boolean;
-  moduloAdministracion?: boolean;
-  moduloEventosTecnicos?: boolean;
-  moduloVehiculos?: boolean;
-  moduloLogs?: boolean;
-  moduloIntegraciones?: boolean;
-  moduloSirenas?: boolean;
-  moduloAlertasSeguridad?: boolean;
-}
+export const ModulosSchema = z.object({
+  moduloColectivos: z.boolean().optional(),
+  moduloAlarmasDomiciliarias: z.boolean().optional(),
+  moduloCamaras: z.boolean().optional(),
+  moduloLuminarias: z.boolean().optional(),
+  moduloEmergenciasMedicas: z.boolean().optional(),
+  moduloEmergenciasBomberos: z.boolean().optional(),
+  moduloActivos: z.boolean().optional(),
+  moduloAdministracion: z.boolean().optional(),
+  moduloEventosTecnicos: z.boolean().optional(),
+  moduloVehiculos: z.boolean().optional(),
+  moduloLogs: z.boolean().optional(),
+  moduloIntegraciones: z.boolean().optional(),
+  moduloSirenas: z.boolean().optional(),
+  moduloAlertasSeguridad: z.boolean().optional(),
+});
+export type IModulos = z.infer<typeof ModulosSchema>;
 
-export interface IDatosPersonales {
-  nombre?: string;
-  dni?: string;
-  sexo?: boolean;
-  email?: string;
-  direccion?: string;
-  pais?: string;
-  telefono?: string;
-  fechaNacimiento?: string;
-  foto?: string;
-}
+export const DatosPersonalesSchema = z.object({
+  nombre: z.string().optional(),
+  dni: z.string().optional(),
+  sexo: z.boolean().optional(),
+  email: z.string().optional(),
+  direccion: z.string().optional(),
+  pais: z.string().optional(),
+  telefono: z.string().optional(),
+  fechaNacimiento: z.string().optional(),
+  foto: z.string().optional(),
+});
+export type IDatosPersonales = z.infer<typeof DatosPersonalesSchema>;
 
-export interface IConfigUsuario {
-  notasEnPrimerPlano?: boolean;
-  cantMapasVehiculos?: number;
-  noMostrarGuardarClaveAlarma?: boolean;
-  clavesAlarma?: IClaveUsuarioAlarma[];
-}
+export const ClaveUsuarioAlarmaSchema = z.object({
+  idAlarma: z.string().optional(),
+  clave: z.string().optional(),
+});
+export type IClaveUsuarioAlarma = z.infer<typeof ClaveUsuarioAlarmaSchema>;
 
-export interface IClaveUsuarioAlarma {
-  idAlarma?: string;
-  clave?: string;
-}
+export const ConfigUsuarioSchema = z.object({
+  notasEnPrimerPlano: z.boolean().optional(),
+  cantMapasVehiculos: z.number().optional(),
+  noMostrarGuardarClaveAlarma: z.boolean().optional(),
+  clavesAlarma: z.array(ClaveUsuarioAlarmaSchema).optional(),
+});
+export type IConfigUsuario = z.infer<typeof ConfigUsuarioSchema>;
 
+// Populates intra-SCC como z.custom (import type-only): un schema real acá
+// arrastra el shape completo del ciclo y revienta la serialización de
+// declarations (TS7056) acá y en los consumidores NestJS.
+export const UsuarioSchema = z.object({
+  _id: z.string().optional(),
+  identificacionInterna: z.string().optional(),
+  /**
+   * @deprecated El cliente del usuario se resuelve por su Permiso
+   * (Permiso.nombreUsuario === Usuario.usuario → Permiso.idCliente), no por este
+   * campo. No usar para agrupar/scopear por cliente: los auto-registrados lo
+   * tienen vacío.
+   */
+  idCliente: z.string().optional(),
+  /** @deprecated Deriva de {@link idCliente} (deprecado). Usar el permiso. */
+  idsAncestros: z.array(z.string()).optional(),
+  //
+  idExterno: z.string().optional(),
+  fechaCreacion: z.string().optional(),
+  usuario: z.string().optional(),
+  hash: z.string().optional(),
+  datosPersonales: DatosPersonalesSchema.optional(),
+  config: ConfigUsuarioSchema.optional(),
+  // Estadísticas de uso (actividad). Se actualizan en cada login exitoso
+  // (grant password o Google / auto-registro), NO en los refresh de token.
+  // Detalle temporal (DAU/WAU/MAU, series) vive en la colección LoginEvento.
+  ultimoLogin: z.string().optional(),
+  primerLogin: z.string().optional(),
+  cantidadLogins: z.number().optional(),
+  // Populate / Virtual
+  cliente: ClienteSchema.optional(),
+  ancestros: z.array(ClienteSchema).optional(),
+  // Permisos del usuario. Ya no es un array embebido: es un virtual poblado
+  // desde la colección Permiso por match de nombreUsuario (Permiso.nombreUsuario === Usuario.usuario).
+  permisos: z.array(z.custom<IPermiso>()).optional(),
+});
+
+/**
+ * Interface hand-written (misma forma que el schema): los tipos de entidad del
+ * SCC no usan z.infer para no arrastrar el ciclo en el declaration emit.
+ */
 export interface IUsuario {
   _id?: string;
   identificacionInterna?: string;
@@ -96,8 +145,24 @@ type CamposStats = 'ultimoLogin' | 'primerLogin' | 'cantidadLogins';
 
 type OmitirCreate = '_id' | 'cliente' | 'fechaCreacion' | CamposStats;
 
+export const CreateUsuarioSchema = UsuarioSchema.omit({
+  _id: true,
+  cliente: true,
+  fechaCreacion: true,
+  ultimoLogin: true,
+  primerLogin: true,
+  cantidadLogins: true,
+});
 export interface ICreateUsuario extends Omit<Partial<IUsuario>, OmitirCreate> {}
 
 type OmitirUpdate = '_id' | 'cliente' | 'fechaCreacion' | CamposStats;
 
+export const UpdateUsuarioSchema = UsuarioSchema.omit({
+  _id: true,
+  cliente: true,
+  fechaCreacion: true,
+  ultimoLogin: true,
+  primerLogin: true,
+  cantidadLogins: true,
+});
 export interface IUpdateUsuario extends Omit<Partial<IUsuario>, OmitirUpdate> {}

--- a/src/interfaces/visita-ubicacion.ts
+++ b/src/interfaces/visita-ubicacion.ts
@@ -1,35 +1,48 @@
-export type RolEnVisita = 'arribo' | 'partida' | 'contiene' | 'durante';
+import { z } from 'zod';
 
-export interface IVisitaTrip {
-  tripId?: string;
-  startTime?: string;
-  endTime?: string;
-  distance?: number;
-  duration?: number;
-  maxSpeed?: number;
-  avgSpeed?: number;
-  startLat?: number;
-  startLon?: number;
-  endLat?: number;
-  endLon?: number;
-  rolEnVisita?: RolEnVisita;
-}
+export const RolEnVisitaSchema = z.enum([
+  'arribo',
+  'partida',
+  'contiene',
+  'durante',
+]);
+export type RolEnVisita = z.infer<typeof RolEnVisitaSchema>;
 
-export interface IVisitaUbicacion {
-  entrada?: string;
-  salida?: string;
-  permanenciaSegundos?: number;
-  cantidadReportes?: number;
-  yaEstabaAlInicio?: boolean;
-  seguiaAlFinal?: boolean;
-  entradaCoords?: [number, number];
-  salidaCoords?: [number, number];
-  trips?: IVisitaTrip[];
-}
+export const VisitaTripSchema = z.object({
+  tripId: z.string().optional(),
+  startTime: z.string().optional(),
+  endTime: z.string().optional(),
+  distance: z.number().optional(),
+  duration: z.number().optional(),
+  maxSpeed: z.number().optional(),
+  avgSpeed: z.number().optional(),
+  startLat: z.number().optional(),
+  startLon: z.number().optional(),
+  endLat: z.number().optional(),
+  endLon: z.number().optional(),
+  rolEnVisita: RolEnVisitaSchema.optional(),
+});
+export type IVisitaTrip = z.infer<typeof VisitaTripSchema>;
 
-export interface IQueryVisitasUbicacion {
-  idVehiculo?: string;
-  from?: string;
-  to?: string;
-  gapMin?: number;
-}
+export const VisitaUbicacionSchema = z.object({
+  entrada: z.string().optional(),
+  salida: z.string().optional(),
+  permanenciaSegundos: z.number().optional(),
+  cantidadReportes: z.number().optional(),
+  yaEstabaAlInicio: z.boolean().optional(),
+  seguiaAlFinal: z.boolean().optional(),
+  entradaCoords: z.tuple([z.number(), z.number()]).optional(),
+  salidaCoords: z.tuple([z.number(), z.number()]).optional(),
+  trips: z.array(VisitaTripSchema).optional(),
+});
+export type IVisitaUbicacion = z.infer<typeof VisitaUbicacionSchema>;
+
+export const QueryVisitasUbicacionSchema = z.object({
+  idVehiculo: z.string().optional(),
+  from: z.string().optional(),
+  to: z.string().optional(),
+  gapMin: z.number().optional(),
+});
+export type IQueryVisitasUbicacion = z.infer<
+  typeof QueryVisitasUbicacionSchema
+>;

--- a/src/interfaces/visita-ubicacion.ts
+++ b/src/interfaces/visita-ubicacion.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod';
+import { PuntoCoord } from '../auxiliares/geojson';
 
 export const RolEnVisitaSchema = z.enum([
   'arribo',
@@ -31,8 +32,8 @@ export const VisitaUbicacionSchema = z.object({
   cantidadReportes: z.number().optional(),
   yaEstabaAlInicio: z.boolean().optional(),
   seguiaAlFinal: z.boolean().optional(),
-  entradaCoords: z.tuple([z.number(), z.number()]).optional(),
-  salidaCoords: z.tuple([z.number(), z.number()]).optional(),
+  entradaCoords: PuntoCoord.optional(),
+  salidaCoords: PuntoCoord.optional(),
   trips: z.array(VisitaTripSchema).optional(),
 });
 export type IVisitaUbicacion = z.infer<typeof VisitaUbicacionSchema>;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,8 +1,20 @@
 {
   "compilerOptions": {
-    "outDir": "./dist"
+    "target": "ES2020",
+    "module": "Node16",
+    "lib": ["ES2020"],
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "moduleResolution": "node16"
   },
-  "files": [
-    "src/index.ts"
-  ]
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
 }


### PR DESCRIPTION
## Qué

Migra `gestion-modelos` de un paquete solo-tipos a **schemas Zod v4** de los que se infieren los tipos, siguiendo el patrón de `acceso-modelos`. Los nombres de tipos exportados se conservan idénticos (`IActivo`, `ICreateActivo`, `TipoVehiculo`…); los `*Schema` son exports **aditivos**.

Aporta: validación runtime (`safeParse`), enums iterables en runtime (`z.enum().options`) y generación de OpenAPI/JSON Schema con `z.toJSONSchema` nativo (`npm run gen:json-schema`).

## Compatibilidad

- El import `from 'modelos/src'` sigue funcionando: `files` incluye `src`; los consumidores compilan la fuente igual que antes.
- El paquete ahora se compila (hook `prepare` → `tsc`) y agrega `zod` como dependencia.
- Todos los nombres de tipos previos siguen existiendo (verificado con diff de exports contra `main`).

## Decisiones y gotchas (documentadas en el código)

- **SCC de 19 archivos cíclicos**: populates intra-ciclo como `z.custom<IInterface>()` con `import type`; los tipos de entidad del ciclo quedan como interfaces hand-written. Evita TS7056 en la emisión de declarations (que rompería también a los consumidores NestJS con `declaration: true`).
- **Uniones discriminadas** (`IUbicacion`, reporte/evento genérico): el discriminante debe ser type alias de literales plano (no `z.infer<z.enum>`), los `valores` de cada variante interfaces hand-written, y los populates hacia ellas `z.custom<ITipo>`. Sin esto, la asignación `doc Mongoose → tipo` falla en los consumidores.
- **Tuplas sin strict**: `z.infer` de `z.tuple` se degrada con `strictNullChecks: false` (como compilan los consumidores) → los tipos geojson quedan hand-written.
- Fix del typo `'comunicador '` en `CreateDispositivoAlarmaSchema` (ahora sí omite `comunicador`; el tipo legacy conserva el comportamiento).

## Verificación

- `tsc` (strict + declarations), smoke runtime (654 schemas `safeParse` OK), `gen:json-schema` (654 schemas, 0 errores).
- **End-to-end**: compilan con 0 errores contra esta rama `gestion-api-datos` (`nest build` completo), `gestion-api-gestion` y los 6 consumidores deployados en novit (notificaciones, trackeo-colectivos, dispositivos-lora, qualcomm-aware, twilio-api, websocket-traccar).

## Antes de mergear

Ver `CONSUMIDORES.md`: el hook `prepare` corre en el `npm install` de todos los consumidores. Lista relevada de novit (prod/test) + fricciones de adopción.

🤖 Generated with [Claude Code](https://claude.com/claude-code)