### PR TITLE
feat: zonaHoraria opcional en la config del cliente

### DIFF
--- a/src/interfaces/cliente.ts
+++ b/src/interfaces/cliente.ts
@@ -313,6 +313,13 @@ export const ConfigClienteSchema = z.object({
   idsClientesQuePuedenAtenderEventos: z.array(z.string()).optional(),
   idsClientesQuePuedenAtenderEventosTecnicos: z.array(z.string()).optional(),
   configHorarioAtencion: ConfigHorarioSchema.optional(),
+  /** Zona horaria del cliente como nombre IANA (ej. 'America/Argentina/Buenos_Aires',
+   *  'America/Montevideo', 'America/Mexico_City'). También se acepta un offset
+   *  numérico en horas ('-3', '-6') para casos sin nombre.
+   *
+   *  Hoy la usan las fechas de los Excel de exportación (gestion-datos-go).
+   *  Ausente = default del backend, UTC-3 (Argentina). */
+  zonaHoraria: z.string().optional(),
   /** Si es true, los operadores de este cliente pueden sumarse a atender
    *  eventos que ya están siendo atendidos por otro operador.
    *  Default false: solo un operador atiende a la vez (lock). */


### PR DESCRIPTION
## Qué

Campo opcional `config.zonaHoraria` en `ClienteSchema`: nombre IANA (`America/Argentina/Buenos_Aires`, `America/Montevideo`, `America/Mexico_City`) o offset numérico en horas (`-3`, `-6`) para casos sin nombre.

## Por qué

Las fechas de los Excel de exportación tienen **UTC-3 hardcodeado**, heredado del legacy NestJS (`getDateTime` en gestion-datos-go). Estaba anotado como pendiente post-cutover en `docs/MIGRACION.md` del repo de datos: "arreglarlo" es una feature, no un fix, porque hace falta saber el huso de cada cliente.

Hoy todos los clientes son de Argentina, pero hay pruebas pendientes en Uruguay y México (que además no comparten offset: -3 vs -6).

## Compatibilidad

Aditivo y opcional: ningún consumidor se rompe. Entra por el `UpdateClienteSchema` que ya existe, así que es seteable sin endpoint nuevo. Ausente = default del backend, UTC-3, que es lo que ven todos los clientes actuales.

## Consumidor

`gestion-datos-go`: bump de `modelos.lock` + resolución del huso por export (un TZ por workbook, el del cliente objetivo) con fallback a `EXPORT_TZ` y de ahí a -3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)