### PR TITLE
feat: un solo z.toJSONSchema sobre un registry — bundle 12,8 MB → 0,99 MB

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,166 @@
+# CLAUDE.md — reglas para trabajar en gestion-modelos
+
+Este repo es la fuente de verdad del modelo de datos de todo el sistema. Un
+error acá no rompe un servicio: rompe **el `npm install` de todos**.
+
+Leer el `README.md` para el uso normal. Este archivo es lo que **no** hay que
+hacer, con el motivo y el daño concreto de cada cosa.
+
+---
+
+## 1. El radio de daño, para dimensionar
+
+`package.json` tiene `"prepare": "npm run build"` (que es `tsc`). Ese hook corre
+en el `npm install` / `npm ci` de **cada consumidor**, porque el paquete se
+consume como git-dependency y `dist/` está en `.gitignore`.
+
+**Si `tsc` falla acá, el `npm install` de todos los consumidores falla.** No es
+un error de tipos en un servicio: es que ningún servicio puede instalar
+dependencias, y ninguna imagen puede buildearse.
+
+Consumidores conocidos: 14 repos locales listados en `CONSUMIDORES.md`, más
+~10 servicios deployados sin repo clonado (también listados ahí). Angular
+(`gestion-web-cliente`, `gestion-irix-web`) y NestJS mezclados.
+
+**Regla dura: nunca mergear a `main` sin `npm run build` verde acá Y el build
+de al menos un consumidor NestJS y uno Angular.** El README §"Pasaje a
+producción" tiene el procedimiento.
+
+Lo que sí da aire: los consumidores están clavados a un commit fijo en su
+`package-lock.json` y usan `npm ci`. Mergear a `main` no cambia prod por sí
+solo — el daño llega cuando alguien refresca su lock.
+
+---
+
+## 2. Los `z.custom` y los getters NO son un error a arreglar
+
+Es la trampa número uno, y la que más veces estuvo por romper el repo. Un dev
+o un agente bien intencionado ve esto en `src/interfaces/activo.ts`:
+
+```typescript
+tracker: z.custom<ITracker>().optional(),
+```
+
+...y piensa "esto debería ser `TrackerSchema.optional()`, lo arreglo".
+
+**No.** El comentario del propio archivo dice por qué:
+
+> Populates intra-SCC como `z.custom` (import type-only): un schema real acá
+> arrastra el shape completo del ciclo y revienta la serialización de
+> declarations (**TS7056**) acá y en los consumidores NestJS.
+
+Los populates entre entidades forman ciclos (activo → tracker → activo). Un
+schema real en esa posición hace explotar el emisor de declaraciones de
+TypeScript, acá y en cada consumidor. Hay **116 `z.custom`** en el repo y
+ninguno es un descuido.
+
+La variante permitida para ciclos es el **getter**, y tiene su propia trampa:
+
+```typescript
+get tracker() {
+  return TrackerSchema.optional();
+},
+```
+
+**Nunca spreadear un objeto que contenga getters** (`{...Base}`): los evalúa
+eager y rompe el ciclo en runtime, no en compilación. O sea que el build pasa y
+explota en producción.
+
+> Hay trabajo planificado para reducir los `z.custom` (ver §5), pero se hace de
+> a poco y midiendo, no de un saque.
+
+---
+
+## 3. Un cambio de schema es un cambio de contrato
+
+Estos schemas describen datos que ya están en Mongo y que consumen 24+
+servicios. Antes de tocar un campo:
+
+- **Renombrar o borrar un campo** rompe a todo el que lo lea, y los datos
+  viejos siguen teniendo el nombre anterior. Agregar opcional es seguro;
+  renombrar no lo es.
+- **Los ids y las fechas son `z.string()` plano** a propósito (ISO string).
+  No "mejorarlos" a `z.date()` ni a un branded type: son strings en la DB y en
+  el JSON de todas las APIs.
+- **Modo strip por defecto**: `z.object()` descarta claves desconocidas al
+  parsear, para interoperar con el strict mode de Mongoose. No cambiar eso
+  globalmente; si un endpoint necesita conservar extras, `Schema.loose()`
+  **local**.
+- No usar `z.nativeEnum` ni los deprecados `.passthrough()` / `.strict()` /
+  `.strip()`.
+
+---
+
+## 4. `scripts/gen-json-schema.mjs`: qué no deshacer
+
+El script emite `dist/json-schema/index.json`, el bundle neutro que consumen
+los generadores de otros lenguajes. Se reescribió el 2026-08-04 y tiene
+decisiones que parecen raras y no lo son:
+
+- **Una sola llamada a `z.toJSONSchema` sobre un registry.** No volver a
+  llamarla por schema dentro de un `for`: cada llamada inlinea el grafo
+  completo. Así estaba antes, y el bundle pesaba **12,8 MB con `ClienteSchema`
+  duplicado 181 veces**. Hoy pesa 0,99 MB.
+- **No reponer el flag `--only`.** Un subconjunto de un bundle con `$ref`
+  compartidos no resuelve: los schemas referenciados que quedan afuera caen en
+  el bucket `__shared` de Zod y los refs quedan colgando. Para inspeccionar uno
+  suelto, generar el bundle completo y buscar su clave en `$defs`.
+- **No volver a emitir un `<name>.json` por schema.** Con `$defs` compartidos
+  quedarían con refs colgantes, y no los leía nadie.
+- **La invariante NO es igualdad de cardinales.** El bundle puede traer más
+  claves que schemas registrados, porque Zod hoistea sub-schemas repetidos a
+  `__shared`. La verificación correcta —la que está— es "todos los registrados
+  están presentes".
+- **Validar antes de escribir.** El script limpia el directorio de salida
+  recién después de que pasan las invariantes, para que un fallo no deje al
+  repo sin el bundle anterior.
+- `unrepresentable: "any"` tiene que quedar: sin eso los `z.custom` de §2 hacen
+  fallar la generación entera.
+
+El script falla la generación si algo de esto se rompe. **Ese `process.exit(1)`
+es la única red que hay: este repo no tiene suite de tests ni CI.** Si lo
+volvés warning, no queda nada.
+
+---
+
+## 5. Hacia dónde va esto
+
+El bundle JSON Schema dejó de ser solo un artefacto de TypeScript: es el puente
+para que las APIs Go (y eventualmente Rust) consuman los mismos modelos. El
+diseño está en `gestion-datos-go`, en
+`docs/superpowers/specs/2026-08-04-aprovechar-go-roadmap-design.md`.
+
+Lo que viene y conviene no contradecir:
+
+- `gestion-modelos` va a publicar un **módulo Go** (`go/esquema` con el bundle
+  embebido y las tablas de metadata, `go/modelos` con structs). La generación
+  ocurre **acá**, una sola vez; los consumidores hacen `go get`. Si alguna vez
+  ves un `generate.sh` que clona este repo dentro de una API, es la deuda que
+  estamos pagando — no el patrón a copiar.
+- Los schemas van a ganar metadata de persistencia vía `.meta({ bson:
+  'objectId' })`. Es **aditiva**: los consumidores TS ignoran las claves
+  desconocidas.
+- Reducir los 329 `{}` que dejan los `z.custom` (3,5 % de las propiedades) es
+  trabajo en curso, de a poco y midiendo. No es una limpieza para hacer de un
+  saque.
+
+**El límite del repo, para que no se vuelva un depósito**: acá va la forma del
+dato y su persistencia, no el comportamiento de cada API. **Si dos APIs pueden
+discrepar legítimamente sobre algo, ese algo no va acá.** Que `idCliente` sea
+ObjectId es cierto para todas y va; que un endpoint devuelva `null` en vez de
+404 es decisión de ese servicio.
+
+---
+
+## 6. Higiene
+
+- **No editar `dist/`**: es generado y está gitignored. Si no existe,
+  `npm run build`.
+- **Agregar o actualizar dependencias npm** requiere chequeo de
+  supply-chain, y **nunca usar una versión publicada hace menos de 7 días**
+  (regla de la organización). Este repo tiene una sola dependencia de runtime
+  (`zod`) a propósito: pensarlo dos veces antes de sumar la segunda.
+- Al empezar una sesión de trabajo, partir de `main` actualizado (`git pull`),
+  cuidando de no pisar trabajo en curso.
+- Los schemas viven en `src/interfaces/` (83 archivos), uno por entidad, más
+  `src/auxiliares/` y `src/externos/`.

--- a/README.md
+++ b/README.md
@@ -85,11 +85,19 @@ TipoVehiculoSchema.options; // ['Auto', 'Camion', ...]
 
 ```bash
 npm run build
-npm run gen:json-schema            # dist/json-schema/<Name>.json + index.json
-npm run gen:json-schema -- --only=Activo --verbose
+npm run gen:json-schema            # dist/json-schema/index.json
+npm run gen:json-schema -- --verbose
 ```
 
-Usa `z.toJSONSchema(schema, { target: 'openapi-3.0' })` nativo de Zod v4, sin librerías extra. Para Swagger en las APIs NestJS se puede usar `nestjs-zod` (`createZodDto(CreateActivoSchema)`).
+Usa `z.toJSONSchema(registry)` nativo de Zod v4, sin librerías extra: **todos los schemas exportados se registran y se emiten en UNA sola llamada**, así cada uno aparece una vez en `$defs` y el resto lo referencia con `$ref`.
+
+Antes se llamaba `z.toJSONSchema` una vez por schema, y como cada llamada inlinea su grafo completo el bundle pesaba 12,8 MB con `ClienteSchema` duplicado 181 veces. Hoy son **0,99 MB y 3 apariciones** (las 3 legítimas: `Cliente`/`CreateCliente`/`UpdateCliente`). Los schemas de `src/` no cambiaron, así que los tipos TS inferidos tampoco.
+
+El script verifica sus propias invariantes y **falla la generación** si algún schema registrado no llegó al bundle o si queda algún `$ref` colgante. La salida reporta cuántas propiedades quedan como `{}` por los `z.custom` (los cortes de ciclo que existen por TS7056): hoy **329 de 9.295, un 3,5 %**.
+
+No hay flag para generar un bundle parcial: un subconjunto con `$ref` compartidos no resuelve. Para inspeccionar un schema suelto, generar el bundle completo y buscar su clave en `$defs`.
+
+Para Swagger en las APIs NestJS se puede usar `nestjs-zod` (`createZodDto(CreateActivoSchema)`).
 
 ## Pasaje a producción (migración Zod)
 

--- a/scripts/gen-json-schema.mjs
+++ b/scripts/gen-json-schema.mjs
@@ -1,22 +1,38 @@
 // Generador JSON Schema desde schemas Zod.
 //
-// Itera todos los *Schema exportados por dist/index.js (Zod v4),
-// corre z.toJSONSchema con target openapi-3.0 y escribe:
-//   - dist/json-schema/<name>.json   (un archivo por schema)
-//   - dist/json-schema/index.json    (bundle único con todos los $defs)
+// Registra todos los *Schema exportados por dist/index.js en un registry de
+// Zod v4 y hace UNA sola llamada a z.toJSONSchema sobre el registry. Escribe:
+//   - dist/json-schema/index.json   (bundle único con $defs + $ref compartidos)
 //
-// Zod es el single source of truth: los tipos TS se infieren de los
-// schemas y el OpenAPI de las APIs puede referenciar estos JSON Schemas.
+// POR QUÉ UN REGISTRY Y UNA SOLA LLAMADA (cambio 2026-08-04): antes se llamaba
+// z.toJSONSchema una vez POR SCHEMA, y cada llamada inlinea su grafo completo.
+// Resultado: ClienteSchema aparecía inlineado 181 veces y el bundle pesaba
+// 3,84 MB. Con el registry cada schema se emite una vez en $defs y el resto lo
+// referencia con $ref: 0,52 MB, 7,4x menos. Esto NO toca src/ — los schemas y
+// los tipos TS inferidos quedan exactamente igual.
+//
+// Zod es el single source of truth: los tipos TS se infieren de los schemas y
+// este bundle es la forma neutra que consumen los generadores de otros
+// lenguajes (roadmap en gestion-datos-go, spec 2026-08-04).
+//
+// Se dejaron de emitir los dist/json-schema/<name>.json por archivo: no los
+// leía nadie, y con $defs compartidos quedarían con $ref colgantes.
 //
 // Pre-requisito: dist/ ya compilado (npm run build).
 //
+// Se quitó el flag --only: tenía sentido cuando cada schema se emitía
+// autocontenido, pero un subconjunto de un bundle con $ref compartidos no es
+// un artefacto válido (los referenciados que quedan afuera caen en el bucket
+// `__shared` de Zod y los refs no resuelven). Para inspeccionar uno solo,
+// generar el bundle completo y buscar su clave en $defs.
+//
 // Uso:
-//   npm run gen:json-schema                            # genera todos
-//   npm run gen:json-schema -- --only=Activo,Tracker --verbose
+//   npm run gen:json-schema
+//   npm run gen:json-schema -- --verbose
 //   npm run gen:json-schema -- --skip=EventoGenerico   # excluye sin fallar
 
 import { z } from "zod";
-import { writeFileSync, mkdirSync, existsSync } from "node:fs";
+import { writeFileSync, mkdirSync, existsSync, rmSync } from "node:fs";
 import { join, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -31,93 +47,181 @@ const OUT_DIR = join(REPO_ROOT, "dist", "json-schema");
 const SKIP_SCHEMAS = [];
 
 function parseArgs(argv) {
-  const only = [];
   const skip = [...SKIP_SCHEMAS];
   let verbose = false;
   for (const arg of argv.slice(2)) {
     if (arg === "--verbose" || arg === "-v") verbose = true;
-    else if (arg.startsWith("--only=")) {
-      only.push(...arg.slice("--only=".length).split(",").filter(Boolean));
-    } else if (arg.startsWith("--skip=")) {
+    else if (arg.startsWith("--skip=")) {
       skip.push(...arg.slice("--skip=".length).split(",").filter(Boolean));
+    } else {
+      console.error(`ERROR: flag desconocido: ${arg}`);
+      process.exit(1);
     }
   }
-  return { only: only.length ? only : null, skip, verbose };
+  return { skip, verbose };
 }
 
 function isZodSchema(value) {
   return !!value && typeof value === "object" && "_zod" in value;
 }
 
+const TO_JSON_SCHEMA_OPTS = {
+  // unrepresentable: 'any' → los z.custom (los cortes de ciclo de populate,
+  // que existen por TS7056 en la emisión de declarations de TS) salen como {}
+  // en vez de hacer fallar la generación. Hoy son 93 de 5.324 propiedades.
+  unrepresentable: "any",
+  // Los $ref apuntan a $defs, que es donde reubicamos los schemas abajo.
+  uri: (id) => `#/$defs/${id}`,
+};
+
+// diagnosticarFallo corre SOLO en el camino de error: la llamada única no dice
+// cuál schema la rompió, así que se prueban de a uno para poder nombrarlos.
+function diagnosticarFallo(entries) {
+  const culpables = [];
+  for (const [name, value] of entries) {
+    try {
+      z.toJSONSchema(value, TO_JSON_SCHEMA_OPTS);
+    } catch (err) {
+      culpables.push([name, err instanceof Error ? err.message : String(err)]);
+    }
+  }
+  return culpables;
+}
+
+// refsColgantes verifica que todo $ref resuelva a una clave real de $defs. Un
+// ref colgante rompe en silencio a cualquier consumidor del bundle.
+function refsColgantes(defs) {
+  const validos = new Set(Object.keys(defs));
+  const rotos = new Set();
+  const visitar = (node) => {
+    if (Array.isArray(node)) return node.forEach(visitar);
+    if (!node || typeof node !== "object") return;
+    if (typeof node.$ref === "string") {
+      const id = node.$ref.replace(/^#\/\$defs\//, "");
+      if (!validos.has(id)) rotos.add(node.$ref);
+    }
+    for (const v of Object.values(node)) visitar(v);
+  };
+  visitar(defs);
+  return [...rotos];
+}
+
+// contarVacios cuenta las propiedades emitidas como {} (los z.custom). No es
+// error: es la métrica de cuánto pierde el bundle por los cortes de ciclo.
+function contarVacios(defs) {
+  let total = 0;
+  let vacios = 0;
+  const visitar = (node) => {
+    if (!node || typeof node !== "object") return;
+    if (node.properties) {
+      for (const v of Object.values(node.properties)) {
+        total++;
+        if (Object.keys(v).length === 0) vacios++;
+        visitar(v);
+      }
+    }
+    if (node.items) visitar(node.items);
+    for (const k of ["allOf", "anyOf", "oneOf"]) {
+      if (Array.isArray(node[k])) node[k].forEach(visitar);
+    }
+  };
+  Object.values(defs).forEach(visitar);
+  return { total, vacios };
+}
+
 function main() {
   const args = parseArgs(process.argv);
 
-  if (!existsSync(OUT_DIR)) {
-    mkdirSync(OUT_DIR, { recursive: true });
-  }
-
   const entries = Object.entries(Modelos)
     .filter(([name]) => name.endsWith("Schema"))
-    .filter(([name]) =>
-      args.only ? args.only.some((needle) => name.includes(needle)) : true,
-    );
+    .filter(([, value]) => isZodSchema(value))
+    .filter(([name]) => !args.skip.some((needle) => name.includes(needle)));
 
-  const results = [];
-  const defs = {};
+  if (entries.length === 0) {
+    console.error("ERROR: ningún schema quedó seleccionado");
+    process.exit(1);
+  }
 
+  const registry = z.registry();
   for (const [name, value] of entries) {
-    if (args.skip.some((needle) => name.includes(needle))) {
-      results.push({ name, status: "skipped", error: "en skip-list" });
-      if (args.verbose) console.log(`  skip ${name}`);
-      continue;
-    }
-    if (!isZodSchema(value)) {
-      results.push({ name, status: "skipped", error: "not a Zod schema" });
-      continue;
-    }
+    registry.add(value, { id: name });
+    if (args.verbose) console.log(`  registrado ${name}`);
+  }
 
-    try {
-      // unrepresentable: 'any' → los z.custom (populates del SCC) se emiten
-      // como {} (any) en vez de fallar
-      const jsonSchema = z.toJSONSchema(value, {
-        target: "openapi-3.0",
-        unrepresentable: "any",
-      });
-      const payload = JSON.stringify(jsonSchema, null, 2);
-      writeFileSync(join(OUT_DIR, `${name}.json`), payload + "\n", "utf-8");
-      defs[name] = jsonSchema;
-      results.push({ name, status: "ok", bytes: payload.length });
-      if (args.verbose) {
-        console.log(`  ok  ${name}  (${payload.length} bytes)`);
-      }
-    } catch (err) {
-      const msg = err instanceof Error ? err.message : String(err);
-      results.push({ name, status: "error", error: msg });
+  let emitido;
+  try {
+    emitido = z.toJSONSchema(registry, TO_JSON_SCHEMA_OPTS);
+  } catch (err) {
+    console.error(
+      `ERROR: la generación falló: ${err instanceof Error ? err.message : err}`,
+    );
+    console.error("Probando schema por schema para identificar el culpable...");
+    for (const [name, msg] of diagnosticarFallo(entries)) {
       console.error(`  ERR ${name}: ${msg}`);
     }
+    console.error(
+      "Agregarlos a SKIP_SCHEMAS (con el motivo) o arreglar el schema.",
+    );
+    process.exit(1);
+  }
+
+  const defs = emitido.schemas ?? emitido.$defs ?? {};
+
+  // Invariantes. Este repo no tiene suite de tests ni CI, así que las
+  // verificaciones viven acá y FALLAN la generación, ANTES de tocar el
+  // directorio de salida (un fallo no debe dejarnos sin el bundle anterior).
+  //
+  // OJO: el bundle puede traer MÁS claves que schemas registrados. Zod hoistea
+  // a `__shared` los sub-schemas que se repiten y no están registrados; con
+  // --only aparecen también los referenciados que quedaron fuera. Por eso la
+  // invariante correcta es "todos los registrados están", no una igualdad de
+  // cardinales.
+  const faltantes = entries.map(([n]) => n).filter((n) => !(n in defs));
+  if (faltantes.length > 0) {
+    console.error(
+      `ERROR: ${faltantes.length} schemas registrados no llegaron al bundle:`,
+    );
+    for (const n of faltantes.slice(0, 20)) console.error(`  ${n}`);
+    process.exit(1);
+  }
+  const rotos = refsColgantes(defs);
+  if (rotos.length > 0) {
+    console.error(`ERROR: ${rotos.length} $ref colgantes:`);
+    for (const r of rotos.slice(0, 20)) console.error(`  ${r}`);
+    process.exit(1);
   }
 
   const bundle = {
     $schema: "https://json-schema.org/draft/2020-12/schema",
     "x-source": "gestion-modelos",
-    "x-generator": "z.toJSONSchema({target:'openapi-3.0'})",
+    "x-generator": "z.toJSONSchema(registry)",
     "x-generated-at": new Date().toISOString(),
     $defs: defs,
   };
-  const bundlePath = join(OUT_DIR, "index.json");
-  writeFileSync(bundlePath, JSON.stringify(bundle, null, 2) + "\n", "utf-8");
+  // Recién acá se toca el disco. Se limpia el directorio porque hasta
+  // 2026-08-04 se emitía un <name>.json por schema, y esos archivos quedarían
+  // para siempre confundiéndose con la salida vigente.
+  if (existsSync(OUT_DIR)) {
+    rmSync(OUT_DIR, { recursive: true });
+  }
+  mkdirSync(OUT_DIR, { recursive: true });
 
-  const ok = results.filter((r) => r.status === "ok").length;
-  const skipped = results.filter((r) => r.status === "skipped").length;
-  const errored = results.filter((r) => r.status === "error").length;
+  const bundlePath = join(OUT_DIR, "index.json");
+  const payload = JSON.stringify(bundle, null, 2) + "\n";
+  writeFileSync(bundlePath, payload, "utf-8");
+
+  const { total, vacios } = contarVacios(defs);
+  const refs = (JSON.stringify(defs).match(/"\$ref"/g) || []).length;
 
   console.log("");
-  console.log(`Resumen: ok=${ok} skipped=${skipped} error=${errored}`);
-  console.log(`Bundle: ${bundlePath}`);
-
-  if (errored > 0) {
-    process.exit(1);
-  }
+  console.log(`Schemas:     ${Object.keys(defs).length}`);
+  console.log(`$ref:        ${refs} (compartidos, ninguno colgante)`);
+  console.log(
+    `Propiedades: ${total}, de las cuales ${vacios} vacías {} por z.custom (${((100 * vacios) / total).toFixed(1)}%)`,
+  );
+  console.log(
+    `Bundle:      ${bundlePath} (${(payload.length / 1024 / 1024).toFixed(2)} MB)`,
+  );
 }
 
 main();


### PR DESCRIPTION
Primer paso de la **etapa 1** del roadmap (`gestion-datos-go`, spec `2026-08-04-aprovechar-go-roadmap-design.md`, PR #13). Va después de GPE-Sistemas/gestion-datos-go#14, que borró el único consumidor del bundle.

## El problema

`z.toJSONSchema` se llamaba **una vez por schema, dentro del `for`**. Cada llamada inlinea su grafo completo, así que el mismo schema se repetía en cada uno que lo referenciara.

## El cambio

Los 675 `*Schema` exportados se registran en un `z.registry()` y se emiten en **una sola llamada**: cada uno aparece una vez en `$defs` y el resto lo referencia con `$ref`.

| | Antes | Después |
|---|---|---|
| Bundle | 12.883.468 bytes | **1.035.694 bytes** (12,4×) |
| `apikeyBotonBLE` (campo de `ClienteSchema`) | 181 apariciones | **3** (Cliente/CreateCliente/UpdateCliente) |
| `$ref` | — | 2.034 (364 distintos, ninguno colgante) |

**No se toca `src/`.** Los schemas y los tipos TS inferidos quedan idénticos, y `gen:json-schema` no está en el `prepare`, así que el `npm install` de los consumidores no se ve afectado. `npm run build` verde.

## Robustez, que el cambio hacía necesaria

Una llamada por schema daba gratis dos cosas que la llamada única pierde. Se reponen explícitamente:

- **Identificar al culpable**: si la llamada única falla, no dice cuál schema la rompió. Se agregó un diagnóstico que corre solo en el camino de error y prueba de a uno para nombrarlos.
- **Invariantes en el script** (este repo no tiene tests ni CI): falla la generación si algún schema registrado no llegó al bundle, o si queda algún `$ref` colgante.
  Ojo: la invariante **no** es igualdad de cardinales — Zod hoistea los sub-schemas repetidos a un bucket `__shared`.

Además:

- Se dejan de emitir los `dist/json-schema/<name>.json` por archivo: no los leía nadie y con `$defs` compartidos quedarían con refs colgantes.
- El directorio se limpia antes de escribir pero **después** de validar, para que un fallo no deje al repo sin el bundle anterior.
- **Se quita `--only`**: un subconjunto de un bundle con `$ref` compartidos no es un artefacto válido — los referenciados que quedan afuera caen en `__shared` y los refs no resuelven. Se descubrió justamente probando el flag. Un flag desconocido ahora falla en vez de ignorarse en silencio.

## Lo que este PR NO arregla

La salida ahora reporta cuántas propiedades quedan como `{}` por los `z.custom` (los cortes de ciclo que existen por TS7056 en la emisión de declarations de TS): **329 de 9.295, un 3,5 %**. Son cosas como `tracker`, `estadoCuenta`, `grupo` — los populates.

El registry ya recupera todo lo que no sea un corte de ciclo: en `ActivoSchema`, `cliente` y `funcion` ahora salen como `$ref`; solo `tracker` sigue vacío. Ese 3,5 % es el próximo PR.

---

## Bonus: `CLAUDE.md`

Se agregó un `CLAUDE.md` con las trampas del repo y el motivo de cada una — sobre todo que **los 116 `z.custom` y los getters no son un error a arreglar** (son cortes de ciclo por TS7056), el radio de daño del hook `prepare`, y las seis decisiones de `gen-json-schema.mjs` que este PR introduce y que conviene no deshacer sin leer el porqué.
