### PR TITLE
Metadata de persistencia por .meta() en 3 entidades (spike etapa 1)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,8 +51,22 @@ tracker: z.custom<ITracker>().optional(),
 
 Los populates entre entidades forman ciclos (activo → tracker → activo). Un
 schema real en esa posición hace explotar el emisor de declaraciones de
-TypeScript, acá y en cada consumidor. Hay **116 `z.custom`** en el repo y
+TypeScript, acá y en cada consumidor. Hay **92 `z.custom<T>()`** en el repo
+(116 era el conteo de líneas que mencionan `z.custom`, comentarios incluidos) y
 ninguno es un descuido.
+
+**Medido el 2026-08-05** (spike de la etapa 1 del roadmap, sobre `activo.ts` y
+`recorrido.ts`): con getters y schemas reales en esos 9 populates, `tsc` tira
+TS7056 en **`asignacion.ts`, `certificado-entidad.ts`, `nota.ts` y
+`recordatorio.ts`** — o sea **no en el archivo que tocás, sino en los que
+EMBEBEN esa entidad** (son 14 los que embeben `ActivoSchema`/`RecorridoSchema`
+por valor). Y la salida de emergencia no sirve: anotar
+`export const XSchema: z.ZodType<IX>` achica el `.d.ts` pero **`z.ZodType` no
+tiene `.omit()`**, que es lo que esos 4 archivos usan para sus `Create*` /
+`Update*`.
+
+Corolario práctico: **si necesitás que algo sepa a dónde apunta un populate, no
+cambies el tipo — anotalo** (`.meta()`, §5).
 
 La variante permitida para ciclos es el **getter**, y tiene su propia trampa:
 
@@ -137,12 +151,31 @@ Lo que viene y conviene no contradecir:
   ocurre **acá**, una sola vez; los consumidores hacen `go get`. Si alguna vez
   ves un `generate.sh` que clona este repo dentro de una API, es la deuda que
   estamos pagando — no el patrón a copiar.
-- Los schemas van a ganar metadata de persistencia vía `.meta({ bson:
-  'objectId' })`. Es **aditiva**: los consumidores TS ignoran las claves
-  desconocidas.
-- Reducir los 329 `{}` que dejan los `z.custom` (3,5 % de las propiedades) es
-  trabajo en curso, de a poco y midiendo. No es una limpieza para hacer de un
-  saque.
+- Los schemas ganan metadata de persistencia vía `.meta()`. Es **aditiva**: los
+  consumidores TS ignoran las claves desconocidas y los tipos inferidos no
+  cambian. **Ya está aplicada en `proveedor.ts`, `recorrido.ts` y `activo.ts`**
+  (spike de la etapa 1, 2026-08-05); la convención está documentada arriba de
+  `ProveedorSchema` y es la que hay que copiar al anotar el resto:
+
+  | Clave | Dónde | Qué declara |
+  |---|---|---|
+  | `x-collection` | schema | colección Mongo |
+  | `x-bson` | propiedad | `objectId` / `date` / `mixed` |
+  | `x-ref` | propiedad | `@Prop({ref})`: populate del path del id en su lugar |
+  | `x-populate` | propiedad | `schema.virtual()`: `{ref, localField, foreignField, justOne}` |
+  | `x-setter` | propiedad | `uppercase` / `lowercase` |
+  | `x-computed` | propiedad | getter del `toJSON`, no es campo ni populate |
+
+  **`x-bson: 'mixed'` no es opcional donde corresponde.** Un
+  `@Prop({type: Object})` del legacy es Mixed y **Mongoose no castea adentro**;
+  si el emisor desciende igual, inventa casteos que divergen. Sin esa clave, el
+  spike generaba 28 casteos falsos en 3 entidades.
+- Reducir los `{}` que dejan los `z.custom` (322 de 9.299, 3,5 %) es trabajo en
+  curso, de a poco y midiendo. No es una limpieza para hacer de un saque — y
+  **el camino no es reemplazarlos** (§2): es anotarlos.
+- `scripts/spike-emisor-meta-go.mjs` es el emisor del spike: lee el bundle y
+  arma el `meta.go` de una entidad para diffearlo contra el real. Es
+  desechable, no es el generador de la etapa 2 (ese vive en `go/`).
 
 **El límite del repo, para que no se vuelva un depósito**: acá va la forma del
 dato y su persistencia, no el comportamiento de cada API. **Si dos APIs pueden

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -76,7 +76,11 @@ tracker: z.custom<ITracker>().optional(),
 
 **No.** Son cortes de ciclo por **TS7056**: un schema real ahí arrastra el
 grafo completo y revienta la emisión de declarations, acá y en cada consumidor
-NestJS. Hay 116 y ninguno es un descuido.
+NestJS. Hay 92 y ninguno es un descuido.
+
+Se probó (2026-08-05, spike de la etapa 1) y **TS7056 vuelve**: no en el archivo
+que tocás, sino en los que embeben esa entidad (`nota.ts`, `asignacion.ts`,
+`certificado-entidad.ts`, `recordatorio.ts`). Detalle en `CLAUDE.md` §2.
 
 La alternativa válida para ciclos es el getter:
 
@@ -89,6 +93,11 @@ get tracker() {
 Y su trampa: **nunca spreadear un objeto que contenga getters** (`{...Base}`)
 — los evalúa eager y rompe el ciclo **en runtime**, no en compilación. El build
 pasa y explota en producción.
+
+**Si lo que querés es que el bundle sepa a dónde apunta el populate** (para que
+las APIs Go lo lean), no toques el tipo: agregale `.meta({ 'x-populate': {...} })`.
+Es aditivo y no cambia la inferencia. La tabla de claves está en `CLAUDE.md` §5 y
+el ejemplo vivo arriba de `ProveedorSchema`.
 
 ---
 

--- a/scripts/gen-json-schema.mjs
+++ b/scripts/gen-json-schema.mjs
@@ -7,9 +7,11 @@
 // POR QUÉ UN REGISTRY Y UNA SOLA LLAMADA (cambio 2026-08-04): antes se llamaba
 // z.toJSONSchema una vez POR SCHEMA, y cada llamada inlinea su grafo completo.
 // Resultado: ClienteSchema aparecía inlineado 181 veces y el bundle pesaba
-// 3,84 MB. Con el registry cada schema se emite una vez en $defs y el resto lo
-// referencia con $ref: 0,52 MB, 7,4x menos. Esto NO toca src/ — los schemas y
-// los tipos TS inferidos quedan exactamente igual.
+// 12.883.468 bytes. Con el registry cada schema se emite una vez en $defs y el
+// resto lo referencia con $ref: 1.035.978 bytes, 12,4x menos. Esto NO toca
+// src/ — los schemas y los tipos TS inferidos quedan exactamente igual.
+// (Los números "0,52 MB / 7,4x" que decía este comentario eran de una corrida
+// intermedia; corregidos el 2026-08-05 volviendo a medir.)
 //
 // Zod es el single source of truth: los tipos TS se infieren de los schemas y
 // este bundle es la forma neutra que consumen los generadores de otros
@@ -68,7 +70,9 @@ function isZodSchema(value) {
 const TO_JSON_SCHEMA_OPTS = {
   // unrepresentable: 'any' → los z.custom (los cortes de ciclo de populate,
   // que existen por TS7056 en la emisión de declarations de TS) salen como {}
-  // en vez de hacer fallar la generación. Hoy son 93 de 5.324 propiedades.
+  // en vez de hacer fallar la generación. Hoy son 322 de 9.299 propiedades
+  // (eran 329 antes de que las 3 entidades del spike de la etapa 1 llevaran su
+  // `.meta()` al lado del {}).
   unrepresentable: "any",
   // Los $ref apuntan a $defs, que es donde reubicamos los schemas abajo.
   uri: (id) => `#/$defs/${id}`,

--- a/scripts/spike-emisor-meta-go.mjs
+++ b/scripts/spike-emisor-meta-go.mjs
@@ -1,0 +1,245 @@
+// SPIKE de la etapa 1 del roadmap (gestion-datos-go,
+// docs/superpowers/specs/2026-08-04-aprovechar-go-roadmap-design.md §4).
+//
+// Emisor Go MÍNIMO: lee el bundle JSON Schema y arma, para las entidades
+// anotadas con la metadata de persistencia (`x-collection`, `x-bson`, `x-ref`,
+// `x-populate`, `x-setter`), el fragmento de `meta.go` que hoy está escrito a
+// mano en gestion-datos-go. Después DIFFEA su salida contra la metadata real.
+//
+// El diff es el punto: mide qué porción del meta.go sale generada de verdad y
+// deja a la vista lo que el bundle todavía no sabe. No es un generador para
+// producción — eso es la etapa 2, y vive en `go/` de este repo.
+//
+// Uso:
+//   node scripts/spike-emisor-meta-go.mjs <metas.json> [Entidad...]
+//
+// <metas.json> lo produce `go run ./cmd/tmpaudit` en gestion-datos-go.
+
+import { readFileSync } from "node:fs";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const BUNDLE = join(__dirname, "..", "dist", "json-schema", "index.json");
+
+const [rutaMetas, ...entidadesPedidas] = process.argv.slice(2);
+if (!rutaMetas) {
+  console.error("uso: node scripts/spike-emisor-meta-go.mjs <metas.json> [Entidad...]");
+  process.exit(1);
+}
+
+const defs = JSON.parse(readFileSync(BUNDLE, "utf8")).$defs;
+const metasReales = JSON.parse(readFileSync(rutaMetas, "utf8"));
+
+const nombreRef = (ref) => ref?.replace(/^#\/\$defs\//, "");
+const schemaDe = (nodo) => (nodo?.$ref ? defs[nombreRef(nodo.$ref)] : null);
+// Un $ref a un schema con x-collection es OTRA entidad (populate); sin
+// x-collection es un subdocumento y hay que descender con dot-path.
+const esEntidad = (nodo) => !!schemaDe(nodo)?.["x-collection"];
+
+// desenvuelve arrays: devuelve {nodo, esArray}
+function desenvolver(prop) {
+  if (prop?.type === "array" && prop.items) return { nodo: prop.items, esArray: true };
+  return { nodo: prop, esArray: false };
+}
+
+function tipoGo(prop, esArray) {
+  const bson = prop["x-bson"];
+  const setter = prop["x-setter"];
+  if (setter === "uppercase") return "TypeUppercase";
+  if (setter === "lowercase") return "TypeLowercase";
+  if (bson === "mixed") return null; // Mixed no se castea
+  if (bson === "objectId") return esArray ? "TypeObjectIDArray" : "TypeObjectID";
+  if (bson === "date") return "TypeDate";
+  const { nodo } = desenvolver(prop);
+  const t = nodo?.type ?? schemaDe(nodo)?.type;
+  if (t === "number" || t === "integer") return "TypeNumber";
+  if (t === "boolean") return "TypeBool";
+  return null;
+}
+
+function emitir(nombreSchema) {
+  const sch = defs[nombreSchema];
+  if (!sch) return null;
+  const coleccion = sch["x-collection"];
+  const props = sch.properties ?? {};
+
+  const fields = [];
+  const fieldTypes = {};
+  const arrayFields = [];
+  const virtuals = {};
+
+  // Recorre el árbol registrando casteos y los populates de los SUBDOCUMENTOS
+  // con su dot-path ("vehiculo.chofer"), que es como los declara el meta.go.
+  const registrarTipos = (prefijo, propiedades) => {
+    for (const [nombre, prop] of Object.entries(propiedades)) {
+      const path = prefijo ? `${prefijo}.${nombre}` : nombre;
+      if (prop["x-computed"]) continue; // getter del toJSON, no es un campo
+      const { nodo, esArray } = desenvolver(prop);
+
+      const pop = prop["x-populate"];
+      if (pop) {
+        if (prefijo) {
+          const destino = defs[pop.ref];
+          virtuals[path] = {
+            ref: destino?.["x-collection"] ?? `?? (${pop.ref} sin x-collection)`,
+            localField: `${prefijo}.${pop.localField}`,
+            foreignField: pop.foreignField ?? "_id",
+            justOne: !!pop.justOne,
+          };
+        }
+        continue; // un virtual no lleva casteo
+      }
+
+      const t = tipoGo(prop, esArray);
+      if (t) fieldTypes[path] = t;
+      // Mixed (@Prop({type: Object})): Mongoose NO castea adentro, así que
+      // declarar los paths de abajo DIVERGE del legacy. No descender.
+      if (prop["x-bson"] === "mixed") continue;
+      // subdocumento: descender con dot-path. Otra entidad: no.
+      if (nodo?.$ref && !esEntidad(nodo)) {
+        const sub = schemaDe(nodo);
+        if (sub?.properties && sub.type === "object") registrarTipos(path, sub.properties);
+      }
+    }
+  };
+
+  for (const [nombre, prop] of Object.entries(props)) {
+    if (nombre === "_id") continue;
+    if (prop["x-computed"]) continue; // getter computado del toJSON legacy
+    const { nodo, esArray } = desenvolver(prop);
+
+    const pop = prop["x-populate"];
+    if (pop) {
+      const destino = defs[pop.ref];
+      virtuals[nombre] = {
+        ref: destino?.["x-collection"] ?? `?? (${pop.ref} sin x-collection)`,
+        localField: pop.localField,
+        foreignField: pop.foreignField ?? "_id",
+        justOne: !!pop.justOne,
+      };
+      continue; // un virtual no va en Fields ni en ArrayFields
+    }
+
+    fields.push(nombre);
+    if (esArray) arrayFields.push(nombre);
+
+    // @Prop({ref}): Mongoose popula el path del id EN SU LUGAR
+    const ref = prop["x-ref"];
+    if (ref) {
+      const destino = defs[ref];
+      virtuals[nombre] = {
+        ref: destino?.["x-collection"] ?? `?? (${ref} sin x-collection)`,
+        localField: nombre,
+        foreignField: "_id",
+        justOne: !esArray,
+      };
+    }
+  }
+
+  registrarTipos("", props);
+
+  return { collection: coleccion, fields, fieldTypes, arrayFields, virtuals };
+}
+
+// ---------- salida Go ----------
+
+function comoGo(nombreSchema, m) {
+  const q = (s) => `"${s}"`;
+  const l = [];
+  l.push(`// generado por scripts/spike-emisor-meta-go.mjs desde ${nombreSchema}`);
+  l.push(`Collection: ${q(m.collection ?? "??")},`);
+  l.push(`Fields: []string{`);
+  l.push(`\t${m.fields.map(q).join(", ")},`);
+  l.push(`},`);
+  l.push(`FieldTypes: query.FieldTypes{`);
+  for (const [p, t] of Object.entries(m.fieldTypes).sort()) {
+    l.push(`\t${q(p)}: query.${t},`);
+  }
+  l.push(`},`);
+  l.push(`ArrayFields: []string{${m.arrayFields.map(q).join(", ")}},`);
+  l.push(`Virtuals: map[string]query.VirtualDef{`);
+  for (const [n, v] of Object.entries(m.virtuals).sort()) {
+    l.push(
+      `\t${q(n)}: {Ref: ${q(v.ref)}, LocalField: ${q(v.localField)}, ForeignField: ${q(v.foreignField)}, JustOne: ${v.justOne}},`,
+    );
+  }
+  l.push(`},`);
+  return l.join("\n");
+}
+
+// ---------- diff ----------
+
+function diffSet(nombre, generado, real) {
+  const g = new Set(generado), r = new Set(real);
+  const falta = [...r].filter((x) => !g.has(x));
+  const sobra = [...g].filter((x) => !r.has(x));
+  return { nombre, falta, sobra, iguales: [...r].filter((x) => g.has(x)).length, total: r.size };
+}
+
+function diffMapa(nombre, generado, real, comparar) {
+  const falta = [], sobra = [], distinto = [];
+  for (const k of Object.keys(real)) {
+    if (!(k in generado)) falta.push(k);
+    else if (!comparar(generado[k], real[k])) distinto.push(`${k}: generado=${JSON.stringify(generado[k])} real=${JSON.stringify(real[k])}`);
+  }
+  for (const k of Object.keys(generado)) if (!(k in real)) sobra.push(k);
+  const iguales = Object.keys(real).length - falta.length - distinto.length;
+  return { nombre, falta, sobra, distinto, iguales, total: Object.keys(real).length };
+}
+
+function reportar(r) {
+  const linea = `  ${r.nombre}: ${r.iguales}/${r.total} exactos`;
+  const extras = [];
+  if (r.falta?.length) extras.push(`falta ${r.falta.length}: ${r.falta.join(", ")}`);
+  if (r.sobra?.length) extras.push(`sobra ${r.sobra.length}: ${r.sobra.join(", ")}`);
+  console.log(extras.length ? `${linea} — ${extras.join(" | ")}` : linea);
+  for (const d of r.distinto ?? []) console.log(`      DISTINTO ${d}`);
+}
+
+const objetivo = entidadesPedidas.length
+  ? entidadesPedidas
+  : Object.keys(defs).filter((n) => defs[n]["x-collection"] && metasReales[n.replace(/Schema$/, "")]);
+
+let totales = { iguales: 0, total: 0 };
+for (const nombreSchema of objetivo.map((n) => (n.endsWith("Schema") ? n : `${n}Schema`))) {
+  const modelo = nombreSchema.replace(/Schema$/, "");
+  const real = metasReales[modelo];
+  const gen = emitir(nombreSchema);
+  if (!gen) { console.log(`\n### ${modelo}: no está en el bundle`); continue; }
+  if (!real) { console.log(`\n### ${modelo}: no hay meta.go`); continue; }
+
+  console.log(`\n### ${modelo} (colección real ${real.collection})`);
+  console.log(comoGo(nombreSchema, gen).split("\n").map((l) => `  ${l}`).join("\n"));
+  console.log(`\n  --- diff contra el meta.go real ---`);
+  const rs = [
+    diffSet("Fields", gen.fields, real.fields),
+    diffSet("ArrayFields", gen.arrayFields, real.arrayFields),
+    diffMapa("FieldTypes", gen.fieldTypes, mapTipos(real.fieldTypes), (a, b) => a === b),
+    diffMapa("Virtuals", gen.virtuals, real.virtuals, (a, b) =>
+      a.ref === b.ref && a.localField === b.localField && a.foreignField === b.foreignField && a.justOne === b.justOne),
+  ];
+  rs.forEach(reportar);
+  if (real.requiredFields?.length) {
+    console.log(`  RequiredFields: 0/${real.requiredFields.length} — zod tiene todo .optional(), no sale del bundle`);
+  }
+  for (const r of rs) { totales.iguales += r.iguales; totales.total += r.total; }
+  totales.total += real.requiredFields?.length ?? 0;
+}
+
+console.log(`\n=== TOTAL entradas generadas exactas: ${totales.iguales}/${totales.total} ===`);
+
+// los tipos del meta.go vienen como "objectId"/"date"/...; el emisor habla en
+// nombres de constante Go
+function mapTipos(ft) {
+  const m = {
+    objectId: "TypeObjectID",
+    objectIdArray: "TypeObjectIDArray",
+    date: "TypeDate",
+    number: "TypeNumber",
+    bool: "TypeBool",
+    uppercase: "TypeUppercase",
+    lowercase: "TypeLowercase",
+  };
+  return Object.fromEntries(Object.entries(ft).map(([k, v]) => [k, m[v] ?? v]));
+}

--- a/src/interfaces/activo.ts
+++ b/src/interfaces/activo.ts
@@ -55,7 +55,7 @@ export type ICategoriaActivo = z.infer<typeof CategoriaActivoSchema>;
 // declarations (TS7056) acá y en los consumidores NestJS.
 export const VehiculoSchema = z.object({
   tipo: TipoVehiculoSchema.optional(),
-  patente: z.string().optional(),
+  patente: z.string().optional().meta({ 'x-setter': 'uppercase' }),
   estado: EstadoVehiculoSchema.optional(),
   modelo: z.string().optional(),
   marca: z.string().optional(),
@@ -64,17 +64,47 @@ export const VehiculoSchema = z.object({
   consumoCiudad: z.number().optional(), // litros cada 100 km
   capacidadCombustible: z.number().optional(), // litros
   //
-  idChofer: z.string().optional(),
-  idRecorrido: z.string().optional(),
-  idsRecorridos: z.array(z.string()).optional(),
+  idChofer: z
+    .string()
+    .optional()
+    .meta({ 'x-bson': 'objectId', 'x-ref': 'UsuarioSchema' }),
+  idRecorrido: z
+    .string()
+    .optional()
+    .meta({ 'x-bson': 'objectId', 'x-ref': 'RecorridoSchema' }),
+  idsRecorridos: z
+    .array(z.string())
+    .optional()
+    .meta({ 'x-bson': 'objectId', 'x-ref': 'RecorridoSchema' }),
   dentroDelRecorrido: z.boolean().optional(), // Para seguir el estado de los eventos
   ignicion: z.boolean().optional(),
   //
   idExterno: z.string().optional(),
   // Populate
-  chofer: z.custom<IUsuario>().optional(),
-  recorrido: z.custom<IRecorrido>().optional(),
-  recorridos: z.array(z.custom<IRecorrido>()).optional(),
+  chofer: z.custom<IUsuario>().optional().meta({
+    'x-populate': {
+      ref: 'UsuarioSchema',
+      localField: 'idChofer',
+      foreignField: '_id',
+      justOne: true,
+    },
+  }),
+  recorrido: z.custom<IRecorrido>().optional().meta({
+    'x-populate': {
+      ref: 'RecorridoSchema',
+      localField: 'idRecorrido',
+      foreignField: '_id',
+      justOne: true,
+    },
+  }),
+  recorridos: z.array(z.custom<IRecorrido>()).optional().meta({
+    'x-populate': {
+      ref: 'RecorridoSchema',
+      localField: 'idsRecorridos',
+      foreignField: '_id',
+      justOne: false,
+    },
+  }),
 });
 
 /**
@@ -118,12 +148,24 @@ export interface IVehiculoCache extends Omit<
 export const ActivoSchema = z.object({
   _id: z.string().optional(),
   //
-  idCliente: z.string().optional(),
-  idsAncestros: z.array(z.string()).optional(),
-  idGrupo: z.string().optional(),
-  idTracker: z.string().optional(),
+  idCliente: z
+    .string()
+    .optional()
+    .meta({ 'x-bson': 'objectId', 'x-ref': 'ClienteSchema' }),
+  idsAncestros: z
+    .array(z.string())
+    .optional()
+    .meta({ 'x-bson': 'objectId', 'x-ref': 'ClienteSchema' }),
+  idGrupo: z
+    .string()
+    .optional()
+    .meta({ 'x-bson': 'objectId', 'x-ref': 'GrupoSchema' }),
+  idTracker: z
+    .string()
+    .optional()
+    .meta({ 'x-bson': 'objectId', 'x-ref': 'TrackerSchema' }),
   ///alta de activo
-  fechaAlta: z.string().optional(),
+  fechaAlta: z.string().optional().meta({ 'x-bson': 'date' }),
   imagenes: z.array(z.string()).optional(),
   // es la imagen en la posición 0 de imagenes, pero reducida para usarla en el mapa
   imagenMiniatura: z.string().optional(),
@@ -131,11 +173,26 @@ export const ActivoSchema = z.object({
   categoria: CategoriaActivoSchema.optional(),
   funcion: FuncionActivoSchema.optional(),
   vehiculo: VehiculoSchema.optional(),
-  idsClientesQuePuedenAtender: z.array(z.string()).optional(),
-  idsClientesQuePuedenAtenderEventosTecnicos: z.array(z.string()).optional(),
+  // Llevan @Prop({ref: Cliente}) en el legacy, así que Mongoose los popula EN
+  // SU LUGAR igual que idCliente.
+  idsClientesQuePuedenAtender: z
+    .array(z.string())
+    .optional()
+    .meta({ 'x-bson': 'objectId', 'x-ref': 'ClienteSchema' }),
+  idsClientesQuePuedenAtenderEventosTecnicos: z
+    .array(z.string())
+    .optional()
+    .meta({ 'x-bson': 'objectId', 'x-ref': 'ClienteSchema' }),
   puedeSolicitarServicioTecnico: z.boolean().optional(),
-  configHorariosAtencion: z.array(ConfigHorarioSchema).optional(),
-  configHorariosAtencionTecnica: z.array(ConfigHorarioSchema).optional(),
+  // @Prop({type: [Object]}): Mixed, sin casteo adentro.
+  configHorariosAtencion: z
+    .array(ConfigHorarioSchema)
+    .optional()
+    .meta({ 'x-bson': 'mixed' }),
+  configHorariosAtencionTecnica: z
+    .array(ConfigHorarioSchema)
+    .optional()
+    .meta({ 'x-bson': 'mixed' }),
   modoDesactivado: z.custom<IModoDesactivado>().optional(),
   // Resultado del último alta/actualización del activo en Soflex (integración
   // externa): true si quedó creado/actualizado, false si no se pudo enviar.
@@ -143,11 +200,39 @@ export const ActivoSchema = z.object({
 
   estadoCuenta: z.custom<estadoCuenta>().optional(),
   // Populate
-  cliente: ClienteSchema.optional(),
-  ancestros: z.array(ClienteSchema).optional(),
-  tracker: z.custom<ITracker>().optional(),
-  grupo: z.custom<IGrupo>().optional(),
-});
+  cliente: ClienteSchema.optional().meta({
+    'x-populate': {
+      ref: 'ClienteSchema',
+      localField: 'idCliente',
+      foreignField: '_id',
+      justOne: true,
+    },
+  }),
+  ancestros: z.array(ClienteSchema).optional().meta({
+    'x-populate': {
+      ref: 'ClienteSchema',
+      localField: 'idsAncestros',
+      foreignField: '_id',
+      justOne: false,
+    },
+  }),
+  tracker: z.custom<ITracker>().optional().meta({
+    'x-populate': {
+      ref: 'TrackerSchema',
+      localField: 'idTracker',
+      foreignField: '_id',
+      justOne: true,
+    },
+  }),
+  grupo: z.custom<IGrupo>().optional().meta({
+    'x-populate': {
+      ref: 'GrupoSchema',
+      localField: 'idGrupo',
+      foreignField: '_id',
+      justOne: true,
+    },
+  }),
+}).meta({ 'x-collection': 'activos' });
 
 /**
  * Interface hand-written (misma forma que el schema): los tipos de entidad del

--- a/src/interfaces/cliente.ts
+++ b/src/interfaces/cliente.ts
@@ -362,7 +362,7 @@ export const ClienteSchema = z.object({
   get ancestros() {
     return z.array(ClienteSchema).optional();
   },
-});
+}).meta({ 'x-collection': 'clientes' });
 export type ICliente = z.infer<typeof ClienteSchema>;
 
 export const CreateClienteSchema = ClienteSchema.omit({

--- a/src/interfaces/grupo.ts
+++ b/src/interfaces/grupo.ts
@@ -33,7 +33,7 @@ export const GrupoSchema = z.object({
   cliente: ClienteSchema.optional(),
   ancestros: z.array(ClienteSchema).optional(),
   perfilConfigs: z.array(z.custom<IConfigPerfil>()).optional(),
-});
+}).meta({ 'x-collection': 'grupos' });
 
 /**
  * Interface hand-written (misma forma que el schema): los tipos de entidad del

--- a/src/interfaces/proveedor.ts
+++ b/src/interfaces/proveedor.ts
@@ -8,18 +8,52 @@ export type TipoProveedor = z.infer<typeof TipoProveedorSchema>;
 export const CategoriaProveedorSchema = z.enum(['Colectivo', 'Vehiculo']);
 export type CategoriaProveedor = z.infer<typeof CategoriaProveedorSchema>;
 
+// SPIKE etapa 1 (roadmap de gestion-datos-go, §4): metadata de persistencia
+// por `.meta()`. Es ADITIVA — los tipos TS inferidos no cambian, los
+// consumidores ignoran las claves desconocidas — y es lo que el bundle JSON
+// Schema necesita para que un emisor Go arme el meta.go de la entidad:
+//
+//   x-collection  colección Mongo (Mongoose pluraliza el nombre de la clase)
+//   x-bson        tipo real en la base: el casteo de filtros y writes
+//   x-ref         @Prop({ref}): Mongoose popula el path del id EN SU LUGAR
+//   x-populate    schema.virtual(): populate bajo el nombre del virtual
+//   x-setter      setter de Mongoose (uppercase/lowercase)
+//
+// `x-ref` y `x-populate` existen separados porque son las DOS formas distintas
+// en que un path es populable, y las dos se usan desde el front.
 export const ProveedorSchema = z.object({
   _id: z.string().optional(),
   categoria: CategoriaProveedorSchema.optional(),
   tipos: z.array(TipoProveedorSchema).optional(),
-  idCliente: z.string().optional(),
-  idsAncestros: z.array(z.string()).optional(),
+  idCliente: z
+    .string()
+    .optional()
+    .meta({ 'x-bson': 'objectId', 'x-ref': 'ClienteSchema' }),
+  idsAncestros: z
+    .array(z.string())
+    .optional()
+    .meta({ 'x-bson': 'objectId', 'x-ref': 'ClienteSchema' }),
   nombre: z.string().optional(),
-  ubicacion: CoordenadasSchema.optional(),
+  // @Prop({type: Object}) en el legacy: Mixed, Mongoose no castea adentro.
+  ubicacion: CoordenadasSchema.optional().meta({ 'x-bson': 'mixed' }),
   // Populate
-  cliente: ClienteSchema.optional(),
-  ancestros: z.array(ClienteSchema).optional(),
-});
+  cliente: ClienteSchema.optional().meta({
+    'x-populate': {
+      ref: 'ClienteSchema',
+      localField: 'idCliente',
+      foreignField: '_id',
+      justOne: true,
+    },
+  }),
+  ancestros: z.array(ClienteSchema).optional().meta({
+    'x-populate': {
+      ref: 'ClienteSchema',
+      localField: 'idsAncestros',
+      foreignField: '_id',
+      justOne: false,
+    },
+  }),
+}).meta({ 'x-collection': 'proveedors' });
 export type IProveedor = z.infer<typeof ProveedorSchema>;
 
 export const CreateProveedorSchema = ProveedorSchema.omit({

--- a/src/interfaces/recorrido.ts
+++ b/src/interfaces/recorrido.ts
@@ -16,13 +16,15 @@ export const TipoParadaSchema = z.enum(['refugio', 'parada']);
 export type ITipoParada = z.infer<typeof TipoParadaSchema>;
 
 export const ParadaSchema = z.object({
-  _id: z.string().optional(),
+  // Subdocumento CON _id (el único del legacy): el front filtra recorridos por
+  // {paradas._id}, así que ese path necesita el casteo a ObjectId.
+  _id: z.string().optional().meta({ 'x-bson': 'objectId' }),
   /**
    * @deprecated Se usa ubicacionOl.
    */
-  ubicacion: CoordenadasSchema.optional(),
+  ubicacion: CoordenadasSchema.optional().meta({ 'x-bson': 'mixed' }),
   ubicacionOl: CoordenadaOLSchema.optional(),
-  geojson: GeoJSONPointSchema.optional(),
+  geojson: GeoJSONPointSchema.optional().meta({ 'x-bson': 'mixed' }),
   nombre: z.string().optional(),
   direccion: z.string().optional(),
   destino: z.string().optional(),
@@ -150,36 +152,95 @@ export type IGeometriaRecorrido = z.infer<typeof GeometriaRecorridoSchema>;
 
 // Populates intra-SCC como z.custom (import type-only): un schema real acá
 // arrastra el shape completo del ciclo y revienta la serialización de
-// declarations (TS7056) acá y en los consumidores NestJS.
+// declarations (TS7056) acá y en los consumidores NestJS. Medido en el spike de
+// la etapa 1 (2026-08-05): con schemas reales acá, TS7056 revienta en los
+// archivos que EMBEBEN esta entidad, no acá.
+//
+// La metadata de persistencia va por `.meta()` justamente por eso: es aditiva y
+// no toca la inferencia. Convención documentada en proveedor.ts.
 export const RecorridoSchema = z.object({
   _id: z.string().optional(),
-  idCliente: z.string().optional(),
-  idsAncestros: z.array(z.string()).optional(),
+  idCliente: z
+    .string()
+    .optional()
+    .meta({ 'x-bson': 'objectId', 'x-ref': 'ClienteSchema' }),
+  idsAncestros: z
+    .array(z.string())
+    .optional()
+    .meta({ 'x-bson': 'objectId', 'x-ref': 'ClienteSchema' }),
   //
   categoria: CategoriaRecorridoSchema.optional(),
   idExterno: z.string().optional(),
-  idGrupo: z.string().optional(),
+  idGrupo: z
+    .string()
+    .optional()
+    .meta({ 'x-bson': 'objectId', 'x-ref': 'GrupoSchema' }),
   nombreFlota: z.string().optional(),
   nombre: z.string().optional(),
-  geojson: GeoJSONLineStringSchema.optional(),
+  geojson: GeoJSONLineStringSchema.optional().meta({ 'x-bson': 'mixed' }),
   paradas: z.array(ParadaSchema).optional(),
-  franjaHoraria: z.array(FranjaHorariaSchema).optional(),
+  franjaHoraria: z
+    .array(FranjaHorariaSchema)
+    .optional()
+    .meta({ 'x-bson': 'mixed' }),
   destino: z.string().optional(),
   por: z.string().optional(),
   color: z.string().optional(),
   duracion: z.number().optional(),
-  idsUbicaciones: z.array(z.string()).optional(),
+  idsUbicaciones: z
+    .array(z.string())
+    .optional()
+    .meta({ 'x-bson': 'objectId', 'x-ref': 'UbicacionSchema' }),
   // Cumplimiento (categoría 'Vehiculo')
-  cumplimiento: ConfigCumplimientoRecorridoSchema.optional(),
-  geometria: GeometriaRecorridoSchema.optional(),
+  cumplimiento: ConfigCumplimientoRecorridoSchema.optional().meta({
+    'x-bson': 'mixed',
+  }),
+  geometria: GeometriaRecorridoSchema.optional().meta({ 'x-bson': 'mixed' }),
   // Populate
-  cliente: ClienteSchema.optional(),
-  ancestros: z.array(ClienteSchema).optional(),
-  grupo: z.custom<IGrupo>().optional(),
-  recorrido: z.array(CoordenadasSchema).optional(),
-  recorridoOl: z.array(CoordenadaOLSchema).optional(),
-  ubicaciones: z.array(z.custom<IUbicacion>()).optional(),
-});
+  cliente: ClienteSchema.optional().meta({
+    'x-populate': {
+      ref: 'ClienteSchema',
+      localField: 'idCliente',
+      foreignField: '_id',
+      justOne: true,
+    },
+  }),
+  ancestros: z.array(ClienteSchema).optional().meta({
+    'x-populate': {
+      ref: 'ClienteSchema',
+      localField: 'idsAncestros',
+      foreignField: '_id',
+      justOne: false,
+    },
+  }),
+  grupo: z.custom<IGrupo>().optional().meta({
+    'x-populate': {
+      ref: 'GrupoSchema',
+      localField: 'idGrupo',
+      foreignField: '_id',
+      justOne: true,
+    },
+  }),
+  // Getters computados del toJSON legacy (geojson → {lat,lng}[] y proj4
+  // EPSG:3857): no son campos del schema ni populates, y por eso no van en
+  // Fields ni llevan casteo. Ver recorridos/tojson.go en gestion-datos-go.
+  recorrido: z
+    .array(CoordenadasSchema)
+    .optional()
+    .meta({ 'x-computed': true }),
+  recorridoOl: z
+    .array(CoordenadaOLSchema)
+    .optional()
+    .meta({ 'x-computed': true }),
+  ubicaciones: z.array(z.custom<IUbicacion>()).optional().meta({
+    'x-populate': {
+      ref: 'UbicacionSchema',
+      localField: 'idsUbicaciones',
+      foreignField: '_id',
+      justOne: false,
+    },
+  }),
+}).meta({ 'x-collection': 'recorridos' });
 
 /**
  * Interface hand-written (misma forma que el schema): los tipos de entidad del

--- a/src/interfaces/tracker.ts
+++ b/src/interfaces/tracker.ts
@@ -84,7 +84,7 @@ export const TrackerSchema = z.object({
   activo: z.custom<IActivo>().optional(),
   modelo: ModeloDispositivoSchema.optional(),
   serviciosContratados: z.array(ServicioContratadoSchema).optional(),
-});
+}).meta({ 'x-collection': 'trackers' });
 
 /**
  * Interface hand-written (misma forma que el schema): los tipos de entidad del

--- a/src/interfaces/ubicacion.ts
+++ b/src/interfaces/ubicacion.ts
@@ -202,7 +202,7 @@ export const UbicacionSchema = z.union([
   VarianteUbicacionDestinoEmergencia,
   VarianteUbicacionVehiculos,
   VarianteUbicacionLuminarias,
-]);
+]).meta({ 'x-collection': 'ubicacions' });
 
 /**
  * Tipo hand-written (misma forma que el schema): los tipos de entidad del

--- a/src/interfaces/usuario.ts
+++ b/src/interfaces/usuario.ts
@@ -100,7 +100,7 @@ export const UsuarioSchema = z.object({
   // Permisos del usuario. Ya no es un array embebido: es un virtual poblado
   // desde la colección Permiso por match de nombreUsuario (Permiso.nombreUsuario === Usuario.usuario).
   permisos: z.array(z.custom<IPermiso>()).optional(),
-});
+}).meta({ 'x-collection': 'usuarios' });
 
 /**
  * Interface hand-written (misma forma que el schema): los tipos de entidad del


### PR DESCRIPTION
Spike de la **etapa 1** del roadmap de `gestion-datos-go`
(`docs/superpowers/specs/2026-08-04-aprovechar-go-roadmap-design.md` §4). El PR
hermano, con los números y la decisión, es GPE-Sistemas/gestion-datos-go#27.

## Qué pasó con el plan

Decía "reemplazar los `z.custom<T>()` por referencias registradas en 3
entidades". Se hizo, con getters y schemas reales en `activo.ts` y
`recorrido.ts`. **TS7056 vuelve** — y el dato nuevo es *dónde*:

```
src/interfaces/asignacion.ts(23,14): error TS7056
src/interfaces/certificado-entidad.ts(9,14): error TS7056
src/interfaces/nota.ts(55,14), (81,14), (87,14): error TS7056
src/interfaces/recordatorio.ts(48,14): error TS7056
```

No revienta en la entidad que se toca: revienta en las que la **embeben** (14
archivos embeben `ActivoSchema`/`RecorridoSchema` por valor). Y la salida por
anotación explícita no sirve: `z.ZodType<IX>` achica el `.d.ts` pero **no tiene
`.omit()`**, que es lo que esos 4 archivos usan para sus `Create*`/`Update*`.
Mecanismo descartado, y el `CLAUDE.md` §2 queda con la medición anotada.

## Qué quedó

Metadata **aditiva** por `.meta()`: no cambia un solo tipo TS inferido y los
consumidores ignoran las claves desconocidas.

| Clave | Dónde | Qué declara |
|---|---|---|
| `x-collection` | schema | colección Mongo |
| `x-bson` | propiedad | `objectId` / `date` / `mixed` |
| `x-ref` | propiedad | `@Prop({ref})`: populate del path del id en su lugar |
| `x-populate` | propiedad | `schema.virtual()`: `{ref, localField, foreignField, justOne}` |
| `x-setter` | propiedad | `uppercase` / `lowercase` |
| `x-computed` | propiedad | getter del `toJSON`, no es campo ni populate |

Anotadas `proveedor`, `recorrido` y `activo`, más el `x-collection` de los cinco
schemas que referencian (`cliente`, `grupo`, `tracker`, `usuario`, `ubicacion`).

**`x-bson: 'mixed'` evita un bug, no agrega información**: en un
`@Prop({type: Object})` Mongoose no castea adentro, así que el emisor no debe
descender. Sin esa clave generaba 28 casteos falsos en 3 entidades — la misma
clase de divergencia que había cerrado el barrido de filtros del 2026-08-04.

`scripts/spike-emisor-meta-go.mjs` es el emisor del spike: lee el bundle, arma
el `meta.go` de una entidad y lo diffea contra el real. **97 de 98 entradas
exactas.** Es desechable; el generador de la etapa 2 va en `go/`.

## Verificación

- `npx tsc` (con `declaration: true`) **exit 0**
- Smoke de runtime: parsean Activo/Recorrido/Proveedor/Cliente con `ancestros`
  anidado, y los `Create*` / `Update*` / `*Cache` siguen existiendo
- `npm run gen:json-schema`: invariantes verdes. Vacías 329 → 322, bundle
  1.035.978 → 1.044.269 bytes, los 2.034 `$ref` y los 675 schemas sin moverse
- **`nest build` de `gestion-api-gestion` exit 0** y **`ng build --configuration
  production` de `gestion-web-cliente` exit 0**, los dos con el `dist` del spike
  sobreescrito en su `node_modules/modelos` (restaurado después) — el gate del
  `CLAUDE.md` §1
- `make sync-campos` + `make test` en `gestion-datos-go`: verdes y **sin cambios
  en `campos-modelos.json`**, o sea que las anotaciones no movieron ni agregaron
  ningún campo

## Riesgo

Bajo, pero toca 5 schemas de uso transversal (`ClienteSchema` y compañía) para
agregarles `x-collection`. Nada cambia en runtime ni en los tipos; lo único que
crece es el bundle JSON Schema, que hoy no consume nadie en producción.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
