### PR TITLE
feat: los schemas declaran su metadata de persistencia con .meta()

### DIFF
--- a/src/interfaces/actividad-usuario.ts
+++ b/src/interfaces/actividad-usuario.ts
@@ -23,29 +23,56 @@ export type TipoActividadUsuario = z.infer<typeof TipoActividadUsuarioSchema>;
  * `idCliente` del permiso activo); `idsAncestros` lo denormaliza api-datos
  * por hook a partir del `idCliente`. TTL 1 año sobre `inicio`.
  */
-export const ActividadUsuarioSchema = z.object({
-  _id: z.string().optional(),
-  // Discrimina inactividad vs periodo de actividad.
-  tipo: TipoActividadUsuarioSchema.optional(),
-  // Vínculo con el usuario.
-  idUsuario: z.string().optional(),
-  // Nombre de usuario denormalizado (lowercase), por si el usuario se borra.
-  usuario: z.string().optional(),
-  // Cliente del permiso activo al momento del evento.
-  idCliente: z.string().optional(),
-  // Cadena de clientes ancestros del idCliente, para roll-up por subárbol.
-  idsAncestros: z.array(z.string()).optional(),
-  // Inactividad: momento en que venció el cartel sin confirmación.
-  // Actividad: comienzo del ciclo de uso. Ancla del índice TTL.
-  inicio: z.string().optional(),
-  // Inactividad: momento en que volvió a confirmar (ausente = intervalo
-  // abierto). Actividad: momento del aviso de descanso. La duración es
-  // `fin - inicio`.
-  fin: z.string().optional(),
-  // Populate / Virtual
-  usuarioDoc: UsuarioSchema.optional(),
-  cliente: ClienteSchema.optional(),
-});
+// Metadata de persistencia por `.meta()` — convención documentada arriba de
+// `ProveedorSchema` en proveedor.ts.
+export const ActividadUsuarioSchema = z
+  .object({
+    _id: z.string().optional(),
+    // Discrimina inactividad vs periodo de actividad.
+    tipo: TipoActividadUsuarioSchema.optional(),
+    // Vínculo con el usuario.
+    idUsuario: z
+      .string()
+      .optional()
+      .meta({ 'x-bson': 'objectId', 'x-ref': 'UsuarioSchema' }),
+    // Nombre de usuario denormalizado (lowercase), por si el usuario se borra.
+    usuario: z.string().optional().meta({ 'x-setter': 'lowercase' }),
+    // Cliente del permiso activo al momento del evento.
+    idCliente: z
+      .string()
+      .optional()
+      .meta({ 'x-bson': 'objectId', 'x-ref': 'ClienteSchema' }),
+    // Cadena de clientes ancestros del idCliente, para roll-up por subárbol.
+    idsAncestros: z
+      .array(z.string())
+      .optional()
+      .meta({ 'x-bson': 'objectId', 'x-ref': 'ClienteSchema' }),
+    // Inactividad: momento en que venció el cartel sin confirmación.
+    // Actividad: comienzo del ciclo de uso. Ancla del índice TTL.
+    inicio: z.string().optional().meta({ 'x-bson': 'date' }),
+    // Inactividad: momento en que volvió a confirmar (ausente = intervalo
+    // abierto). Actividad: momento del aviso de descanso. La duración es
+    // `fin - inicio`.
+    fin: z.string().optional().meta({ 'x-bson': 'date' }),
+    // Populate / Virtual
+    usuarioDoc: UsuarioSchema.optional().meta({
+      'x-populate': {
+        ref: 'UsuarioSchema',
+        localField: 'idUsuario',
+        foreignField: '_id',
+        justOne: true,
+      },
+    }),
+    cliente: ClienteSchema.optional().meta({
+      'x-populate': {
+        ref: 'ClienteSchema',
+        localField: 'idCliente',
+        foreignField: '_id',
+        justOne: true,
+      },
+    }),
+  })
+  .meta({ 'x-collection': 'actividadusuarios' });
 export type IActividadUsuario = z.infer<typeof ActividadUsuarioSchema>;
 
 export const CreateActividadUsuarioSchema = ActividadUsuarioSchema.omit({

--- a/src/interfaces/alerta-boton-ble.ts
+++ b/src/interfaces/alerta-boton-ble.ts
@@ -3,21 +3,65 @@ import { ClienteSchema } from "./cliente";
 import { DispositivoLorawanSchema } from "./dispositivo-lorawan";
 import { LuminariaSchema } from "./luminaria";
 
-export const AlertaBotonBLESchema = z.object({
-  _id: z.string().optional(),
-  idCliente: z.string().optional(),
-  idsAncestros: z.array(z.string()).optional(),
-  fechaCreacion: z.string().optional(),
-  idDispositivoLorawan: z.string().optional(),
-  idLuminaria: z.string().optional(),
-  mac: z.string().optional(),
+// Metadata de persistencia por `.meta()` — convención documentada arriba de
+// `ProveedorSchema` en proveedor.ts.
+export const AlertaBotonBLESchema = z
+  .object({
+    _id: z.string().optional(),
+    idCliente: z
+      .string()
+      .optional()
+      .meta({ 'x-bson': 'objectId', 'x-ref': 'ClienteSchema' }),
+    idsAncestros: z
+      .array(z.string())
+      .optional()
+      .meta({ 'x-bson': 'objectId', 'x-ref': 'ClienteSchema' }),
+    fechaCreacion: z.string().optional().meta({ 'x-bson': 'date' }),
+    idDispositivoLorawan: z
+      .string()
+      .optional()
+      .meta({ 'x-bson': 'objectId', 'x-ref': 'DispositivoLorawanSchema' }),
+    idLuminaria: z
+      .string()
+      .optional()
+      .meta({ 'x-bson': 'objectId', 'x-ref': 'LuminariaSchema' }),
+    mac: z.string().optional(),
 
-  //Populate
-  dispositivoLorawan: DispositivoLorawanSchema.optional(),
-  luminaria: LuminariaSchema.optional(),
-  cliente: ClienteSchema.optional(),
-  ancestros: z.array(ClienteSchema).optional(),
-});
+    //Populate
+    dispositivoLorawan: DispositivoLorawanSchema.optional().meta({
+      'x-populate': {
+        ref: 'DispositivoLorawanSchema',
+        localField: 'idDispositivoLorawan',
+        foreignField: '_id',
+        justOne: true,
+      },
+    }),
+    luminaria: LuminariaSchema.optional().meta({
+      'x-populate': {
+        ref: 'LuminariaSchema',
+        localField: 'idLuminaria',
+        foreignField: '_id',
+        justOne: true,
+      },
+    }),
+    cliente: ClienteSchema.optional().meta({
+      'x-populate': {
+        ref: 'ClienteSchema',
+        localField: 'idCliente',
+        foreignField: '_id',
+        justOne: true,
+      },
+    }),
+    ancestros: z.array(ClienteSchema).optional().meta({
+      'x-populate': {
+        ref: 'ClienteSchema',
+        localField: 'idsAncestros',
+        foreignField: '_id',
+        justOne: false,
+      },
+    }),
+  })
+  .meta({ 'x-collection': 'alertabotonbles' });
 export type IAlertaBotonBLE = z.infer<typeof AlertaBotonBLESchema>;
 
 export const CreateAlertaBotonBLESchema = AlertaBotonBLESchema.omit({

--- a/src/interfaces/apikey.ts
+++ b/src/interfaces/apikey.ts
@@ -4,6 +4,8 @@ import { ClienteSchema } from './cliente';
 export const ModuloSchema = z.enum(['flotas', 'alarmas']);
 export type Modulo = z.infer<typeof ModuloSchema>;
 
+// Metadata de persistencia por `.meta()` — convención documentada arriba de
+// `ProveedorSchema` en proveedor.ts.
 export const ApikeySchema = z.object({
   _id: z.string().optional(),
   //
@@ -11,15 +13,43 @@ export const ApikeySchema = z.object({
   key: z.string().optional(),
   // Permisos
   global: z.boolean().optional(), // Si es global, no se le asignan clientes
-  idCreador: z.string().optional(), // Si es global. Es lo que puede ver ese cliente.
-  idClientes: z.array(z.string()).optional(), // Si no es global, se le asignan clientes
+  idCreador: z
+    .string()
+    .optional()
+    .meta({ 'x-bson': 'objectId', 'x-ref': 'ClienteSchema' }), // Si es global. Es lo que puede ver ese cliente.
+  idClientes: z
+    .array(z.string())
+    .optional()
+    .meta({ 'x-bson': 'objectId', 'x-ref': 'ClienteSchema' }), // Si no es global, se le asignan clientes
   modulos: z.array(ModuloSchema).optional(), // Flotas - Alarmas - etc
 
   // Populate
-  cliente: ClienteSchema.optional(),
+  cliente: ClienteSchema.optional().meta({
+    'x-populate': {
+      ref: 'ClienteSchema',
+      localField: 'idCreador',
+      foreignField: '_id',
+      justOne: true,
+    },
+  }),
+  // ancestros: sin `.meta()` a propósito — hallazgo (tarea 7, docs/MIGRACION.md
+  // §7): el schema.ts legacy (apikeys/schema.ts) SOLO declara los virtuals
+  // `cliente` (localField idCreador) y `clientes` (localField idClientes);
+  // "ancestros" no existe ahí ni en apikeys/meta.go (Virtuals no tiene esa
+  // clave). No es un @Prop ni un schema.virtual() real: no se popula nunca.
+  // No se anota un x-populate que mentiría sobre el comportamiento real, y no
+  // se borra el campo (cambiaría z.infer, §3 de CLAUDE.md). Exento puntual en
+  // `arraysQueNoSonArrays["Apikey"]["ancestros"]` de gestion-datos-go.
   ancestros: z.array(ClienteSchema).optional(), // Este sería el creador
-  clientes: z.array(ClienteSchema).optional(), // Estos son los elegidos para ver
-});
+  clientes: z.array(ClienteSchema).optional().meta({
+    'x-populate': {
+      ref: 'ClienteSchema',
+      localField: 'idClientes',
+      foreignField: '_id',
+      justOne: false,
+    },
+  }), // Estos son los elegidos para ver
+}).meta({ 'x-collection': 'apikeys' });
 export type IApikey = z.infer<typeof ApikeySchema>;
 
 export const CreateApikeySchema = ApikeySchema.omit({

--- a/src/interfaces/asignacion.ts
+++ b/src/interfaces/asignacion.ts
@@ -20,34 +20,103 @@ export const EntidadesSchema = z.enum([
 ]);
 export type IEntidades = z.infer<typeof EntidadesSchema>;
 
+// Metadata de persistencia por `.meta()` — convención documentada arriba de
+// `ProveedorSchema` en proveedor.ts.
 export const AsignacionSchema = z.object({
   _id: z.string().optional(),
   //
-  fechaAsignacion: z.string().optional(),
-  fechaDesasignacion: z.string().optional(),
-  idCliente: z.string().optional(),
-  idsAncestros: z.array(z.string()).optional(),
-  idUsuario: z.string().optional(),
+  fechaAsignacion: z.string().optional().meta({ 'x-bson': 'date' }),
+  fechaDesasignacion: z.string().optional().meta({ 'x-bson': 'date' }),
+  idCliente: z
+    .string()
+    .optional()
+    .meta({ 'x-bson': 'objectId', 'x-ref': 'ClienteSchema' }),
+  idsAncestros: z
+    .array(z.string())
+    .optional()
+    .meta({ 'x-bson': 'objectId', 'x-ref': 'ClienteSchema' }),
+  idUsuario: z
+    .string()
+    .optional()
+    .meta({ 'x-bson': 'objectId', 'x-ref': 'UsuarioSchema' }),
 
-  // Id de la entidad a la que se le asigna algo
-  idEntidadModificada: z.string().optional(),
+  // Id de la entidad a la que se le asigna algo. Polimórfico según
+  // tipoEntidadModificada (Chofer/Activo/Tracker/...): sin ref fijo en el
+  // legacy (@Prop sin `ref`), por eso sin x-ref acá tampoco.
+  idEntidadModificada: z.string().optional().meta({ 'x-bson': 'objectId' }),
   tipoEntidadModificada: EntidadesSchema.optional(),
   nombreEntidadModificada: z.string().optional(),
-  // Id de la entidad que se asigna a la otra
-  idEntidadAsignada: z.string().optional(),
+  // Id de la entidad que se asigna a la otra. Mismo polimorfismo que arriba.
+  idEntidadAsignada: z.string().optional().meta({ 'x-bson': 'objectId' }),
   tipoEntidadAsignada: EntidadesSchema.optional(),
   nombreEntidadAsignada: z.string().optional(),
 
   // Populate
-  cliente: ClienteSchema.optional(),
-  usuario: UsuarioSchema.optional(),
-  choferModificado: UsuarioSchema.optional(),
-  activoModificado: ActivoSchema.optional(),
-  trackerModificado: TrackerSchema.optional(),
-  choferAsignado: UsuarioSchema.optional(),
-  activoAsignado: ActivoSchema.optional(),
-  trackerAsignado: TrackerSchema.optional(),
-});
+  cliente: ClienteSchema.optional().meta({
+    'x-populate': {
+      ref: 'ClienteSchema',
+      localField: 'idCliente',
+      foreignField: '_id',
+      justOne: true,
+    },
+  }),
+  usuario: UsuarioSchema.optional().meta({
+    'x-populate': {
+      ref: 'UsuarioSchema',
+      localField: 'idUsuario',
+      foreignField: '_id',
+      justOne: true,
+    },
+  }),
+  choferModificado: UsuarioSchema.optional().meta({
+    'x-populate': {
+      ref: 'UsuarioSchema',
+      localField: 'idEntidadModificada',
+      foreignField: '_id',
+      justOne: true,
+    },
+  }),
+  activoModificado: ActivoSchema.optional().meta({
+    'x-populate': {
+      ref: 'ActivoSchema',
+      localField: 'idEntidadModificada',
+      foreignField: '_id',
+      justOne: true,
+    },
+  }),
+  trackerModificado: TrackerSchema.optional().meta({
+    'x-populate': {
+      ref: 'TrackerSchema',
+      localField: 'idEntidadModificada',
+      foreignField: '_id',
+      justOne: true,
+    },
+  }),
+  choferAsignado: UsuarioSchema.optional().meta({
+    'x-populate': {
+      ref: 'UsuarioSchema',
+      localField: 'idEntidadAsignada',
+      foreignField: '_id',
+      justOne: true,
+    },
+  }),
+  activoAsignado: ActivoSchema.optional().meta({
+    'x-populate': {
+      ref: 'ActivoSchema',
+      localField: 'idEntidadAsignada',
+      foreignField: '_id',
+      justOne: true,
+    },
+  }),
+  trackerAsignado: TrackerSchema.optional().meta({
+    'x-populate': {
+      ref: 'TrackerSchema',
+      localField: 'idEntidadAsignada',
+      foreignField: '_id',
+      justOne: true,
+    },
+  }),
+}).meta({ 'x-collection': 'asignacions' });
 export type IAsignacion = z.infer<typeof AsignacionSchema>;
 
 export const CreateAsignacionSchema = AsignacionSchema.omit({

--- a/src/interfaces/auditoria.ts
+++ b/src/interfaces/auditoria.ts
@@ -5,26 +5,66 @@ import { UsuarioSchema } from './usuario';
 export const AccionAuditoriaSchema = z.enum(['Crear', 'Editar', 'Eliminar', 'Ver']);
 export type AccionAuditoria = z.infer<typeof AccionAuditoriaSchema>;
 
-export const AuditoriaSchema = z.object({
-  _id: z.string().optional(),
-  idCliente: z.string().optional(),
-  idsAncestros: z.array(z.string()).optional(),
-  fechaCreacion: z.string().optional(),
-  idUsuario: z.string().optional(),
-  nombreUsuario: z.string().optional(), // se persiste por si se borra el usuario
-  entidad: z.string().optional(), // 'activos', 'usuarios', 'clientes', etc.
-  subPath: z.string().optional(), // Lo que sigue en la ruta despues de la entidad
-  idEntidad: z.string().optional(), // ID del documento afectado
-  accion: AccionAuditoriaSchema.optional(),
-  cambios: z.record(z.string(), z.unknown()).optional(), // { campo: valorNuevo }
-  valoresAnteriores: z.record(z.string(), z.unknown()).optional(), // { campo: valorAntes } — solo para Editar
-  camposModificados: z.array(z.string()).optional(), // ['nombre', 'descripcion'] — indexable
+// Metadata de persistencia por `.meta()` — convención documentada arriba de
+// `ProveedorSchema` en proveedor.ts.
+export const AuditoriaSchema = z
+  .object({
+    _id: z.string().optional(),
+    idCliente: z
+      .string()
+      .optional()
+      .meta({ 'x-bson': 'objectId', 'x-ref': 'ClienteSchema' }),
+    idsAncestros: z
+      .array(z.string())
+      .optional()
+      .meta({ 'x-bson': 'objectId', 'x-ref': 'ClienteSchema' }),
+    fechaCreacion: z.string().optional().meta({ 'x-bson': 'date' }),
+    idUsuario: z
+      .string()
+      .optional()
+      .meta({ 'x-bson': 'objectId', 'x-ref': 'UsuarioSchema' }),
+    nombreUsuario: z.string().optional(), // se persiste por si se borra el usuario
+    entidad: z.string().optional(), // 'activos', 'usuarios', 'clientes', etc.
+    subPath: z.string().optional(), // Lo que sigue en la ruta despues de la entidad
+    // @Prop({type: String}) en el legacy — sin casting, no es un ObjectId.
+    idEntidad: z.string().optional(), // ID del documento afectado
+    accion: AccionAuditoriaSchema.optional(),
+    // @Prop({type: Object}) en el legacy: Mixed, Mongoose no castea adentro.
+    cambios: z.record(z.string(), z.unknown()).optional().meta({
+      'x-bson': 'mixed',
+    }), // { campo: valorNuevo }
+    valoresAnteriores: z.record(z.string(), z.unknown()).optional().meta({
+      'x-bson': 'mixed',
+    }), // { campo: valorAntes } — solo para Editar
+    camposModificados: z.array(z.string()).optional(), // ['nombre', 'descripcion'] — indexable
 
-  // Populate
-  usuario: UsuarioSchema.optional(),
-  cliente: ClienteSchema.optional(),
-  ancestros: z.array(ClienteSchema).optional(),
-});
+    // Populate
+    usuario: UsuarioSchema.optional().meta({
+      'x-populate': {
+        ref: 'UsuarioSchema',
+        localField: 'idUsuario',
+        foreignField: '_id',
+        justOne: true,
+      },
+    }),
+    cliente: ClienteSchema.optional().meta({
+      'x-populate': {
+        ref: 'ClienteSchema',
+        localField: 'idCliente',
+        foreignField: '_id',
+        justOne: true,
+      },
+    }),
+    ancestros: z.array(ClienteSchema).optional().meta({
+      'x-populate': {
+        ref: 'ClienteSchema',
+        localField: 'idsAncestros',
+        foreignField: '_id',
+        justOne: false,
+      },
+    }),
+  })
+  .meta({ 'x-collection': 'auditorias' });
 export type IAuditoria = z.infer<typeof AuditoriaSchema>;
 
 export const CreateAuditoriaSchema = AuditoriaSchema.omit({

--- a/src/interfaces/boton-bluetooth.ts
+++ b/src/interfaces/boton-bluetooth.ts
@@ -2,21 +2,55 @@ import { z } from 'zod';
 import { ClienteSchema } from './cliente';
 import { ModeloDispositivoSchema } from './modelo-dispositivo';
 
-export const BotonBluetoothSchema = z.object({
-  _id: z.string().optional(),
-  idModeloDispositivo: z.string().optional(),
+// Metadata de persistencia por `.meta()` — convención documentada arriba de
+// `ProveedorSchema` en proveedor.ts.
+export const BotonBluetoothSchema = z
+  .object({
+    _id: z.string().optional(),
+    idModeloDispositivo: z
+      .string()
+      .optional()
+      .meta({ 'x-bson': 'objectId', 'x-ref': 'ModeloDispositivoSchema' }),
 
-  fechaCreacion: z.string().optional(),
-  idCliente: z.string().optional(),
-  idsAncestros: z.array(z.string()).optional(),
-  mac: z.string().optional(),
-  serialNumber: z.string().optional(),
+    fechaCreacion: z.string().optional().meta({ 'x-bson': 'date' }),
+    idCliente: z
+      .string()
+      .optional()
+      .meta({ 'x-bson': 'objectId', 'x-ref': 'ClienteSchema' }),
+    idsAncestros: z
+      .array(z.string())
+      .optional()
+      .meta({ 'x-bson': 'objectId', 'x-ref': 'ClienteSchema' }),
+    mac: z.string().optional(),
+    serialNumber: z.string().optional(),
 
-  //Populate
-  cliente: ClienteSchema.optional(),
-  ancestros: z.array(ClienteSchema).optional(),
-  modeloDispositivo: ModeloDispositivoSchema.optional(),
-});
+    //Populate
+    cliente: ClienteSchema.optional().meta({
+      'x-populate': {
+        ref: 'ClienteSchema',
+        localField: 'idCliente',
+        foreignField: '_id',
+        justOne: true,
+      },
+    }),
+    ancestros: z.array(ClienteSchema).optional().meta({
+      'x-populate': {
+        ref: 'ClienteSchema',
+        localField: 'idsAncestros',
+        foreignField: '_id',
+        justOne: false,
+      },
+    }),
+    modeloDispositivo: ModeloDispositivoSchema.optional().meta({
+      'x-populate': {
+        ref: 'ModeloDispositivoSchema',
+        localField: 'idModeloDispositivo',
+        foreignField: '_id',
+        justOne: true,
+      },
+    }),
+  })
+  .meta({ 'x-collection': 'botonbluetooths' });
 export type IBotonBluetooth = z.infer<typeof BotonBluetoothSchema>;
 
 export const CreateBotonBluetoothSchema = BotonBluetoothSchema.omit({

--- a/src/interfaces/camara.ts
+++ b/src/interfaces/camara.ts
@@ -39,28 +39,69 @@ export const CredencialesDahuaSchema = z.object({
 });
 export type ICredencialesDahua = z.infer<typeof CredencialesDahuaSchema>;
 
-export const CamaraSchema = z.object({
-  _id: z.string().optional(),
-  idCliente: z.string().optional(),
-  idsAncestros: z.array(z.string()).optional(),
-  fechaCreacion: z.string().optional(),
-  identificacion: z.string().optional(),
-  canales: z.array(CanalesCamaraSchema).optional(),
-  idModeloDispositivo: z.string().optional(),
-  tipo: TipoCamaraSchema.optional(),
-  numeroSerie: z.string().optional(),
-  host: z.string().optional(),
-  puertoRTSP: z.number().optional(),
-  puertoHTTP: z.number().optional(),
-  usuario: z.string().optional(),
-  password: z.string().optional(),
-  claveDeEncriptacion: z.string().optional(),
-  credencialesDahua: CredencialesDahuaSchema.optional(),
-  // Populate
-  cliente: ClienteSchema.optional(),
-  ancestros: z.array(ClienteSchema).optional(),
-  modeloDispositivo: ModeloDispositivoSchema.optional(),
-});
+// Metadata de persistencia por `.meta()` — convención documentada arriba de
+// `ProveedorSchema` en proveedor.ts.
+export const CamaraSchema = z
+  .object({
+    _id: z.string().optional(),
+    idCliente: z
+      .string()
+      .optional()
+      .meta({ 'x-bson': 'objectId', 'x-ref': 'ClienteSchema' }),
+    idsAncestros: z
+      .array(z.string())
+      .optional()
+      .meta({ 'x-bson': 'objectId', 'x-ref': 'ClienteSchema' }),
+    fechaCreacion: z.string().optional().meta({ 'x-bson': 'date' }),
+    identificacion: z.string().optional(),
+    // @Prop({type: [Object]}) en el legacy: cada elemento es Mixed, Mongoose
+    // no castea adentro.
+    canales: z.array(CanalesCamaraSchema).optional().meta({
+      'x-bson': 'mixed',
+    }),
+    idModeloDispositivo: z
+      .string()
+      .optional()
+      .meta({ 'x-bson': 'objectId', 'x-ref': 'ModeloDispositivoSchema' }),
+    tipo: TipoCamaraSchema.optional(),
+    numeroSerie: z.string().optional(),
+    host: z.string().optional(),
+    puertoRTSP: z.number().optional(),
+    puertoHTTP: z.number().optional(),
+    usuario: z.string().optional(),
+    password: z.string().optional(),
+    claveDeEncriptacion: z.string().optional(),
+    // @Prop({type: Object}) en el legacy: Mixed, Mongoose no castea adentro.
+    credencialesDahua: CredencialesDahuaSchema.optional().meta({
+      'x-bson': 'mixed',
+    }),
+    // Populate
+    cliente: ClienteSchema.optional().meta({
+      'x-populate': {
+        ref: 'ClienteSchema',
+        localField: 'idCliente',
+        foreignField: '_id',
+        justOne: true,
+      },
+    }),
+    ancestros: z.array(ClienteSchema).optional().meta({
+      'x-populate': {
+        ref: 'ClienteSchema',
+        localField: 'idsAncestros',
+        foreignField: '_id',
+        justOne: false,
+      },
+    }),
+    modeloDispositivo: ModeloDispositivoSchema.optional().meta({
+      'x-populate': {
+        ref: 'ModeloDispositivoSchema',
+        localField: 'idModeloDispositivo',
+        foreignField: '_id',
+        justOne: true,
+      },
+    }),
+  })
+  .meta({ 'x-collection': 'camaras' });
 export type ICamara = z.infer<typeof CamaraSchema>;
 
 export const CreateCamaraSchema = CamaraSchema.omit({

--- a/src/interfaces/categoria-evento.ts
+++ b/src/interfaces/categoria-evento.ts
@@ -14,25 +14,49 @@ export const TipoCategoriaSchema = z.enum([
 ]);
 export type TipoCategoria = z.infer<typeof TipoCategoriaSchema>;
 
-export const CategoriaEventoSchema = z.object({
-  _id: z.string().optional(),
-  //
-  nombre: z.string().optional(), // BUR
-  prioridad: z.number().optional(), // 100
-  color: z.string().optional(),
-  notificar: z.boolean().optional(),
-  atender: z.boolean().optional(),
-  noDerivar: z.boolean().optional(),
-  sonido: SonidoEventoSchema.optional(),
-  modulo: TipoCategoriaSchema.optional(),
-  idCliente: z.string().optional(),
-  idsAncestros: z.array(z.string()).optional(),
-  default: z.boolean().optional(),
-  global: z.boolean().optional(),
-  //Populate
-  cliente: ClienteSchema.optional(),
-  ancestros: z.array(ClienteSchema).optional(),
-});
+// Metadata de persistencia por `.meta()` — convención documentada arriba de
+// `ProveedorSchema` en proveedor.ts.
+export const CategoriaEventoSchema = z
+  .object({
+    _id: z.string().optional(),
+    //
+    nombre: z.string().optional(), // BUR
+    prioridad: z.number().optional(), // 100
+    color: z.string().optional(),
+    notificar: z.boolean().optional(),
+    atender: z.boolean().optional(),
+    noDerivar: z.boolean().optional(),
+    sonido: SonidoEventoSchema.optional(),
+    modulo: TipoCategoriaSchema.optional(),
+    idCliente: z
+      .string()
+      .optional()
+      .meta({ 'x-bson': 'objectId', 'x-ref': 'ClienteSchema' }),
+    idsAncestros: z
+      .array(z.string())
+      .optional()
+      .meta({ 'x-bson': 'objectId', 'x-ref': 'ClienteSchema' }),
+    default: z.boolean().optional(),
+    global: z.boolean().optional(),
+    //Populate
+    cliente: ClienteSchema.optional().meta({
+      'x-populate': {
+        ref: 'ClienteSchema',
+        localField: 'idCliente',
+        foreignField: '_id',
+        justOne: true,
+      },
+    }),
+    ancestros: z.array(ClienteSchema).optional().meta({
+      'x-populate': {
+        ref: 'ClienteSchema',
+        localField: 'idsAncestros',
+        foreignField: '_id',
+        justOne: false,
+      },
+    }),
+  })
+  .meta({ 'x-collection': 'categoriaeventos' });
 export type ICategoriaEvento = z.infer<typeof CategoriaEventoSchema>;
 
 export const CreateCategoriaEventoSchema = CategoriaEventoSchema.omit({

--- a/src/interfaces/certificado-entidad.ts
+++ b/src/interfaces/certificado-entidad.ts
@@ -6,23 +6,63 @@ import { DispositivoAlarmaSchema } from './dispositivo-alarma';
 import type { IEventoGenerico } from './evento-generico';
 import { TrackerSchema } from './tracker';
 
-export const CertificadoEntidadSchema = z.object({
-  _id: z.string().optional(),
-  //
-  idCliente: z.string().optional(),
-  idsAncestros: z.array(z.string()).optional(),
-  //
-  idEntidad: z.string().optional(),
-  fechaComienzo: z.string().optional(),
-  fechaEmision: z.string().optional(),
-  eventosRegistrados: z.array(z.custom<IEventoGenerico>()).optional(),
-  codigosEsperados: z.array(CodigoDispositivoSchema).optional(),
-  // Populate
-  tracker: TrackerSchema.optional(),
-  activo: ActivoSchema.optional(),
-  alarma: DispositivoAlarmaSchema.optional(),
-  cliente: ClienteSchema.optional(),
-});
+// Metadata de persistencia por `.meta()` — convención documentada arriba de
+// `ProveedorSchema` en proveedor.ts.
+export const CertificadoEntidadSchema = z
+  .object({
+    _id: z.string().optional(),
+    //
+    idCliente: z
+      .string()
+      .optional()
+      .meta({ 'x-bson': 'objectId', 'x-ref': 'ClienteSchema' }),
+    idsAncestros: z
+      .array(z.string())
+      .optional()
+      .meta({ 'x-bson': 'objectId', 'x-ref': 'ClienteSchema' }),
+    //
+    // Polimórfico (tracker / activo / alarma): sin ref fijo en el legacy
+    // (@Prop sin `ref`), por eso sin x-ref acá tampoco.
+    idEntidad: z.string().optional().meta({ 'x-bson': 'objectId' }),
+    fechaComienzo: z.string().optional().meta({ 'x-bson': 'date' }),
+    fechaEmision: z.string().optional().meta({ 'x-bson': 'date' }),
+    eventosRegistrados: z.array(z.custom<IEventoGenerico>()).optional(),
+    codigosEsperados: z.array(CodigoDispositivoSchema).optional(),
+    // Populate
+    tracker: TrackerSchema.optional().meta({
+      'x-populate': {
+        ref: 'TrackerSchema',
+        localField: 'idEntidad',
+        foreignField: '_id',
+        justOne: true,
+      },
+    }),
+    activo: ActivoSchema.optional().meta({
+      'x-populate': {
+        ref: 'ActivoSchema',
+        localField: 'idEntidad',
+        foreignField: '_id',
+        justOne: true,
+      },
+    }),
+    alarma: DispositivoAlarmaSchema.optional().meta({
+      'x-populate': {
+        ref: 'DispositivoAlarmaSchema',
+        localField: 'idEntidad',
+        foreignField: '_id',
+        justOne: true,
+      },
+    }),
+    cliente: ClienteSchema.optional().meta({
+      'x-populate': {
+        ref: 'ClienteSchema',
+        localField: 'idCliente',
+        foreignField: '_id',
+        justOne: true,
+      },
+    }),
+  })
+  .meta({ 'x-collection': 'certificadoentidads' });
 export type ICertificadoEntidad = z.infer<typeof CertificadoEntidadSchema>;
 
 export const CreateCertificadoEntidadSchema = CertificadoEntidadSchema.omit({

--- a/src/interfaces/client.ts
+++ b/src/interfaces/client.ts
@@ -1,5 +1,7 @@
 import { z } from 'zod';
 
+// Metadata de persistencia por `.meta()` — convención documentada arriba de
+// `ProveedorSchema` en proveedor.ts.
 export const ClientSchema = z.object({
   _id: z.string().optional(),
   id: z.string().optional(),
@@ -8,7 +10,7 @@ export const ClientSchema = z.object({
   redirectUris: z.array(z.string()).optional(),
   accessTokenLifetime: z.number().optional(),
   refreshTokenLifetime: z.number().optional(),
-});
+}).meta({ 'x-collection': 'clients' });
 export type IClient = z.infer<typeof ClientSchema>;
 
 export const CreateClientSchema = ClientSchema.omit({ _id: true });

--- a/src/interfaces/cliente.ts
+++ b/src/interfaces/cliente.ts
@@ -334,33 +334,63 @@ export const ConfigClienteSchema = z.object({
 });
 export type IConfigCliente = z.infer<typeof ConfigClienteSchema>;
 
+// Metadata de persistencia por `.meta()` — convención documentada arriba de
+// `ProveedorSchema` en proveedor.ts.
 export const ClienteSchema = z.object({
   _id: z.string().optional(),
-  idsAncestros: z.array(z.string()).optional(),
-  idPadre: z.string().optional(),
+  idsAncestros: z
+    .array(z.string())
+    .optional()
+    .meta({ 'x-bson': 'objectId', 'x-ref': 'ClienteSchema' }),
+  idPadre: z
+    .string()
+    .optional()
+    .meta({ 'x-bson': 'objectId', 'x-ref': 'ClienteSchema' }),
   activo: z.boolean().optional(),
   nombre: z.string().optional(),
-  fechaCreacion: z.string().optional(),
+  fechaCreacion: z.string().optional().meta({ 'x-bson': 'date' }),
   nivel: z.number().optional(),
-  config: ConfigClienteSchema.optional(),
+  // @Prop({type: Object, default: {}}) en el legacy: Mixed, Mongoose no
+  // castea adentro.
+  config: ConfigClienteSchema.optional().meta({ 'x-bson': 'mixed' }),
   tipoCliente: TipoClienteSchema.optional(),
   estadoDeCuenta: EstadoCuentaSchema.optional(),
   numeroCliente: z.string().optional(),
   habilitado: z.boolean().optional(),
   apikeyBotonBLE: z.string().optional(),
+  // @Prop({type: Object}) en el legacy: Mixed.
   poligono: z
     .object({
       type: z.literal('MultiPolygon'),
       coordinates: z.array(z.array(z.array(PuntoCoord))),
     })
-    .optional(),
-  mapLayers: z.array(LayerMapaPersonalizadoSchema).optional(), //Capas de mapa personalizadas
+    .optional()
+    .meta({ 'x-bson': 'mixed' }),
+  // @Prop({type: [Object]}) en el legacy: array real de Mixed.
+  mapLayers: z
+    .array(LayerMapaPersonalizadoSchema)
+    .optional()
+    .meta({ 'x-bson': 'mixed' }), //Capas de mapa personalizadas
   // Populate
   get padre() {
-    return ClienteSchema.optional();
+    return ClienteSchema.optional().meta({
+      'x-populate': {
+        ref: 'ClienteSchema',
+        localField: 'idPadre',
+        foreignField: '_id',
+        justOne: true,
+      },
+    });
   },
   get ancestros() {
-    return z.array(ClienteSchema).optional();
+    return z.array(ClienteSchema).optional().meta({
+      'x-populate': {
+        ref: 'ClienteSchema',
+        localField: 'idsAncestros',
+        foreignField: '_id',
+        justOne: false,
+      },
+    });
   },
 }).meta({ 'x-collection': 'clientes' });
 export type ICliente = z.infer<typeof ClienteSchema>;

--- a/src/interfaces/codigos-dispositivo.ts
+++ b/src/interfaces/codigos-dispositivo.ts
@@ -69,20 +69,48 @@ export const TipoDispositivoSchema = z.enum([
 ]);
 export type TipoDispositivo = z.infer<typeof TipoDispositivoSchema>;
 
-export const CodigosDispositivoSchema = z.object({
-  _id: z.string().optional(),
-  //
-  nombre: z.string().optional(),
-  tipo: TipoDispositivoSchema.optional(),
-  codigos: z.array(CodigoDispositivoSchema).optional(),
-  codigosEntrada: z.array(CodigoDispositivoEntradaSchema).optional(),
-  idCliente: z.string().optional(),
-  idsAncestros: z.array(z.string()).optional(),
-  global: z.boolean().optional(),
-  // Populate
-  cliente: ClienteSchema.optional(),
-  ancestros: z.array(ClienteSchema).optional(),
-});
+export const CodigosDispositivoSchema = z
+  .object({
+    _id: z.string().optional(),
+    //
+    nombre: z.string().optional(),
+    tipo: TipoDispositivoSchema.optional(),
+    // @Prop({type: [Object]}) en el legacy: Mixed, sin casteo adentro (igual
+    // codigosEntrada).
+    codigos: z.array(CodigoDispositivoSchema).optional().meta({
+      'x-bson': 'mixed',
+    }),
+    codigosEntrada: z.array(CodigoDispositivoEntradaSchema).optional().meta({
+      'x-bson': 'mixed',
+    }),
+    idCliente: z
+      .string()
+      .optional()
+      .meta({ 'x-bson': 'objectId', 'x-ref': 'ClienteSchema' }),
+    idsAncestros: z
+      .array(z.string())
+      .optional()
+      .meta({ 'x-bson': 'objectId', 'x-ref': 'ClienteSchema' }),
+    global: z.boolean().optional(),
+    // Populate
+    cliente: ClienteSchema.optional().meta({
+      'x-populate': {
+        ref: 'ClienteSchema',
+        localField: 'idCliente',
+        foreignField: '_id',
+        justOne: true,
+      },
+    }),
+    ancestros: z.array(ClienteSchema).optional().meta({
+      'x-populate': {
+        ref: 'ClienteSchema',
+        localField: 'idsAncestros',
+        foreignField: '_id',
+        justOne: false,
+      },
+    }),
+  })
+  .meta({ 'x-collection': 'codigosdispositivos' });
 export type ICodigosDispositivo = z.infer<typeof CodigosDispositivoSchema>;
 
 export const CodigosDispositivoCacheSchema = CodigosDispositivoSchema.omit({

--- a/src/interfaces/comando.ts
+++ b/src/interfaces/comando.ts
@@ -39,16 +39,32 @@ export type IObjetivoComando = z.infer<typeof ObjetivoComandoSchema>;
 // Populates intra-SCC como z.custom (import type-only): un schema real acá
 // arrastra el shape completo del ciclo y revienta la serialización de
 // declarations (TS7056) acá y en los consumidores NestJS.
+//
+// Metadata de persistencia por `.meta()` — convención documentada arriba de
+// `ProveedorSchema` en proveedor.ts.
 export const ComandoSchema = z.object({
   _id: z.string().optional(),
-  idCliente: z.string().optional(),
-  idsAncestros: z.array(z.string()).optional(),
-  idUsuario: z.string().optional(),
+  idCliente: z
+    .string()
+    .optional()
+    .meta({ 'x-bson': 'objectId', 'x-ref': 'ClienteSchema' }),
+  idsAncestros: z
+    .array(z.string())
+    .optional()
+    .meta({ 'x-bson': 'objectId', 'x-ref': 'ClienteSchema' }),
+  idUsuario: z
+    .string()
+    .optional()
+    .meta({ 'x-bson': 'objectId', 'x-ref': 'UsuarioSchema' }),
   nombre: z.string().optional(),
   descripcion: z.string().optional(),
-  fechaCreacion: z.string().optional(),
+  fechaCreacion: z.string().optional().meta({ 'x-bson': 'date' }),
   payload: z.string().optional(),
-  datosExtra: z.record(z.string(), z.any()).optional(),
+  // Mixed: metadata arbitraria — feature aplicar-config-por-ACK del legacy
+  // (configPatch/autoRespondeUplink/confirmadoPor).
+  datosExtra: z.record(z.string(), z.any()).optional().meta({
+    'x-bson': 'mixed',
+  }),
   // Tracker
   idTracker: z.string().optional(),
   respuesta: z.string().optional(),
@@ -57,20 +73,58 @@ export const ComandoSchema = z.object({
   deveui: z.string().optional(),
   puerto: z.number().optional(),
   //
-  fechaActualizacion: z.string().optional(),
-  estado: EstadoComandoSchema.optional(), // Default: Enviado
+  fechaActualizacion: z.string().optional().meta({ 'x-bson': 'date' }),
+  // @Prop({type: Object, default: 'Enviado'}) en el legacy: Mixed, Mongoose
+  // no castea adentro pese a que zod lo tipa como enum.
+  estado: EstadoComandoSchema.optional().meta({ 'x-bson': 'mixed' }), // Default: Enviado
   fallos: z.number().optional(),
   fCnt: z.string().optional(),
   idChirpstack: z.string().optional(),
-  objetivo: ObjetivoComandoSchema.optional(), // Procedencia: desde qué nivel/entidad se originó (luminaria/grupo/puesta/punto-alim)
+  // @Prop({type: Object}) en el legacy: Mixed, Mongoose no castea adentro.
+  objetivo: ObjetivoComandoSchema.optional().meta({ 'x-bson': 'mixed' }), // Procedencia: desde qué nivel/entidad se originó (luminaria/grupo/puesta/punto-alim)
 
   // Virtuals
-  tracker: z.custom<ITracker>().optional(),
-  cliente: ClienteSchema.optional(),
-  ancestros: z.array(ClienteSchema).optional(),
-  usuario: z.custom<IUsuario>().optional(),
-  dispositivo: z.custom<IDispositivoLorawan>().optional(),
-});
+  tracker: z.custom<ITracker>().optional().meta({
+    'x-populate': {
+      ref: 'TrackerSchema',
+      localField: 'idTracker',
+      foreignField: '_id',
+      justOne: true,
+    },
+  }),
+  cliente: ClienteSchema.optional().meta({
+    'x-populate': {
+      ref: 'ClienteSchema',
+      localField: 'idCliente',
+      foreignField: '_id',
+      justOne: true,
+    },
+  }),
+  ancestros: z.array(ClienteSchema).optional().meta({
+    'x-populate': {
+      ref: 'ClienteSchema',
+      localField: 'idsAncestros',
+      foreignField: '_id',
+      justOne: false,
+    },
+  }),
+  usuario: z.custom<IUsuario>().optional().meta({
+    'x-populate': {
+      ref: 'UsuarioSchema',
+      localField: 'idUsuario',
+      foreignField: '_id',
+      justOne: true,
+    },
+  }),
+  dispositivo: z.custom<IDispositivoLorawan>().optional().meta({
+    'x-populate': {
+      ref: 'DispositivoLorawanSchema',
+      localField: 'deveui',
+      foreignField: 'deveui',
+      justOne: true,
+    },
+  }),
+}).meta({ 'x-collection': 'comandos' });
 
 /**
  * Interface hand-written (misma forma que el schema): los tipos de entidad del

--- a/src/interfaces/config-deseada.ts
+++ b/src/interfaces/config-deseada.ts
@@ -115,32 +115,68 @@ export interface IConfigDeseadaBase<T extends keyof MapaConfigDeseada> {
   ancestros?: ICliente[];
 }
 
+// Metadata de persistencia por `.meta()` — convención documentada arriba de
+// `ProveedorSchema` en proveedor.ts. `x-collection` va en el z.union() de
+// ConfigDeseadaSchema más abajo (una sola colección para las 3 variantes).
 const ConfigDeseadaCamposSchema = z.object({
   // Info autogenerada
   _id: z.string().optional(),
-  idCliente: z.string().optional(),
-  idsAncestros: z.array(z.string()).optional(),
+  idCliente: z
+    .string()
+    .optional()
+    .meta({ 'x-bson': 'objectId', 'x-ref': 'ClienteSchema' }),
+  idsAncestros: z
+    .array(z.string())
+    .optional()
+    .meta({ 'x-bson': 'objectId', 'x-ref': 'ClienteSchema' }),
 
   // Info de carga
-  fechaCreacion: z.string().optional(), // Default: Date.now
-  fechaActualizacion: z.string().optional(), // Última vez que cambió el contenido de la configuración deseada
-  fechaAplicacion: z.string().optional(),
+  fechaCreacion: z.string().optional().meta({ 'x-bson': 'date' }), // Default: Date.now
+  fechaActualizacion: z.string().optional().meta({ 'x-bson': 'date' }), // Última vez que cambió el contenido de la configuración deseada
+  fechaAplicacion: z.string().optional().meta({ 'x-bson': 'date' }),
+  // String plano (unique sparse — ver comentario de configdeseadas/meta.go
+  // en gestion-datos-go): sin x-bson. Se popula bajo el nombre "dispositivo"
+  // (virtual con nombre distinto al path) matcheando contra
+  // dispositivolorawans._id.
   idEntidad: z.string().optional(),
   estado: EstadoSchema.optional(),
 
   // Reconciliación (escritos por el cron reconciliador)
-  diffs: z.array(DiffConfigSchema).optional(), // campos en discrepancia tras la última comparación
-  ultimaComparacion: z.string().optional(), // ISO timestamp de la última comparación realizada por el reconciliador
-  ultimaReconciliacion: z.string().optional(), // ISO timestamp del último set disparado
+  // @Prop({type:[Object], default: undefined}): Mixed, Mongoose no lo
+  // materializa como [] (exento en arraysQueNoSonArrays del drift test).
+  diffs: z.array(DiffConfigSchema).optional().meta({ 'x-bson': 'mixed' }), // campos en discrepancia tras la última comparación
+  ultimaComparacion: z.string().optional().meta({ 'x-bson': 'date' }), // ISO timestamp de la última comparación realizada por el reconciliador
+  ultimaReconciliacion: z.string().optional().meta({ 'x-bson': 'date' }), // ISO timestamp del último set disparado
   reintentosReconciliacion: z.number().optional(), // counter para back-off
-  bloqueadoHasta: z.string().optional(), // ISO. Si > now no se reintenta (circuit breaker)
+  bloqueadoHasta: z.string().optional().meta({ 'x-bson': 'date' }), // ISO. Si > now no se reintenta (circuit breaker)
 
   // Virtuals
   // z.custom para no arrastrar el shape completo del dispositivo al
   // declaration emit (TS7056 en ConfigDeseadaSchema).
-  dispositivo: z.custom<IDispositivoLorawan>().optional(),
-  cliente: ClienteSchema.optional(),
-  ancestros: z.array(ClienteSchema).optional(),
+  dispositivo: z.custom<IDispositivoLorawan>().optional().meta({
+    'x-populate': {
+      ref: 'DispositivoLorawanSchema',
+      localField: 'idEntidad',
+      foreignField: '_id',
+      justOne: true,
+    },
+  }),
+  cliente: ClienteSchema.optional().meta({
+    'x-populate': {
+      ref: 'ClienteSchema',
+      localField: 'idCliente',
+      foreignField: '_id',
+      justOne: true,
+    },
+  }),
+  ancestros: z.array(ClienteSchema).optional().meta({
+    'x-populate': {
+      ref: 'ClienteSchema',
+      localField: 'idsAncestros',
+      foreignField: '_id',
+      justOne: false,
+    },
+  }),
 });
 
 const VarianteConfigDeseadaGPE = ConfigDeseadaCamposSchema.extend({
@@ -163,11 +199,13 @@ const VarianteConfigDeseadaACTIS = ConfigDeseadaCamposSchema.extend({
  *  TIPO DISCRIMINADO (TYPE-SAFE) - READ
  * ────────────────────────────────────────────────*/
 
-export const ConfigDeseadaSchema = z.union([
-  VarianteConfigDeseadaGPE,
-  VarianteConfigDeseadaWellness,
-  VarianteConfigDeseadaACTIS,
-]);
+export const ConfigDeseadaSchema = z
+  .union([
+    VarianteConfigDeseadaGPE,
+    VarianteConfigDeseadaWellness,
+    VarianteConfigDeseadaACTIS,
+  ])
+  .meta({ 'x-collection': 'configdeseadas' });
 
 export type IConfigDeseada =
   | IConfigDeseadaBase<'Luminaria GPE'>

--- a/src/interfaces/config-evento-usuario.ts
+++ b/src/interfaces/config-evento-usuario.ts
@@ -78,6 +78,9 @@ export const CondicionNotificacionSchema = z.object({
         .optional(),
       ubicacion: z
         .object({
+          // Dentro de `condicion`, que es Mixed: Mongoose NO castea este path
+          // (meta.go lo dice explícito), así que NO lleva x-bson pese a ser
+          // un id de Mongo en la práctica — sería un casteo inventado.
           idUbicacion: z.string(),
           dentro: z.boolean().optional(),
           fuera: z.boolean().optional(),
@@ -85,8 +88,17 @@ export const CondicionNotificacionSchema = z.object({
            * Comprueba que el activo esté asignado a una emergencia medica para generar el evento
            */
           soloEnEmergencias: z.boolean().optional(),
-          // Virtual
-          ubicacion: z.custom<IUbicacion>().optional(),
+          // Virtual. Path anidado: el motor de populate actual (populate.go)
+          // no traversa dot-paths, así que hoy no resuelve, pero se declara
+          // para no perder el contrato del legacy (meta.go lo documenta igual).
+          ubicacion: z.custom<IUbicacion>().optional().meta({
+            'x-populate': {
+              ref: 'UbicacionSchema',
+              localField: 'condicion.activo.ubicacion.idUbicacion',
+              foreignField: '_id',
+              justOne: true,
+            },
+          }),
         })
         .optional(),
       detenido: z
@@ -347,14 +359,14 @@ export type Dia = z.infer<typeof DiaSchema>;
 
 export const ConfigEventoUsuarioSchema = z.object({
   _id: z.string().optional(),
-  fechaCreacion: z.string().optional(),
+  fechaCreacion: z.string().optional().meta({ 'x-bson': 'date' }),
   // Para eventos de una sola vez, al cumplirse se desactiva
   activa: z.boolean().optional(),
   // Agrupaciones temporales
   frecuencia: FrecuenciaSchema.optional(),
   // Fechas de vigencia para generar los eventos
-  validaDesde: z.string().optional(),
-  validaHasta: z.string().optional(),
+  validaDesde: z.string().optional().meta({ 'x-bson': 'date' }),
+  validaHasta: z.string().optional().meta({ 'x-bson': 'date' }),
   // Frecuencia de generacion de eventos
   generarSoloUnaVez: z.boolean().optional(),
   // Si pasa el periodo y sigue activa se genera el evento
@@ -380,37 +392,147 @@ export const ConfigEventoUsuarioSchema = z.object({
   // Tipo de dispositivo
   tipoEntidad: TipoEntidadSchema.optional(),
   // Configuracion de la condicion para enviar la notificacion
-  condicion: CondicionNotificacionSchema.optional(),
+  // @Prop({type: Object}) en el legacy: Mixed, Mongoose no castea adentro
+  // (por eso condicion.activo.ubicacion.idUbicacion no se cast-ea tampoco).
+  condicion: CondicionNotificacionSchema.optional().meta({
+    'x-bson': 'mixed',
+  }),
   // Agrupacion para buscar las entidades
   agrupacion: AgrupacionSchema.optional(),
   // Sobre que entidades se reciben las notificaciones
-  idCliente: z.string().optional(),
-  idsAncestros: z.array(z.string()).optional(),
-  idGrupo: z.string().optional(),
-  idEntidad: z.string().optional(),
+  idCliente: z
+    .string()
+    .optional()
+    .meta({ 'x-bson': 'objectId', 'x-ref': 'ClienteSchema' }),
+  idsAncestros: z
+    .array(z.string())
+    .optional()
+    .meta({ 'x-bson': 'objectId', 'x-ref': 'ClienteSchema' }),
+  idGrupo: z
+    .string()
+    .optional()
+    .meta({ 'x-bson': 'objectId', 'x-ref': 'GrupoSchema' }),
+  // Polimórfico (Activo/Luminaria/Alarma/Tracker según tipoEntidad): sin
+  // `ref` en el @Prop, así que Mongoose no lo popula en su lugar. Los
+  // populates salen de los virtuals de abajo (activo/luminaria/alarma/tracker).
+  idEntidad: z.string().optional().meta({ 'x-bson': 'objectId' }),
   // Los usuarios que van a recibir las notificaciones
-  idsUsuarios: z.array(z.string()).optional(),
+  idsUsuarios: z
+    .array(z.string())
+    .optional()
+    .meta({ 'x-bson': 'objectId', 'x-ref': 'UsuarioSchema' }),
   // Los clientes que pueden atender el evento
-  idsClientesQuePuedenAtender: z.array(z.string()).optional(),
-  configHorariosAtencion: z.array(ConfigHorarioSchema).optional(),
-  idCategoriaEvento: z.string().optional(),
+  idsClientesQuePuedenAtender: z
+    .array(z.string())
+    .optional()
+    .meta({ 'x-bson': 'objectId', 'x-ref': 'ClienteSchema' }),
+  // @Prop({type: [Object]}): Mixed, sin casteo adentro.
+  configHorariosAtencion: z
+    .array(ConfigHorarioSchema)
+    .optional()
+    .meta({ 'x-bson': 'mixed' }),
+  idCategoriaEvento: z
+    .string()
+    .optional()
+    .meta({ 'x-bson': 'objectId', 'x-ref': 'CategoriaEventoSchema' }),
   codigoReportado: z.string().optional(),
-  idListadoCategoria: z.string().optional(),
-  configZona: ConfigZonaSchema.optional(),
+  idListadoCategoria: z
+    .string()
+    .optional()
+    .meta({ 'x-bson': 'objectId', 'x-ref': 'ListadoCategoriaSchema' }),
+  // @Prop({type: Object}) en el legacy: Mixed, Mongoose no castea adentro.
+  configZona: ConfigZonaSchema.optional().meta({ 'x-bson': 'mixed' }),
 
   // Virtual
-  usuarios: z.array(z.custom<IUsuario>()).optional(),
-  cliente: ClienteSchema.optional(),
-  ancestros: z.array(ClienteSchema).optional(),
-  grupo: z.custom<IGrupo>().optional(),
-  activo: z.custom<IActivo>().optional(),
-  luminaria: z.custom<ILuminaria>().optional(),
-  alarma: z.custom<IDispositivoAlarma>().optional(),
-  clientesQuePuedenAtender: z.array(ClienteSchema).optional(),
-  categoriaEvento: CategoriaEventoSchema.optional(),
-  tracker: z.custom<ITracker>().optional(),
-  listadoCategoria: ListadoCategoriaSchema.optional(),
-});
+  usuarios: z.array(z.custom<IUsuario>()).optional().meta({
+    'x-populate': {
+      ref: 'UsuarioSchema',
+      localField: 'idsUsuarios',
+      foreignField: '_id',
+      justOne: false,
+    },
+  }),
+  cliente: ClienteSchema.optional().meta({
+    'x-populate': {
+      ref: 'ClienteSchema',
+      localField: 'idCliente',
+      foreignField: '_id',
+      justOne: true,
+    },
+  }),
+  ancestros: z.array(ClienteSchema).optional().meta({
+    'x-populate': {
+      ref: 'ClienteSchema',
+      localField: 'idsAncestros',
+      foreignField: '_id',
+      justOne: false,
+    },
+  }),
+  grupo: z.custom<IGrupo>().optional().meta({
+    'x-populate': {
+      ref: 'GrupoSchema',
+      localField: 'idGrupo',
+      foreignField: '_id',
+      justOne: true,
+    },
+  }),
+  activo: z.custom<IActivo>().optional().meta({
+    'x-populate': {
+      ref: 'ActivoSchema',
+      localField: 'idEntidad',
+      foreignField: '_id',
+      justOne: true,
+    },
+  }),
+  luminaria: z.custom<ILuminaria>().optional().meta({
+    'x-populate': {
+      ref: 'LuminariaSchema',
+      localField: 'idEntidad',
+      foreignField: '_id',
+      justOne: true,
+    },
+  }),
+  alarma: z.custom<IDispositivoAlarma>().optional().meta({
+    'x-populate': {
+      ref: 'DispositivoAlarmaSchema',
+      localField: 'idEntidad',
+      foreignField: '_id',
+      justOne: true,
+    },
+  }),
+  clientesQuePuedenAtender: z.array(ClienteSchema).optional().meta({
+    'x-populate': {
+      ref: 'ClienteSchema',
+      localField: 'idsClientesQuePuedenAtender',
+      foreignField: '_id',
+      justOne: false,
+    },
+  }),
+  categoriaEvento: CategoriaEventoSchema.optional().meta({
+    'x-populate': {
+      ref: 'CategoriaEventoSchema',
+      localField: 'idCategoriaEvento',
+      foreignField: '_id',
+      justOne: true,
+    },
+  }),
+  tracker: z.custom<ITracker>().optional().meta({
+    'x-populate': {
+      ref: 'TrackerSchema',
+      localField: 'idEntidad',
+      foreignField: '_id',
+      justOne: true,
+    },
+  }),
+  listadoCategoria: ListadoCategoriaSchema.optional().meta({
+    'x-populate': {
+      ref: 'ListadoCategoriaSchema',
+      localField: 'idListadoCategoria',
+      foreignField: '_id',
+      justOne: true,
+    },
+  }),
+}).meta({ 'x-collection': 'configeventousuarios' });
 
 /**
  * Interface hand-written (misma forma que el schema): los tipos de entidad del

--- a/src/interfaces/config-marker.ts
+++ b/src/interfaces/config-marker.ts
@@ -30,31 +30,73 @@ export const VistaMarkerSchema = z.object({
 });
 export type IVistaMarker = z.infer<typeof VistaMarkerSchema>;
 
-export const ConfigMarkerSchema = z.object({
-  _id: z.string().optional(),
-  //
-  fechaCreacion: z.string().optional(),
+// Metadata de persistencia por `.meta()` — convención documentada arriba de
+// `ProveedorSchema` en proveedor.ts.
+export const ConfigMarkerSchema = z
+  .object({
+    _id: z.string().optional(),
+    //
+    fechaCreacion: z.string().optional().meta({ 'x-bson': 'date' }),
 
-  // Define quien puede usar este marker
-  //
-  global: z.boolean().optional(), // Si es global, puede ser usado por cualquiera
-  idCliente: z.string().optional(), // IdCliente que lo creó
-  idsAncestros: z.array(z.string()).optional(), // IdsAncestros del cliente que lo creó
-  idUsuario: z.string().optional(), // Si tiene idUsuario, solo lo puede usar ese usuario
+    // Define quien puede usar este marker
+    //
+    global: z.boolean().optional(), // Si es global, puede ser usado por cualquiera
+    idCliente: z
+      .string()
+      .optional()
+      .meta({ 'x-bson': 'objectId', 'x-ref': 'ClienteSchema' }), // IdCliente que lo creó
+    idsAncestros: z
+      .array(z.string())
+      .optional()
+      .meta({ 'x-bson': 'objectId', 'x-ref': 'ClienteSchema' }), // IdsAncestros del cliente que lo creó
+    // @Prop({type: [ObjectId]}): array pese al nombre singular — fiel al
+    // legacy (docs/MIGRACION.md). Si tiene idUsuario, solo lo pueden usar
+    // esos usuarios.
+    idUsuario: z
+      .array(z.string())
+      .optional()
+      .meta({ 'x-bson': 'objectId', 'x-ref': 'UsuarioSchema' }),
 
-  // Sobre que aplica este marker
-  //
-  idClienteVer: z.string().optional(), // idCliente del grupo o activo a ver; o repetido el idRef si scope es cliente ya que idRef es idCliente
-  scope: z.enum(['cliente', 'grupo', 'activo']),
-  idRef: z.string(), // idCliente, idGrupo o idActivo
+    // Sobre que aplica este marker
+    //
+    idClienteVer: z
+      .string()
+      .optional()
+      .meta({ 'x-bson': 'objectId', 'x-ref': 'ClienteSchema' }), // idCliente del grupo o activo a ver; o repetido el idRef si scope es cliente ya que idRef es idCliente
+    scope: z.enum(['cliente', 'grupo', 'activo']),
+    // idCliente, idGrupo o idActivo (polimórfico según `scope`): ObjectId sin
+    // un único `ref` de destino.
+    idRef: z.string().meta({ 'x-bson': 'objectId' }),
 
-  vistas: z.array(VistaMarkerSchema).optional(),
+    vistas: z.array(VistaMarkerSchema).optional(),
 
-  // Populate
-  cliente: ClienteSchema.optional(),
-  clienteVer: ClienteSchema.optional(),
-  ancestros: z.array(ClienteSchema).optional(),
-});
+    // Populate
+    cliente: ClienteSchema.optional().meta({
+      'x-populate': {
+        ref: 'ClienteSchema',
+        localField: 'idCliente',
+        foreignField: '_id',
+        justOne: true,
+      },
+    }),
+    clienteVer: ClienteSchema.optional().meta({
+      'x-populate': {
+        ref: 'ClienteSchema',
+        localField: 'idClienteVer',
+        foreignField: '_id',
+        justOne: true,
+      },
+    }),
+    ancestros: z.array(ClienteSchema).optional().meta({
+      'x-populate': {
+        ref: 'ClienteSchema',
+        localField: 'idsAncestros',
+        foreignField: '_id',
+        justOne: false,
+      },
+    }),
+  })
+  .meta({ 'x-collection': 'configmarkers' });
 export type IConfigMarker = z.infer<typeof ConfigMarkerSchema>;
 
 // El original era Omit<Partial<IConfigMarker>, Omitir>: acá el Partial NO era

--- a/src/interfaces/config-marker.ts
+++ b/src/interfaces/config-marker.ts
@@ -49,13 +49,13 @@ export const ConfigMarkerSchema = z
       .array(z.string())
       .optional()
       .meta({ 'x-bson': 'objectId', 'x-ref': 'ClienteSchema' }), // IdsAncestros del cliente que lo creó
-    // @Prop({type: [ObjectId]}): array pese al nombre singular — fiel al
-    // legacy (docs/MIGRACION.md). Si tiene idUsuario, solo lo pueden usar
-    // esos usuarios.
-    idUsuario: z
-      .array(z.string())
-      .optional()
-      .meta({ 'x-bson': 'objectId', 'x-ref': 'UsuarioSchema' }),
+    // Sin `.meta()`: el legacy declara `@Prop({type: [ObjectId]})` (array) y
+    // zod acá lo tiene como escalar desde antes de esta tarea. Alinearlos
+    // rompe consumidores (gestion-api-gestion/src/entidades/config-marker/
+    // service.ts:55 asigna un string; :157 compara con `===` contra un
+    // string) — ver docs/MIGRACION.md §7 y ConfigMarker en `sinAnotar`
+    // (gestion-datos-go/test/drift/anotaciones_test.go).
+    idUsuario: z.string().optional(), // Si tiene idUsuario, solo lo puede usar ese usuario
 
     // Sobre que aplica este marker
     //

--- a/src/interfaces/config-perfil.ts
+++ b/src/interfaces/config-perfil.ts
@@ -85,54 +85,90 @@ export interface IConfigPerfilBase<T extends keyof MapaConfigPerfil> {
 // Campos comunes a todas las variantes (sin tipoConfig/valores, que discriminan)
 const ConfigPerfilCamposSchema = z.object({
   _id: z.string().optional(),
-  fechaCreacion: z.string().optional(),
+  fechaCreacion: z.string().optional().meta({ 'x-bson': 'date' }),
   nombre: z.string().optional(),
   global: z.boolean().optional(), // Si es global, puede ser usado por cualquier cliente.
 
   // Tenant
-  idCliente: z.string().optional(),
-  idsAncestros: z.array(z.string()).optional(),
+  idCliente: z
+    .string()
+    .optional()
+    .meta({ 'x-bson': 'objectId', 'x-ref': 'ClienteSchema' }),
+  idsAncestros: z
+    .array(z.string())
+    .optional()
+    .meta({ 'x-bson': 'objectId', 'x-ref': 'ClienteSchema' }),
 
   // Tipo y datos
   tipoEntidad: TipoEntidadConfigPerfilSchema.optional(),
 
   // Populate
-  cliente: ClienteSchema.optional(),
-  ancestros: z.array(ClienteSchema).optional(),
+  cliente: ClienteSchema.optional().meta({
+    'x-populate': {
+      ref: 'ClienteSchema',
+      localField: 'idCliente',
+      foreignField: '_id',
+      justOne: true,
+    },
+  }),
+  ancestros: z.array(ClienteSchema).optional().meta({
+    'x-populate': {
+      ref: 'ClienteSchema',
+      localField: 'idsAncestros',
+      foreignField: '_id',
+      justOne: false,
+    },
+  }),
 });
 
 // Populates intra-SCC como z.custom (import type-only): un schema real acá
 // arrastra el shape completo del ciclo y revienta la serialización de
 // declarations (TS7056) acá y en los consumidores NestJS.
+// valores es @Prop({type: Object}) en el legacy (config-perfil/schema.ts): Mixed,
+// Mongoose no castea adentro. Igual en las cuatro variantes.
 const VarianteConfigPerfilLuminariaGPE = ConfigPerfilCamposSchema.extend({
   tipoConfig: z.literal('Luminaria GPE').optional(),
-  valores: z.custom<IConfigPerfilLuminariaGPE>().optional(),
+  valores: z
+    .custom<IConfigPerfilLuminariaGPE>()
+    .optional()
+    .meta({ 'x-bson': 'mixed' }),
 });
 const VarianteConfigPerfilLuminariaWellness = ConfigPerfilCamposSchema.extend({
   tipoConfig: z.literal('Luminaria Wellness').optional(),
-  valores: z.custom<IConfigPerfilLuminariaWellness>().optional(),
+  valores: z
+    .custom<IConfigPerfilLuminariaWellness>()
+    .optional()
+    .meta({ 'x-bson': 'mixed' }),
 });
 const VarianteConfigPerfilLuminariaACTISGeneral =
   ConfigPerfilCamposSchema.extend({
     tipoConfig: z.literal('Luminaria ACTIS FING General').optional(),
-    valores: z.custom<IConfigPerfilLuminariaACTISGeneral>().optional(),
+    valores: z
+      .custom<IConfigPerfilLuminariaACTISGeneral>()
+      .optional()
+      .meta({ 'x-bson': 'mixed' }),
   });
 const VarianteConfigPerfilLuminariaACTISDimming =
   ConfigPerfilCamposSchema.extend({
     tipoConfig: z.literal('Luminaria ACTIS FING Dimming').optional(),
-    valores: z.custom<IConfigPerfilLuminariaACTISDimming>().optional(),
+    valores: z
+      .custom<IConfigPerfilLuminariaACTISDimming>()
+      .optional()
+      .meta({ 'x-bson': 'mixed' }),
   });
 
 /* ────────────────────────────────────────────────
  *  TIPO DISCRIMINADO (TYPE-SAFE) - READ
  * ────────────────────────────────────────────────*/
 
-export const ConfigPerfilSchema = z.union([
-  VarianteConfigPerfilLuminariaGPE,
-  VarianteConfigPerfilLuminariaWellness,
-  VarianteConfigPerfilLuminariaACTISGeneral,
-  VarianteConfigPerfilLuminariaACTISDimming,
-]);
+export const ConfigPerfilSchema = z
+  .union([
+    VarianteConfigPerfilLuminariaGPE,
+    VarianteConfigPerfilLuminariaWellness,
+    VarianteConfigPerfilLuminariaACTISGeneral,
+    VarianteConfigPerfilLuminariaACTISDimming,
+  ])
+  .meta({ 'x-collection': 'configperfils' });
 
 export type IConfigPerfil =
   | IConfigPerfilBase<'Luminaria GPE'>

--- a/src/interfaces/config-reenvios.ts
+++ b/src/interfaces/config-reenvios.ts
@@ -53,28 +53,81 @@ export const OpcionesReenvioSchema = z.object({
 });
 export type IOpcionesReenvio = z.infer<typeof OpcionesReenvioSchema>;
 
-export const ConfigReenvioSchema = z.object({
-  _id: z.string().optional(),
-  activo: z.boolean().optional(),
-  idCliente: z.string().optional(),
-  idsAncestros: z.array(z.string()).optional(),
-  fechaCreacion: z.string().optional(),
-  // Configuracion
-  agrupacionReenvio: AgrupacionReenvioSchema.optional(),
-  idClienteReenvio: z.string().optional(),
-  idEntidadReenvio: z.string().optional(),
-  opcionesReenvio: OpcionesReenvioSchema.optional(),
-  reenviarHijos: z.boolean().optional(), /// solo para trackers o alarmas de clientes hijos del cliente reenvio -- tambien se reenvian los propios
-  periodoInicio: z.string().optional(), // Fecha desde la cual se comenzará a reenviar la data (si no se especifica, se asume que es desde la fecha de creación del reenvío)
-  periodoFin: z.string().optional(), // Fecha hasta la cual se reenviará la data (si no se especifica, se asume que es indefinido)
+// Metadata de persistencia por `.meta()` — convención documentada arriba de
+// `ProveedorSchema` en proveedor.ts.
+export const ConfigReenvioSchema = z
+  .object({
+    _id: z.string().optional(),
+    activo: z.boolean().optional(),
+    idCliente: z
+      .string()
+      .optional()
+      .meta({ 'x-bson': 'objectId', 'x-ref': 'ClienteSchema' }),
+    idsAncestros: z
+      .array(z.string())
+      .optional()
+      .meta({ 'x-bson': 'objectId', 'x-ref': 'ClienteSchema' }),
+    fechaCreacion: z.string().optional().meta({ 'x-bson': 'date' }),
+    // Configuracion
+    agrupacionReenvio: AgrupacionReenvioSchema.optional(),
+    idClienteReenvio: z
+      .string()
+      .optional()
+      .meta({ 'x-bson': 'objectId', 'x-ref': 'ClienteSchema' }),
+    // Polimórfico (tracker o dispositivoAlarma según agrupacionReenvio): sin
+    // ref fijo en el legacy (@Prop sin `ref`), por eso sin x-ref acá tampoco.
+    idEntidadReenvio: z.string().optional().meta({ 'x-bson': 'objectId' }),
+    // @Prop({type: Object}) en el legacy: Mixed, Mongoose no castea adentro.
+    opcionesReenvio: OpcionesReenvioSchema.optional().meta({
+      'x-bson': 'mixed',
+    }),
+    reenviarHijos: z.boolean().optional(), /// solo para trackers o alarmas de clientes hijos del cliente reenvio -- tambien se reenvian los propios
+    periodoInicio: z.string().optional().meta({ 'x-bson': 'date' }), // Fecha desde la cual se comenzará a reenviar la data (si no se especifica, se asume que es desde la fecha de creación del reenvío)
+    periodoFin: z.string().optional().meta({ 'x-bson': 'date' }), // Fecha hasta la cual se reenviará la data (si no se especifica, se asume que es indefinido)
 
-  // Virtual
-  cliente: ClienteSchema.optional(),
-  ancestros: z.array(ClienteSchema).optional(),
-  clienteReenvio: ClienteSchema.optional(),
-  dispositivoAlarma: DispositivoAlarmaSchema.optional(),
-  tracker: TrackerSchema.optional(),
-});
+    // Virtual
+    cliente: ClienteSchema.optional().meta({
+      'x-populate': {
+        ref: 'ClienteSchema',
+        localField: 'idCliente',
+        foreignField: '_id',
+        justOne: true,
+      },
+    }),
+    ancestros: z.array(ClienteSchema).optional().meta({
+      'x-populate': {
+        ref: 'ClienteSchema',
+        localField: 'idsAncestros',
+        foreignField: '_id',
+        justOne: false,
+      },
+    }),
+    clienteReenvio: ClienteSchema.optional().meta({
+      'x-populate': {
+        ref: 'ClienteSchema',
+        localField: 'idClienteReenvio',
+        foreignField: '_id',
+        justOne: true,
+      },
+    }),
+    dispositivoAlarma: DispositivoAlarmaSchema.optional().meta({
+      'x-populate': {
+        ref: 'DispositivoAlarmaSchema',
+        localField: 'idEntidadReenvio',
+        foreignField: '_id',
+        justOne: true,
+      },
+    }),
+    tracker: TrackerSchema.optional().meta({
+      'x-populate': {
+        ref: 'TrackerSchema',
+        localField: 'idEntidadReenvio',
+        foreignField: '_id',
+        justOne: true,
+      },
+    }),
+  })
+  .meta({ 'x-collection': 'configreenvios' });
 export type IConfigReenvio = z.infer<typeof ConfigReenvioSchema>;
 
 export const CreateConfigReenvioSchema = ConfigReenvioSchema.omit({

--- a/src/interfaces/cronograma.ts
+++ b/src/interfaces/cronograma.ts
@@ -19,30 +19,66 @@ export const ConfigCronogramaSchema = z.object({
 });
 export type ConfigCronograma = z.infer<typeof ConfigCronogramaSchema>;
 
-export const CronogramaSchema = z.object({
-  _id: z.string().optional(),
-  //
-  idCliente: z.string().optional(),
-  idsAncestros: z.array(z.string()).optional(),
-  idUbicacion: z.string().optional(),
-  //
-  fechaCreacion: z.string().optional(),
-  automatico: z.boolean().optional(),
-  dias: z.array(DiaSchema).optional(),
-  nombre: z.string().optional(),
-  descripcion: z.string().optional(),
-  tipo: TipoDeCronogramaSchema.optional(),
-  periodos: z.array(PeriodoSchema).optional(),
-  //
-  configuracion: ConfigCronogramaSchema.optional(), // Colores, el nombre de de lo que se está mostrando, etc
-  // Populate
-  cliente: ClienteSchema.optional(),
-  ancestros: z.array(ClienteSchema).optional(),
-  // Populate hacia una union discriminada (IUbicacion): z.custom con el tipo
-  // hand-written, NO UbicacionSchema. z.infer del schema union rompe el
-  // narrowing por categoria al asignar un doc Mongoose en consumidores.
-  ubicacion: z.custom<IUbicacion>().optional(),
-});
+export const CronogramaSchema = z
+  .object({
+    _id: z.string().optional(),
+    //
+    idCliente: z
+      .string()
+      .optional()
+      .meta({ 'x-bson': 'objectId', 'x-ref': 'ClienteSchema' }),
+    idsAncestros: z
+      .array(z.string())
+      .optional()
+      .meta({ 'x-bson': 'objectId', 'x-ref': 'ClienteSchema' }),
+    idUbicacion: z
+      .string()
+      .optional()
+      .meta({ 'x-bson': 'objectId', 'x-ref': 'UbicacionSchema' }),
+    //
+    fechaCreacion: z.string().optional().meta({ 'x-bson': 'date' }),
+    automatico: z.boolean().optional(),
+    dias: z.array(DiaSchema).optional(),
+    nombre: z.string().optional(),
+    descripcion: z.string().optional(),
+    tipo: TipoDeCronogramaSchema.optional(),
+    // @Prop({type: [Object]}) en el legacy: Mixed, sin casteo adentro.
+    periodos: z.array(PeriodoSchema).optional().meta({ 'x-bson': 'mixed' }),
+    //
+    // @Prop({type: Object}) en el legacy: Mixed.
+    configuracion: ConfigCronogramaSchema.optional().meta({
+      'x-bson': 'mixed',
+    }), // Colores, el nombre de de lo que se está mostrando, etc
+    // Populate
+    cliente: ClienteSchema.optional().meta({
+      'x-populate': {
+        ref: 'ClienteSchema',
+        localField: 'idCliente',
+        foreignField: '_id',
+        justOne: true,
+      },
+    }),
+    ancestros: z.array(ClienteSchema).optional().meta({
+      'x-populate': {
+        ref: 'ClienteSchema',
+        localField: 'idsAncestros',
+        foreignField: '_id',
+        justOne: false,
+      },
+    }),
+    // Populate hacia una union discriminada (IUbicacion): z.custom con el tipo
+    // hand-written, NO UbicacionSchema. z.infer del schema union rompe el
+    // narrowing por categoria al asignar un doc Mongoose en consumidores.
+    ubicacion: z.custom<IUbicacion>().optional().meta({
+      'x-populate': {
+        ref: 'UbicacionSchema',
+        localField: 'idUbicacion',
+        foreignField: '_id',
+        justOne: true,
+      },
+    }),
+  })
+  .meta({ 'x-collection': 'cronogramas' });
 export type ICronograma = z.infer<typeof CronogramaSchema>;
 
 export const CreateCronogramaSchema = CronogramaSchema.omit({

--- a/src/interfaces/cumplimiento-recorrido.ts
+++ b/src/interfaces/cumplimiento-recorrido.ts
@@ -50,11 +50,23 @@ export type IMotivoCierreCumplimiento = z.infer<
  */
 export const CumplimientoRecorridoSchema = z.object({
   _id: z.string().optional(),
-  idCliente: z.string().optional(),
-  idsAncestros: z.array(z.string()).optional(),
+  idCliente: z
+    .string()
+    .optional()
+    .meta({ 'x-bson': 'objectId', 'x-ref': 'ClienteSchema' }),
+  idsAncestros: z
+    .array(z.string())
+    .optional()
+    .meta({ 'x-bson': 'objectId', 'x-ref': 'ClienteSchema' }),
   //
-  idActivo: z.string().optional(),
-  idRecorrido: z.string().optional(),
+  idActivo: z
+    .string()
+    .optional()
+    .meta({ 'x-bson': 'objectId', 'x-ref': 'ActivoSchema' }),
+  idRecorrido: z
+    .string()
+    .optional()
+    .meta({ 'x-bson': 'objectId', 'x-ref': 'RecorridoSchema' }),
   /**
    * Hash de la geometría contra la que se midió. Snapshot: si el recorrido se
    * edita después, este documento sigue siendo interpretable.
@@ -64,8 +76,8 @@ export const CumplimientoRecorridoSchema = z.object({
   numeroVuelta: z.number().optional(),
   //
   /** Primer reporte on-route que arrancó la medición. */
-  fechaInicio: z.string().optional(),
-  fechaFin: z.string().optional(),
+  fechaInicio: z.string().optional().meta({ 'x-bson': 'date' }),
+  fechaFin: z.string().optional().meta({ 'x-bson': 'date' }),
   duracionMinutos: z.number().optional(),
   //
   /** Cobertura lograda, 0..100. */
@@ -110,11 +122,39 @@ export const CumplimientoRecorridoSchema = z.object({
   estado: EstadoCumplimientoRecorridoSchema.optional(),
   motivoCierre: MotivoCierreCumplimientoSchema.optional(),
   // Populate
-  cliente: ClienteSchema.optional(),
-  ancestros: z.array(ClienteSchema).optional(),
-  activo: ActivoSchema.optional(),
-  recorrido: RecorridoSchema.optional(),
-});
+  cliente: ClienteSchema.optional().meta({
+    'x-populate': {
+      ref: 'ClienteSchema',
+      localField: 'idCliente',
+      foreignField: '_id',
+      justOne: true,
+    },
+  }),
+  ancestros: z.array(ClienteSchema).optional().meta({
+    'x-populate': {
+      ref: 'ClienteSchema',
+      localField: 'idsAncestros',
+      foreignField: '_id',
+      justOne: false,
+    },
+  }),
+  activo: ActivoSchema.optional().meta({
+    'x-populate': {
+      ref: 'ActivoSchema',
+      localField: 'idActivo',
+      foreignField: '_id',
+      justOne: true,
+    },
+  }),
+  recorrido: RecorridoSchema.optional().meta({
+    'x-populate': {
+      ref: 'RecorridoSchema',
+      localField: 'idRecorrido',
+      foreignField: '_id',
+      justOne: true,
+    },
+  }),
+}).meta({ 'x-collection': 'cumplimientorecorridos' });
 export type ICumplimientoRecorrido = z.infer<
   typeof CumplimientoRecorridoSchema
 >;

--- a/src/interfaces/despacho.ts
+++ b/src/interfaces/despacho.ts
@@ -8,30 +8,103 @@ import { UsuarioSchema } from './usuario';
 export const DespachoSchema = z.object({
   _id: z.string().optional(),
   //
-  idCliente: z.string().optional(),
-  idsAncestros: z.array(z.string()).optional(),
-  idUsuario: z.string().optional(),
+  idCliente: z
+    .string()
+    .optional()
+    .meta({ 'x-bson': 'objectId', 'x-ref': 'ClienteSchema' }),
+  idsAncestros: z
+    .array(z.string())
+    .optional()
+    .meta({ 'x-bson': 'objectId', 'x-ref': 'ClienteSchema' }),
+  idUsuario: z
+    .string()
+    .optional()
+    .meta({ 'x-bson': 'objectId', 'x-ref': 'UsuarioSchema' }),
   //
-  fechaCreacion: z.string().optional(),
+  fechaCreacion: z.string().optional().meta({ 'x-bson': 'date' }),
   fecha: z.string().optional(),
   hora: z.string().optional(), // Sale
   salio: z.string().optional(), // Salió
-  idCronograma: z.string().optional(),
-  idActivo: z.string().optional(),
-  idChofer: z.string().optional(),
-  idsRecorridos: z.array(z.string()).optional(),
-  idRecorridoActual: z.string().optional(),
+  idCronograma: z
+    .string()
+    .optional()
+    .meta({ 'x-bson': 'objectId', 'x-ref': 'CronogramaSchema' }),
+  idActivo: z
+    .string()
+    .optional()
+    .meta({ 'x-bson': 'objectId', 'x-ref': 'ActivoSchema' }),
+  idChofer: z
+    .string()
+    .optional()
+    .meta({ 'x-bson': 'objectId', 'x-ref': 'UsuarioSchema' }),
+  idsRecorridos: z
+    .array(z.string())
+    .optional()
+    .meta({ 'x-bson': 'objectId', 'x-ref': 'RecorridoSchema' }),
+  // No está en el schema Mongoose legacy (drift documentado en meta.go:
+  // "Campos que estaban en el schema zod y faltaban acá"). Sin @Prop({ref}),
+  // así que solo lleva el casteo, no populate.
+  idRecorridoActual: z.string().optional().meta({ 'x-bson': 'objectId' }),
   completado: z.boolean().optional(), /// Que los datos son iguales al cronograma
   cancelado: z.boolean().optional(), /// Que el despacho fue cancelado
   // Populate
-  cliente: ClienteSchema.optional(),
-  ancestros: z.array(ClienteSchema).optional(),
-  usuario: UsuarioSchema.optional(),
-  activo: ActivoSchema.optional(),
-  chofer: UsuarioSchema.optional(),
-  recorridos: z.array(RecorridoSchema).optional(),
-  cronograma: CronogramaSchema.optional(),
-});
+  cliente: ClienteSchema.optional().meta({
+    'x-populate': {
+      ref: 'ClienteSchema',
+      localField: 'idCliente',
+      foreignField: '_id',
+      justOne: true,
+    },
+  }),
+  ancestros: z.array(ClienteSchema).optional().meta({
+    'x-populate': {
+      ref: 'ClienteSchema',
+      localField: 'idsAncestros',
+      foreignField: '_id',
+      justOne: false,
+    },
+  }),
+  usuario: UsuarioSchema.optional().meta({
+    'x-populate': {
+      ref: 'UsuarioSchema',
+      localField: 'idUsuario',
+      foreignField: '_id',
+      justOne: true,
+    },
+  }),
+  activo: ActivoSchema.optional().meta({
+    'x-populate': {
+      ref: 'ActivoSchema',
+      localField: 'idActivo',
+      foreignField: '_id',
+      justOne: true,
+    },
+  }),
+  chofer: UsuarioSchema.optional().meta({
+    'x-populate': {
+      ref: 'UsuarioSchema',
+      localField: 'idChofer',
+      foreignField: '_id',
+      justOne: true,
+    },
+  }),
+  recorridos: z.array(RecorridoSchema).optional().meta({
+    'x-populate': {
+      ref: 'RecorridoSchema',
+      localField: 'idsRecorridos',
+      foreignField: '_id',
+      justOne: false,
+    },
+  }),
+  cronograma: CronogramaSchema.optional().meta({
+    'x-populate': {
+      ref: 'CronogramaSchema',
+      localField: 'idCronograma',
+      foreignField: '_id',
+      justOne: true,
+    },
+  }),
+}).meta({ 'x-collection': 'despachos' });
 export type IDespacho = z.infer<typeof DespachoSchema>;
 
 export const CreateDespachoSchema = DespachoSchema.omit({

--- a/src/interfaces/destinatario-asistencia.ts
+++ b/src/interfaces/destinatario-asistencia.ts
@@ -12,29 +12,54 @@ export type IInfoAdicional = z.infer<typeof InfoAdicionalSchema>;
 // Populates intra-SCC como z.custom (import type-only): un schema real acá
 // arrastra el shape completo del ciclo y revienta la serialización de
 // declarations (TS7056) acá y en los consumidores NestJS.
-export const DestinatarioAsistenciaSchema = z.object({
-  _id: z.string().optional(), // ID único del destinatario
-  idCliente: z.string().optional(),
-  idsAncestros: z.array(z.string()).optional(),
+export const DestinatarioAsistenciaSchema = z
+  .object({
+    _id: z.string().optional(), // ID único del destinatario
+    idCliente: z
+      .string()
+      .optional()
+      .meta({ 'x-bson': 'objectId', 'x-ref': 'ClienteSchema' }),
+    idsAncestros: z
+      .array(z.string())
+      .optional()
+      .meta({ 'x-bson': 'objectId', 'x-ref': 'ClienteSchema' }),
 
-  fechaCreacion: z.string().optional(),
-  nombre: z.string().optional(),
-  tipoEmergencia: z.custom<TipoEmergencia>().optional(),
-  apellido: z.string().optional(),
-  sexo: z.enum(["M", "F", "X"]).optional(),
-  dni: z.string().optional(),
-  edad: z.number().optional(),
-  obraSocial: z.string().optional(),
-  infoAdicional: InfoAdicionalSchema.optional(), // Información adicional del destinatario
-  telefono: z.string().optional(), // Teléfono del destinatario
-  email: z.string().optional(), // Correo electrónico del destinatario
-  telefonoAlternativo: z.string().optional(),
-  ubicacion: DireccionV2Schema.optional(), // Ubicación del destinatario
+    fechaCreacion: z.string().optional().meta({ 'x-bson': 'date' }),
+    nombre: z.string().optional(),
+    tipoEmergencia: z.custom<TipoEmergencia>().optional(),
+    apellido: z.string().optional(),
+    sexo: z.enum(["M", "F", "X"]).optional(),
+    dni: z.string().optional(),
+    edad: z.number().optional(),
+    obraSocial: z.string().optional(),
+    // @Prop({type: Object, default: {}}) en el legacy: Mixed.
+    infoAdicional: InfoAdicionalSchema.optional().meta({ 'x-bson': 'mixed' }), // Información adicional del destinatario
+    telefono: z.string().optional(), // Teléfono del destinatario
+    email: z.string().optional(), // Correo electrónico del destinatario
+    telefonoAlternativo: z.string().optional(),
+    // @Prop({type: Object, default: {}, required: true}) en el legacy: Mixed
+    // pese a tener un schema DireccionV2 tipado en zod.
+    ubicacion: DireccionV2Schema.optional().meta({ 'x-bson': 'mixed' }), // Ubicación del destinatario
 
-  //Populate
-  cliente: ClienteSchema.optional(),
-  ancestros: z.array(ClienteSchema).optional(),
-});
+    //Populate
+    cliente: ClienteSchema.optional().meta({
+      'x-populate': {
+        ref: 'ClienteSchema',
+        localField: 'idCliente',
+        foreignField: '_id',
+        justOne: true,
+      },
+    }),
+    ancestros: z.array(ClienteSchema).optional().meta({
+      'x-populate': {
+        ref: 'ClienteSchema',
+        localField: 'idsAncestros',
+        foreignField: '_id',
+        justOne: false,
+      },
+    }),
+  })
+  .meta({ 'x-collection': 'destinatarioasistencias' });
 
 /**
  * Interface hand-written (misma forma que el schema): los tipos de entidad del

--- a/src/interfaces/dispositivo-alarma.ts
+++ b/src/interfaces/dispositivo-alarma.ts
@@ -208,71 +208,93 @@ export type IConfigComunicadorUnicom = z.infer<
   typeof ConfigComunicadorUnicomSchema
 >;
 
+// SPIKE etapa 1 + tarea 3 (2026-08-06): metadata de persistencia por
+// `.meta()`. Convención documentada arriba de ProveedorSchema
+// (src/interfaces/proveedor.ts) — copiada acá, no reinventada.
 export const DispositivoAlarmaSchema = z.object({
   _id: z.string().optional(),
   //
-  fechaCreacion: z.string().optional(),
-  fechaAlta: z.string().optional(),
-  fechaUltimaComunicacion: z.string().optional(),
+  fechaCreacion: z.string().optional().meta({ 'x-bson': 'date' }),
+  fechaAlta: z.string().optional().meta({ 'x-bson': 'date' }),
+  fechaUltimaComunicacion: z.string().optional().meta({ 'x-bson': 'date' }),
   // Doble canal (primario/secundario). `reportaDoble` se autodetecta en el gateway
   // cuando un mismo evento llega por ambos puertos dentro de la ventana de gracia.
   // `fechaUltimoReporteDoble` marca la última confirmación (para envejecer el flag).
   // `forzarUnCanal` = escotilla manual: no esperar el 2do canal aunque sea dual.
   reportaDoble: z.boolean().optional(),
-  fechaUltimoReporteDoble: z.string().optional(),
+  fechaUltimoReporteDoble: z.string().optional().meta({ 'x-bson': 'date' }),
   forzarUnCanal: z.boolean().optional(),
-  idComunicador: z.string().optional(),
+  idComunicador: z.string().optional().meta({ 'x-bson': 'objectId', 'x-ref': 'ModeloDispositivoSchema' }),
   idUnicoComunicador: z.string().optional(),
   passwordComunicador: z.string().optional(),
-  idModelo: z.string().optional(),
-  idDomicilio: z.string().optional(),
-  idCliente: z.string().optional(),
-  idsAncestros: z.array(z.string()).optional(),
+  idModelo: z.string().optional().meta({ 'x-bson': 'objectId', 'x-ref': 'ModeloDispositivoSchema' }),
+  idDomicilio: z.string().optional().meta({ 'x-bson': 'objectId', 'x-ref': 'UbicacionSchema' }),
+  idCliente: z.string().optional().meta({ 'x-bson': 'objectId', 'x-ref': 'ClienteSchema' }),
+  idsAncestros: z.array(z.string()).optional().meta({ 'x-bson': 'objectId', 'x-ref': 'ClienteSchema' }),
   nombre: z.string().optional(),
-  numeroAbonado: z.string().optional(),
-  sim1: SimSchema.optional(),
-  sim2: SimSchema.optional(),
-  idsClientesQuePuedenAtender: z.array(z.string()).optional(),
-  idsClientesQuePuedenAtenderEventosTecnicos: z.array(z.string()).optional(),
+  numeroAbonado: z.string().optional().meta({ 'x-setter': 'uppercase' }),
+  // @Prop({type: Object}) en el legacy: Mixed, Mongoose no castea adentro.
+  sim1: SimSchema.optional().meta({ 'x-bson': 'mixed' }),
+  sim2: SimSchema.optional().meta({ 'x-bson': 'mixed' }),
+  idsClientesQuePuedenAtender: z.array(z.string()).optional().meta({ 'x-bson': 'objectId', 'x-ref': 'ClienteSchema' }),
+  idsClientesQuePuedenAtenderEventosTecnicos: z.array(z.string()).optional().meta({ 'x-bson': 'objectId', 'x-ref': 'ClienteSchema' }),
   puedeSolicitarServicioTecnico: z.boolean().optional(),
-  configHorariosAtencion: z.array(ConfigHorarioSchema).optional(),
-  configHorariosAtencionTecnica: z.array(ConfigHorarioSchema).optional(),
-  camarasPorZona: z.array(CamaraAlarmaSchema).optional(),
+  // @Prop({type: [Object]}) en el legacy: array real (se inicializa a []) de Mixed.
+  configHorariosAtencion: z.array(ConfigHorarioSchema).optional().meta({ 'x-bson': 'mixed' }),
+  configHorariosAtencionTecnica: z.array(ConfigHorarioSchema).optional().meta({ 'x-bson': 'mixed' }),
+  // @Prop({type: Object}) en el legacy: escalar Mixed pese al tipo TS array.
+  camarasPorZona: z.array(CamaraAlarmaSchema).optional().meta({ 'x-bson': 'mixed' }),
   idsCamaras: z.array(z.string()).optional(),
   armado: z.array(z.boolean()).optional(),
   armadoPor: z.array(z.union([z.string(), z.null()])).optional(),
   // UNICOM: estado de armado con semántica propia (total/perimetral/selectivo).
   // Additive — NO reemplaza `armado`/`TiposDeArmado` (uso productivo de otras alarmas).
-  estadoArmadoUnicom: EstadoArmadoUnicomSchema.optional(),
-  configUnicom: ConfigComunicadorUnicomSchema.optional(),
+  // @Prop({type: Object}) en el legacy: Mixed.
+  estadoArmadoUnicom: EstadoArmadoUnicomSchema.optional().meta({ 'x-bson': 'mixed' }),
+  configUnicom: ConfigComunicadorUnicomSchema.optional().meta({ 'x-bson': 'mixed' }),
   // UNICOM: último estado de energía/panel decodificado del `sts` (persistido por el gateway).
-  ultimoEstadoUnicom: UltimoEstadoUnicomSchema.optional(),
+  ultimoEstadoUnicom: UltimoEstadoUnicomSchema.optional().meta({ 'x-bson': 'mixed' }),
   imagenes: z.array(z.string()).optional(),
-  ultimaConexion: UltimaConexionSchema.optional(),
-  modoDesactivado: ModoDesactivadoSchema.optional(),
-  infoZonas: z.array(ParticionZonaSchema).optional(),
-  controlHorario: ControlHorarioSchema.optional(),
+  ultimaConexion: UltimaConexionSchema.optional().meta({ 'x-bson': 'mixed' }),
+  modoDesactivado: ModoDesactivadoSchema.optional().meta({ 'x-bson': 'mixed' }),
+  infoZonas: z.array(ParticionZonaSchema).optional().meta({ 'x-bson': 'mixed' }),
+  controlHorario: ControlHorarioSchema.optional().meta({ 'x-bson': 'mixed' }),
   //
   nroDeSistema: z.string().optional(),
   //
   estadoCuenta: z.custom<estadoCuenta>().optional(),
   frecReporte: z.number().optional(),
-  idServiciosContratados: z.array(z.string()).optional(),
+  idServiciosContratados: z.array(z.string()).optional().meta({ 'x-bson': 'objectId', 'x-ref': 'ServicioContratadoSchema' }),
   clave: z.string().optional(),
   contraClave: z.string().optional(),
   // undefined = usar credenciales del cliente (config.credencialesAlarmas)
-  credencialesAlarma: CredencialesAlarmaSchema.optional(),
+  // @Prop({type: Object}) en el legacy: Mixed.
+  credencialesAlarma: CredencialesAlarmaSchema.optional().meta({ 'x-bson': 'mixed' }),
   tipoComercio: z.string().optional(),
   tipoCategoria: z.string().optional(),
   // Populate
-  domicilio: z.custom<IUbicacion>().optional(),
-  modelo: ModeloDispositivoSchema.optional(),
-  cliente: ClienteSchema.optional(),
-  ancestros: z.array(ClienteSchema).optional(),
-  comunicador: ModeloDispositivoSchema.optional(),
-  camaras: z.array(CamaraSchema).optional(),
-  serviciosContratados: z.array(ServicioContratadoSchema).optional(),
-});
+  domicilio: z.custom<IUbicacion>().optional().meta({
+    'x-populate': { ref: 'UbicacionSchema', localField: 'idDomicilio', foreignField: '_id', justOne: true },
+  }),
+  modelo: ModeloDispositivoSchema.optional().meta({
+    'x-populate': { ref: 'ModeloDispositivoSchema', localField: 'idModelo', foreignField: '_id', justOne: true },
+  }),
+  cliente: ClienteSchema.optional().meta({
+    'x-populate': { ref: 'ClienteSchema', localField: 'idCliente', foreignField: '_id', justOne: true },
+  }),
+  ancestros: z.array(ClienteSchema).optional().meta({
+    'x-populate': { ref: 'ClienteSchema', localField: 'idsAncestros', foreignField: '_id', justOne: false },
+  }),
+  comunicador: ModeloDispositivoSchema.optional().meta({
+    'x-populate': { ref: 'ModeloDispositivoSchema', localField: 'idComunicador', foreignField: '_id', justOne: true },
+  }),
+  camaras: z.array(CamaraSchema).optional().meta({
+    'x-populate': { ref: 'CamaraSchema', localField: 'idsCamaras', foreignField: '_id', justOne: false },
+  }),
+  serviciosContratados: z.array(ServicioContratadoSchema).optional().meta({
+    'x-populate': { ref: 'ServicioContratadoSchema', localField: 'idServiciosContratados', foreignField: '_id', justOne: false },
+  }),
+}).meta({ 'x-collection': 'dispositivoalarmas' });
 /**
  * Interface hand-written (misma forma que el schema): los tipos de entidad del
  * SCC no usan z.infer para no arrastrar el ciclo en el declaration emit.

--- a/src/interfaces/dispositivo-alarma.ts
+++ b/src/interfaces/dispositivo-alarma.ts
@@ -222,7 +222,13 @@ export const DispositivoAlarmaSchema = z.object({
   // `fechaUltimoReporteDoble` marca la última confirmación (para envejecer el flag).
   // `forzarUnCanal` = escotilla manual: no esperar el 2do canal aunque sea dual.
   reportaDoble: z.boolean().optional(),
-  fechaUltimoReporteDoble: z.string().optional().meta({ 'x-bson': 'date' }),
+  // SIN x-bson pese al nombre "fecha*": es Go-nativo (no tiene @Prop en el
+  // schema Mongoose legacy) y gestion-api-alarmas lo escribe como string ISO
+  // (new Date().toISOString()), no como BSON Date. Anotarlo 'date' migraría
+  // el tipo BSON en el próximo write sin que nadie lo decida — el mecanismo
+  // de docs/MIGRACION.md item 12 (valores.timestamp). Decisión pendiente,
+  // ver §7 item 23.
+  fechaUltimoReporteDoble: z.string().optional(),
   forzarUnCanal: z.boolean().optional(),
   idComunicador: z.string().optional().meta({ 'x-bson': 'objectId', 'x-ref': 'ModeloDispositivoSchema' }),
   idUnicoComunicador: z.string().optional(),
@@ -245,7 +251,11 @@ export const DispositivoAlarmaSchema = z.object({
   // @Prop({type: Object}) en el legacy: escalar Mixed pese al tipo TS array.
   camarasPorZona: z.array(CamaraAlarmaSchema).optional().meta({ 'x-bson': 'mixed' }),
   idsCamaras: z.array(z.string()).optional(),
-  armado: z.array(z.boolean()).optional(),
+  // @Prop() armado?: boolean[] sin `type` explícito: @nestjs/mongoose refleja
+  // Array y lo resuelve a Mixed (sin caster propio), no a [Boolean]. Medido en
+  // prod: hay documentos con `armado` array Y documentos con `armado` boolean
+  // escalar (heterogéneo de verdad) — ver docs/MIGRACION.md §7 item 23.
+  armado: z.array(z.boolean()).optional().meta({ 'x-bson': 'mixed' }),
   armadoPor: z.array(z.union([z.string(), z.null()])).optional(),
   // UNICOM: estado de armado con semántica propia (total/perimetral/selectivo).
   // Additive — NO reemplaza `armado`/`TiposDeArmado` (uso productivo de otras alarmas).

--- a/src/interfaces/dispositivo-lorawan.ts
+++ b/src/interfaces/dispositivo-lorawan.ts
@@ -508,35 +508,40 @@ export interface IDispositivoLorawanBase<
   modeloDispositivo?: IModeloDispositivo;
 }
 
+// SPIKE etapa 1 + tarea 3 (2026-08-06): metadata de persistencia por
+// `.meta()`. Convención documentada arriba de ProveedorSchema
+// (src/interfaces/proveedor.ts) — copiada acá, no reinventada.
+//
 // Campos comunes a todas las variantes (sin tipo/config, que discriminan)
 const DispositivoLorawanCamposSchema = z.object({
   _id: z.string().optional(),
-  idCliente: z.string().optional(),
-  idsAncestros: z.array(z.string()).optional(),
-  idModeloDispositivo: z.string().optional(),
-  fechaCreacion: z.string().optional(),
+  idCliente: z.string().optional().meta({ 'x-bson': 'objectId', 'x-ref': 'ClienteSchema' }),
+  idsAncestros: z.array(z.string()).optional().meta({ 'x-bson': 'objectId', 'x-ref': 'ClienteSchema' }),
+  idModeloDispositivo: z.string().optional().meta({ 'x-bson': 'objectId', 'x-ref': 'ModeloDispositivoSchema' }),
+  fechaCreacion: z.string().optional().meta({ 'x-bson': 'date' }),
 
   // Campos comunes
-  fechaUltimaComunicacion: z.string().optional(),
-  ultimoReporte: z.custom<IReporteGenerico>().optional(),
+  fechaUltimaComunicacion: z.string().optional().meta({ 'x-bson': 'date' }),
+  // @Prop({type: Object}) en el legacy: Mixed pese al tipo TS estructurado.
+  ultimoReporte: z.custom<IReporteGenerico>().optional().meta({ 'x-bson': 'mixed' }),
   margin: z.number().optional(), //Es la señal del dispositivo, expresada en dB
   tiempoLimiteComunicacion: z.number().optional(), // Tiempo máximo sin reportar (en horas) antes de generar evento "Sin comunicación".
 
-  ubicacion: GeoJSONPointSchema.optional(), // GeoJSON de la ubicacion del dispositivo
-  ultimoComando: z.custom<IComando>().optional(), //Último downlink enviado a este dispositivo
-  paquetes: PaquetesDispositivoLorawanSchema.optional(), //Información para calcular la pérdida de paquetes
-  ultimoGateway: UltimoGatewaySchema.optional(), //Gateway con mejor señal en el último uplink capturado
-  consultaConfig: ConsultaConfigDispositivoSchema.optional(), //Rastreo del cron de consulta de configuración inicial (bootstrap de config).
+  ubicacion: GeoJSONPointSchema.optional().meta({ 'x-bson': 'mixed' }), // GeoJSON de la ubicacion del dispositivo
+  ultimoComando: z.custom<IComando>().optional().meta({ 'x-bson': 'mixed' }), //Último downlink enviado a este dispositivo
+  paquetes: PaquetesDispositivoLorawanSchema.optional().meta({ 'x-bson': 'mixed' }), //Información para calcular la pérdida de paquetes
+  ultimoGateway: UltimoGatewaySchema.optional().meta({ 'x-bson': 'mixed' }), //Gateway con mejor señal en el último uplink capturado
+  consultaConfig: ConsultaConfigDispositivoSchema.optional().meta({ 'x-bson': 'mixed' }), //Rastreo del cron de consulta de configuración inicial (bootstrap de config).
 
   // Datos para el lora server
-  deveui: z.string().optional(),
+  deveui: z.string().optional().meta({ 'x-setter': 'uppercase' }),
   joineui: z.string().optional(),
   description: z.string().optional(),
   name: z.string().optional(),
-  tags: z.record(z.string(), z.string()).optional(),
+  tags: z.record(z.string(), z.string()).optional().meta({ 'x-bson': 'mixed' }),
   applicationId: z.string().optional(),
   deviceProfileId: z.string().optional(),
-  variables: z.record(z.string(), z.string()).optional(),
+  variables: z.record(z.string(), z.string()).optional().meta({ 'x-bson': 'mixed' }),
   isDisabled: z.boolean().optional(),
   skipFcntCheck: z.boolean().optional(),
 
@@ -551,34 +556,43 @@ const DispositivoLorawanCamposSchema = z.object({
   nwkskey: z.string().optional(), //Con esta se completa fNwkSIntKey, nwkSEncKey y sNwkSIntKey para activationKeys
 
   //Populate
-  cliente: ClienteSchema.optional(),
-  ancestros: z.array(ClienteSchema).optional(),
-  modeloDispositivo: ModeloDispositivoSchema.optional(),
+  cliente: ClienteSchema.optional().meta({
+    'x-populate': { ref: 'ClienteSchema', localField: 'idCliente', foreignField: '_id', justOne: true },
+  }),
+  ancestros: z.array(ClienteSchema).optional().meta({
+    'x-populate': { ref: 'ClienteSchema', localField: 'idsAncestros', foreignField: '_id', justOne: false },
+  }),
+  modeloDispositivo: ModeloDispositivoSchema.optional().meta({
+    'x-populate': { ref: 'ModeloDispositivoSchema', localField: 'idModeloDispositivo', foreignField: '_id', justOne: true },
+  }),
 });
 
 const VarianteDispositivoLorawanGPE = DispositivoLorawanCamposSchema.extend({
   tipo: z.literal('Luminaria GPE').optional(),
-  config: DispositivoLuminariaGPESchema.optional(),
+  // config es @Prop({type: Object, default: {}}) en el legacy: Mixed.
+  config: DispositivoLuminariaGPESchema.optional().meta({ 'x-bson': 'mixed' }),
 });
 const VarianteDispositivoLorawanWellness =
   DispositivoLorawanCamposSchema.extend({
     tipo: z.literal('Luminaria Wellness').optional(),
-    config: DispositivoLuminariaWellnessSchema.optional(),
+    config: DispositivoLuminariaWellnessSchema.optional().meta({ 'x-bson': 'mixed' }),
   });
 const VarianteDispositivoLorawanACTIS = DispositivoLorawanCamposSchema.extend({
   tipo: z.literal('Luminaria ACTIS FING').optional(),
-  config: DispositivoLuminariaACTISSchema.optional(),
+  config: DispositivoLuminariaACTISSchema.optional().meta({ 'x-bson': 'mixed' }),
 });
 
 /* ────────────────────────────────────────────────
  *  TIPO DISCRIMINADO (TYPE-SAFE) - READ
  * ────────────────────────────────────────────────*/
 
-export const DispositivoLorawanSchema = z.union([
-  VarianteDispositivoLorawanGPE,
-  VarianteDispositivoLorawanWellness,
-  VarianteDispositivoLorawanACTIS,
-]);
+export const DispositivoLorawanSchema = z
+  .union([
+    VarianteDispositivoLorawanGPE,
+    VarianteDispositivoLorawanWellness,
+    VarianteDispositivoLorawanACTIS,
+  ])
+  .meta({ 'x-collection': 'dispositivolorawans' });
 
 /**
  * Tipo hand-written (misma forma que el schema): los tipos de entidad del

--- a/src/interfaces/documentacion.ts
+++ b/src/interfaces/documentacion.ts
@@ -6,24 +6,68 @@ import { UsuarioSchema } from './usuario';
 export const TipoDocumentacionSchema = z.enum(['Licencia', 'Seguro']);
 export type TipoDocumentacion = z.infer<typeof TipoDocumentacionSchema>;
 
-export const DocumentacionSchema = z.object({
-  _id: z.string().optional(),
-  tipo: TipoDocumentacionSchema.optional(),
-  vencimiento: z.string().optional(),
-  fechaCreacion: z.string().optional(),
-  emision: z.string().optional(),
-  descripcion: z.string().optional(),
-  imagenes: z.array(z.string()).optional(),
-  idCliente: z.string().optional(),
-  idsAncestros: z.array(z.string()).optional(),
-  idChofer: z.string().optional(),
-  idActivo: z.string().optional(),
-  // Populate
-  cliente: ClienteSchema.optional(),
-  ancestros: z.array(ClienteSchema).optional(),
-  chofer: UsuarioSchema.optional(),
-  activo: ActivoSchema.optional(),
-});
+// Metadata de persistencia por `.meta()` — convención documentada arriba de
+// `ProveedorSchema` en proveedor.ts.
+export const DocumentacionSchema = z
+  .object({
+    _id: z.string().optional(),
+    tipo: TipoDocumentacionSchema.optional(),
+    vencimiento: z.string().optional().meta({ 'x-bson': 'date' }),
+    fechaCreacion: z.string().optional().meta({ 'x-bson': 'date' }),
+    emision: z.string().optional().meta({ 'x-bson': 'date' }),
+    descripcion: z.string().optional(),
+    imagenes: z.array(z.string()).optional(),
+    idCliente: z
+      .string()
+      .optional()
+      .meta({ 'x-bson': 'objectId', 'x-ref': 'ClienteSchema' }),
+    idsAncestros: z
+      .array(z.string())
+      .optional()
+      .meta({ 'x-bson': 'objectId', 'x-ref': 'ClienteSchema' }),
+    idChofer: z
+      .string()
+      .optional()
+      .meta({ 'x-bson': 'objectId', 'x-ref': 'UsuarioSchema' }),
+    idActivo: z
+      .string()
+      .optional()
+      .meta({ 'x-bson': 'objectId', 'x-ref': 'ActivoSchema' }),
+    // Populate
+    cliente: ClienteSchema.optional().meta({
+      'x-populate': {
+        ref: 'ClienteSchema',
+        localField: 'idCliente',
+        foreignField: '_id',
+        justOne: true,
+      },
+    }),
+    ancestros: z.array(ClienteSchema).optional().meta({
+      'x-populate': {
+        ref: 'ClienteSchema',
+        localField: 'idsAncestros',
+        foreignField: '_id',
+        justOne: false,
+      },
+    }),
+    chofer: UsuarioSchema.optional().meta({
+      'x-populate': {
+        ref: 'UsuarioSchema',
+        localField: 'idChofer',
+        foreignField: '_id',
+        justOne: true,
+      },
+    }),
+    activo: ActivoSchema.optional().meta({
+      'x-populate': {
+        ref: 'ActivoSchema',
+        localField: 'idActivo',
+        foreignField: '_id',
+        justOne: true,
+      },
+    }),
+  })
+  .meta({ 'x-collection': 'documentacions' });
 export type IDocumentacion = z.infer<typeof DocumentacionSchema>;
 
 // El omit original incluía la clave 'Cliente' (con mayúscula), que no existe en

--- a/src/interfaces/downlink-job.ts
+++ b/src/interfaces/downlink-job.ts
@@ -70,17 +70,28 @@ export type IProximoGetDownlinkJob = z.infer<
   typeof ProximoGetDownlinkJobSchema
 >;
 
+// Metadata de persistencia por `.meta()` — convención documentada arriba de
+// `ProveedorSchema` en proveedor.ts.
 export const DownlinkJobSchema = z.object({
   _id: z.string().optional(),
-  idCliente: z.string().optional(),
-  idsAncestros: z.array(z.string()).optional(),
+  idCliente: z
+    .string()
+    .optional()
+    .meta({ 'x-bson': 'objectId', 'x-ref': 'ClienteSchema' }),
+  idsAncestros: z
+    .array(z.string())
+    .optional()
+    .meta({ 'x-bson': 'objectId', 'x-ref': 'ClienteSchema' }),
 
-  idDispositivoLorawan: z.string(),
-  deveui: z.string(),
+  idDispositivoLorawan: z
+    .string()
+    .meta({ 'x-bson': 'objectId', 'x-ref': 'DispositivoLorawanSchema' }),
+  deveui: z.string().meta({ 'x-setter': 'uppercase' }),
   tipoDispositivo: TipoDispositivoLorawanSchema.optional(),
 
   origen: OrigenDownlinkJobSchema,
-  objetivo: ObjetivoComandoSchema.optional(), // Procedencia: desde qué nivel/entidad se originó (se propaga al IComando)
+  // @Prop({type: Object}) en el legacy: Mixed, Mongoose no castea adentro.
+  objetivo: ObjetivoComandoSchema.optional().meta({ 'x-bson': 'mixed' }), // Procedencia: desde qué nivel/entidad se originó (se propaga al IComando)
   idEjecucion: z.string().optional(), // batch id (uuid) — agrupa todos los jobs de una acción
   idJobBull: z.string().optional(), // BullMQ job id
   indicePaso: z.number().optional(), //posición de este downlink dentro del plan ordenado del dispositivo
@@ -99,25 +110,56 @@ export const DownlinkJobSchema = z.object({
   estado: EstadoDownlinkJobSchema,
   intentos: z.number(),
   ultimoError: z.string().optional(),
-  intentosLog: z.array(IntentoDownlinkSchema).optional(), // historial append-only por intento de transporte
-  idComando: z.string().optional(), // se llena al crear el IComando real en BD
+  // @Prop({type: [Object]}) en el legacy: Mixed, sin casteo adentro.
+  intentosLog: z.array(IntentoDownlinkSchema).optional().meta({
+    'x-bson': 'mixed',
+  }), // historial append-only por intento de transporte
+  // Sin ref en el legacy (@Prop sin `ref`), por eso sin x-ref acá.
+  idComando: z.string().optional().meta({ 'x-bson': 'objectId' }), // se llena al crear el IComando real en BD
 
   // Auto-get encadenado (ACTIS)
-  proximoGet: ProximoGetDownlinkJobSchema.optional(),
+  // @Prop({type: Object}) en el legacy: Mixed, Mongoose no castea adentro.
+  proximoGet: ProximoGetDownlinkJobSchema.optional().meta({
+    'x-bson': 'mixed',
+  }),
 
-  datosExtra: z.record(z.string(), z.any()).optional(),
+  // @Prop({type: Object}) en el legacy: Mixed, Mongoose no castea adentro.
+  datosExtra: z.record(z.string(), z.any()).optional().meta({
+    'x-bson': 'mixed',
+  }),
 
   //Fechas
-  fechaCreacion: z.string().optional(),
-  fechaProgramada: z.string().optional(), // cuando se encola en BullMQ con delay
-  fechaEnviado: z.string().optional(),
-  fechaConfirmado: z.string().optional(),
+  fechaCreacion: z.string().optional().meta({ 'x-bson': 'date' }),
+  fechaProgramada: z.string().optional().meta({ 'x-bson': 'date' }), // cuando se encola en BullMQ con delay
+  fechaEnviado: z.string().optional().meta({ 'x-bson': 'date' }),
+  fechaConfirmado: z.string().optional().meta({ 'x-bson': 'date' }),
 
   //Populate
-  cliente: ClienteSchema.optional(),
-  ancestros: z.array(ClienteSchema).optional(),
-  dispositivo: DispositivoLorawanSchema.optional(),
-});
+  cliente: ClienteSchema.optional().meta({
+    'x-populate': {
+      ref: 'ClienteSchema',
+      localField: 'idCliente',
+      foreignField: '_id',
+      justOne: true,
+    },
+  }),
+  ancestros: z.array(ClienteSchema).optional().meta({
+    'x-populate': {
+      ref: 'ClienteSchema',
+      localField: 'idsAncestros',
+      foreignField: '_id',
+      justOne: false,
+    },
+  }),
+  dispositivo: DispositivoLorawanSchema.optional().meta({
+    'x-populate': {
+      ref: 'DispositivoLorawanSchema',
+      localField: 'idDispositivoLorawan',
+      foreignField: '_id',
+      justOne: true,
+    },
+  }),
+}).meta({ 'x-collection': 'downlinkjobs' });
 export type IDownlinkJob = z.infer<typeof DownlinkJobSchema>;
 
 // El original era Omit<Partial<IDownlinkJob>, OmitirCreate> re-declarando como

--- a/src/interfaces/emergencias.ts
+++ b/src/interfaces/emergencias.ts
@@ -80,9 +80,18 @@ export type IEmergenciaBomberos = z.infer<typeof EmergenciaBomberosSchema>;
 export const EmergenciaSchema = z.object({
   //IDS
   _id: z.string().optional(),
-  idDestinatarioAsistencia: z.string().optional(),
-  idCliente: z.string().optional(),
-  idsAncestros: z.array(z.string()).optional(),
+  idDestinatarioAsistencia: z
+    .string()
+    .optional()
+    .meta({ 'x-bson': 'objectId', 'x-ref': 'DestinatarioAsistenciaSchema' }),
+  idCliente: z
+    .string()
+    .optional()
+    .meta({ 'x-bson': 'objectId', 'x-ref': 'ClienteSchema' }),
+  idsAncestros: z
+    .array(z.string())
+    .optional()
+    .meta({ 'x-bson': 'objectId', 'x-ref': 'ClienteSchema' }),
 
   //DATOS GENERALES DE LA EMERGENCIA
   tipo: TipoEmergenciaSchema.optional(),
@@ -95,15 +104,21 @@ export const EmergenciaSchema = z.object({
   codigo: z.number().optional(), // Código único del caso de emergencia médica es incremental
   solicitante: z.string().optional(), // Nombre del solicitante de la emergencia
   telefono: z.string().optional(), // Teléfono de contacto del solicitante
-  archivosAdjuntos: z.array(ArchivosAdjuntosSchema).optional(),
+  // @Prop({type: [Array]}) en el legacy: Mongoose castea el elemento a
+  // SchemaArray de SchemaMixed (verificado contra mongoose 8.13.2), o sea
+  // Mixed igual que [Object] pese a no usar esa sintaxis.
+  archivosAdjuntos: z
+    .array(ArchivosAdjuntosSchema)
+    .optional()
+    .meta({ 'x-bson': 'mixed' }),
   observaciones: z.string().optional(), // Notas adicionales sobre el auxilio
 
   //FECHAS RELEVANTES DE LA EMERGENCIA
-  fechaCreacion: z.string().optional(),
-  fechaPrimeraAsignacion: z.string().optional(),
-  fechaSalida: z.string().optional(), //La ambulancia puede salir del centro o salir desde otro lugar (este dato debe analizarse junto con el campo salioDelCentro)
-  fechaLlegadaDestino: z.string().optional(),
-  fechaFinalizacion: z.string().optional(),
+  fechaCreacion: z.string().optional().meta({ 'x-bson': 'date' }),
+  fechaPrimeraAsignacion: z.string().optional().meta({ 'x-bson': 'date' }),
+  fechaSalida: z.string().optional().meta({ 'x-bson': 'date' }), //La ambulancia puede salir del centro o salir desde otro lugar (este dato debe analizarse junto con el campo salioDelCentro)
+  fechaLlegadaDestino: z.string().optional().meta({ 'x-bson': 'date' }),
+  fechaFinalizacion: z.string().optional().meta({ 'x-bson': 'date' }),
 
   //SITUACIÓN DE LA EMERGENCIA
   //Si no es ninguna de estas, es una llamada común que no requiere seguimiento ni auxilio, ni tampoco es una emergencia ya atendida en el hospital.
@@ -114,27 +129,70 @@ export const EmergenciaSchema = z.object({
 
   //DATOS DE UBICACIÓN
   direccion: z.string().optional(), //Esta es la dirección que el solicitante indica para la emergencia. No tiene nada que ver con las direcciones que puede haber en los seguimientos
-  ubicacionDestino: GeoJSONPointSchema.optional(), //geojson del lugar de la emergencia
-  idUbicacion: z.string().optional(), //Cuando se crea una emergencia, se genera la entidad IUbicacion para la ubicacion, para luego ejecutar una lógica de negocio junto con la configEventoUsuario.
+  // @Prop({type: Object}) en el legacy: Mixed, Mongoose no castea adentro.
+  ubicacionDestino: GeoJSONPointSchema.optional().meta({
+    'x-bson': 'mixed',
+  }), //geojson del lugar de la emergencia
+  idUbicacion: z
+    .string()
+    .optional()
+    .meta({ 'x-bson': 'objectId', 'x-ref': 'UbicacionSchema' }), //Cuando se crea una emergencia, se genera la entidad IUbicacion para la ubicacion, para luego ejecutar una lógica de negocio junto con la configEventoUsuario.
 
   //SEGUIMIENTO DE LA EMERGENCIA
   asignada: z.boolean().optional(), //Indica si a la emergencia se le asignó alguna clase de personal para el seguimiento (vehículos, médicos, choferes, etc)
-  ultimaActualizacion: z.string().optional(),
-  ultimoEventoEmergencia: z.custom<IEventoGenerico>().optional(), //Acá se carga el último evento para hacer el seguimiento del auxilio
+  ultimaActualizacion: z.string().optional().meta({ 'x-bson': 'date' }),
+  // @Prop({type: Object}) en el legacy: Mixed, Mongoose no castea adentro.
+  ultimoEventoEmergencia: z
+    .custom<IEventoGenerico>()
+    .optional()
+    .meta({ 'x-bson': 'mixed' }), //Acá se carga el último evento para hacer el seguimiento del auxilio
   salioDelCentro: z.boolean().optional(), //En caso de que sea un auxilio, se indica si el móvil asignado salió del centro o no para ir al destino.
   centroEnTransito: z.boolean().optional(), //Indica si la ambulancia pasó por un centro en el camino (sirve para diferenciar el caso en el que la ambulancia sale de un centro o pasa por uno. Esto sirve para determinar el campo salioDelCentro)
   cantidadReasignaciones: z.number().optional(), //Cuenta la cantidad de reasignaciones que tuvo la emergencia
 
   //DATOS ESPECÍFICOS DE CADA TIPO DE EMERGENCIA
-  emergenciaMedica: EmergenciaMedicaSchema.optional(),
-  emergenciaBomberos: EmergenciaBomberosSchema.optional(),
+  // @Prop({type: Object}) en el legacy: Mixed, Mongoose no castea adentro.
+  emergenciaMedica: EmergenciaMedicaSchema.optional().meta({
+    'x-bson': 'mixed',
+  }),
+  emergenciaBomberos: EmergenciaBomberosSchema.optional().meta({
+    'x-bson': 'mixed',
+  }),
 
   //Populate
-  destinatarioAsistencia: z.custom<IDestinatarioAsistencia>().optional(), // Información del paciente
-  cliente: ClienteSchema.optional(),
-  ancestros: z.array(ClienteSchema).optional(),
-  ubicacion: z.custom<IUbicacion>().optional(),
-});
+  destinatarioAsistencia: z.custom<IDestinatarioAsistencia>().optional().meta({
+    'x-populate': {
+      ref: 'DestinatarioAsistenciaSchema',
+      localField: 'idDestinatarioAsistencia',
+      foreignField: '_id',
+      justOne: true,
+    },
+  }), // Información del paciente
+  cliente: ClienteSchema.optional().meta({
+    'x-populate': {
+      ref: 'ClienteSchema',
+      localField: 'idCliente',
+      foreignField: '_id',
+      justOne: true,
+    },
+  }),
+  ancestros: z.array(ClienteSchema).optional().meta({
+    'x-populate': {
+      ref: 'ClienteSchema',
+      localField: 'idsAncestros',
+      foreignField: '_id',
+      justOne: false,
+    },
+  }),
+  ubicacion: z.custom<IUbicacion>().optional().meta({
+    'x-populate': {
+      ref: 'UbicacionSchema',
+      localField: 'idUbicacion',
+      foreignField: '_id',
+      justOne: true,
+    },
+  }),
+}).meta({ 'x-collection': 'emergencias' });
 
 /**
  * Interface hand-written (misma forma que el schema): los tipos de entidad del

--- a/src/interfaces/envio-vehiculo.ts
+++ b/src/interfaces/envio-vehiculo.ts
@@ -13,28 +13,90 @@ export const EstadoEnvioVehiculoSchema = z.enum([
 ]);
 export type EstadoEnvioVehiculo = z.infer<typeof EstadoEnvioVehiculoSchema>;
 
+// Metadata de persistencia por `.meta()` — convención documentada arriba de
+// `ProveedorSchema` en proveedor.ts.
 export const EnvioVehiculoSchema = z.object({
   _id: z.string().optional(),
-  fechaCreacion: z.string().optional(),
-  fechaFinalizacion: z.string().optional(),
+  fechaCreacion: z.string().optional().meta({ 'x-bson': 'date' }),
+  fechaFinalizacion: z.string().optional().meta({ 'x-bson': 'date' }),
   descripcion: z.string().optional(),
   estado: EstadoEnvioVehiculoSchema.optional(),
   ///
-  idCliente: z.string().optional(),
-  idsAncestros: z.array(z.string()).optional(),
-  idConductor: z.string().optional(),
-  idsEventos: z.array(z.string()).optional(),
+  idCliente: z
+    .string()
+    .optional()
+    .meta({ 'x-bson': 'objectId', 'x-ref': 'ClienteSchema' }),
+  idsAncestros: z
+    .array(z.string())
+    .optional()
+    .meta({ 'x-bson': 'objectId', 'x-ref': 'ClienteSchema' }),
+  idConductor: z
+    .string()
+    .optional()
+    .meta({ 'x-bson': 'objectId', 'x-ref': 'UsuarioSchema' }),
+  idsEventos: z
+    .array(z.string())
+    .optional()
+    .meta({ 'x-bson': 'objectId', 'x-ref': 'EventoGenericoSchema' }),
   //Usuario que lo crea
-  idUsuario: z.string().optional(),
-  idActivo: z.string().optional(),
+  idUsuario: z
+    .string()
+    .optional()
+    .meta({ 'x-bson': 'objectId', 'x-ref': 'UsuarioSchema' }),
+  idActivo: z
+    .string()
+    .optional()
+    .meta({ 'x-bson': 'objectId', 'x-ref': 'ActivoSchema' }),
   // Populate
-  cliente: ClienteSchema.optional(),
-  ancestros: z.array(ClienteSchema).optional(),
-  conductor: UsuarioSchema.optional(),
-  usuario: UsuarioSchema.optional(),
-  eventos: z.array(z.custom<IEventoGenerico>()).optional(),
-  activo: ActivoSchema.optional(),
-});
+  cliente: ClienteSchema.optional().meta({
+    'x-populate': {
+      ref: 'ClienteSchema',
+      localField: 'idCliente',
+      foreignField: '_id',
+      justOne: true,
+    },
+  }),
+  ancestros: z.array(ClienteSchema).optional().meta({
+    'x-populate': {
+      ref: 'ClienteSchema',
+      localField: 'idsAncestros',
+      foreignField: '_id',
+      justOne: false,
+    },
+  }),
+  conductor: UsuarioSchema.optional().meta({
+    'x-populate': {
+      ref: 'UsuarioSchema',
+      localField: 'idConductor',
+      foreignField: '_id',
+      justOne: true,
+    },
+  }),
+  usuario: UsuarioSchema.optional().meta({
+    'x-populate': {
+      ref: 'UsuarioSchema',
+      localField: 'idUsuario',
+      foreignField: '_id',
+      justOne: true,
+    },
+  }),
+  eventos: z.array(z.custom<IEventoGenerico>()).optional().meta({
+    'x-populate': {
+      ref: 'EventoGenericoSchema',
+      localField: 'idsEventos',
+      foreignField: '_id',
+      justOne: false,
+    },
+  }),
+  activo: ActivoSchema.optional().meta({
+    'x-populate': {
+      ref: 'ActivoSchema',
+      localField: 'idActivo',
+      foreignField: '_id',
+      justOne: true,
+    },
+  }),
+}).meta({ 'x-collection': 'enviovehiculos' });
 export type IEnvioVehiculo = z.infer<typeof EnvioVehiculoSchema>;
 
 export const CreateEnvioVehiculoSchema = EnvioVehiculoSchema.omit({

--- a/src/interfaces/estado-entidad.ts
+++ b/src/interfaces/estado-entidad.ts
@@ -13,24 +13,70 @@ export type estadoCuenta = z.infer<typeof EstadoCuentaEntidadSchema>;
 // arrastra el shape completo del ciclo tracker↔activo↔usuario↔permiso↔alarma
 // y revienta la serialización de declarations (TS7056) en este paquete y en
 // los consumidores NestJS (compilan este fuente con declaration: true).
-export const EstadoEntidadSchema = z.object({
-  _id: z.string().optional(),
-  fechaCreacion: z.string().optional(),
-  estado: EstadoCuentaEntidadSchema.optional(),
-  idEntidad: z.string().optional(), /// POR DISPOSITIVO
-  idCliente: z.string().optional(),
-  idsAncestros: z.array(z.string()).optional(),
-  idUsuario: z.string().optional(),
-  nota: z.string().optional(),
-  motivos: z.array(z.string()).optional(),
-  vigencia: z.string().optional(), // Desde cuando se aplica el estado
-  // Populate
-  cliente: ClienteSchema.optional(),
-  ancestros: z.array(ClienteSchema).optional(),
-  usuario: z.custom<IUsuario>().optional(),
-  alarma: z.custom<IDispositivoAlarma>().optional(),
-  tracker: z.custom<ITracker>().optional(),
-});
+export const EstadoEntidadSchema = z
+  .object({
+    _id: z.string().optional(),
+    fechaCreacion: z.string().optional().meta({ 'x-bson': 'date' }),
+    estado: EstadoCuentaEntidadSchema.optional(),
+    idEntidad: z.string().optional().meta({ 'x-bson': 'objectId' }), /// POR DISPOSITIVO
+    idCliente: z
+      .string()
+      .optional()
+      .meta({ 'x-bson': 'objectId', 'x-ref': 'ClienteSchema' }),
+    idsAncestros: z
+      .array(z.string())
+      .optional()
+      .meta({ 'x-bson': 'objectId', 'x-ref': 'ClienteSchema' }),
+    idUsuario: z
+      .string()
+      .optional()
+      .meta({ 'x-bson': 'objectId', 'x-ref': 'UsuarioSchema' }),
+    nota: z.string().optional(),
+    motivos: z.array(z.string()).optional(),
+    vigencia: z.string().optional().meta({ 'x-bson': 'date' }), // Desde cuando se aplica el estado
+    // Populate
+    cliente: ClienteSchema.optional().meta({
+      'x-populate': {
+        ref: 'ClienteSchema',
+        localField: 'idCliente',
+        foreignField: '_id',
+        justOne: true,
+      },
+    }),
+    ancestros: z.array(ClienteSchema).optional().meta({
+      'x-populate': {
+        ref: 'ClienteSchema',
+        localField: 'idsAncestros',
+        foreignField: '_id',
+        justOne: false,
+      },
+    }),
+    usuario: z.custom<IUsuario>().optional().meta({
+      'x-populate': {
+        ref: 'UsuarioSchema',
+        localField: 'idUsuario',
+        foreignField: '_id',
+        justOne: true,
+      },
+    }),
+    alarma: z.custom<IDispositivoAlarma>().optional().meta({
+      'x-populate': {
+        ref: 'DispositivoAlarmaSchema',
+        localField: 'idEntidad',
+        foreignField: '_id',
+        justOne: true,
+      },
+    }),
+    tracker: z.custom<ITracker>().optional().meta({
+      'x-populate': {
+        ref: 'TrackerSchema',
+        localField: 'idEntidad',
+        foreignField: '_id',
+        justOne: true,
+      },
+    }),
+  })
+  .meta({ 'x-collection': 'estadoentidads' });
 
 /**
  * Interface hand-written (misma forma que el schema): los tipos de entidad del

--- a/src/interfaces/evento-generico.ts
+++ b/src/interfaces/evento-generico.ts
@@ -673,49 +673,85 @@ export type IEventoGenericoCache = Omit<
 
 // Populates intra-SCC como z.custom (import type-only) — ver comentario en
 // DetallesTecnicosSchema. Sin getters, el objeto es spreadeable.
+//
+// SPIKE etapa 1 + tarea 3 (2026-08-06): metadata de persistencia por
+// `.meta()`. Convención documentada arriba de ProveedorSchema
+// (src/interfaces/proveedor.ts) — copiada acá, no reinventada. Al ser un
+// objeto plano spreadeado en cada variante (varianteEvento), la MISMA
+// instancia de cada campo (con su `.meta()`) termina en las 17 variantes.
 const camposComunesEvento = {
   _id: z.string().optional(),
-  fechaCreacion: z.string().optional(),
-  expireAt: z.string().optional(),
-  idCliente: z.string().optional(),
-  idsAncestros: z.array(z.string()).optional(),
+  fechaCreacion: z.string().optional().meta({ 'x-bson': 'date' }),
+  expireAt: z.string().optional().meta({ 'x-bson': 'date' }),
+  idCliente: z.string().optional().meta({ 'x-bson': 'objectId', 'x-ref': 'ClienteSchema' }),
+  idsAncestros: z.array(z.string()).optional().meta({ 'x-bson': 'objectId', 'x-ref': 'ClienteSchema' }),
   filtrador: CategoriaSchema.optional(), // Para las vistas de atender
   notificar: z.boolean().optional(),
   atender: z.boolean().optional(),
   /** Derivado en backend (hooks): atender===true && estado en estados activos. */
   requiereAtencion: z.boolean().optional(),
   noDerivar: z.boolean().optional(),
-  posponerHasta: z.string().optional(),
+  posponerHasta: z.string().optional().meta({ 'x-bson': 'date' }),
   categoria: z.string().optional(), // Nombre de la categoria del tipo de evento
   prioridad: z.number().optional(),
   repetido: z.number().optional(),
-  fechaUltimoRepetido: z.string().optional(),
+  fechaUltimoRepetido: z.string().optional().meta({ 'x-bson': 'date' }),
   tiempoRespuesta: z.number().optional(),
-  idEntidad: z.string().optional(), // Lo que generó el evento
-  idReporte: z.string().optional(), // En caso de ser un evento generado por un reporte automático
-  idConfigEventoUsuario: z.string().optional(),
-  detallesTecnicos: DetallesTecnicosSchema.optional(),
-  detallesEmergencias: DetallesEmergenciasSchema.optional(),
-  idsClientesQuePuedenAtender: z.array(z.string()).optional(),
-  configHorariosAtencion: z.array(ConfigHorarioSchema).optional(),
-  idsClientesAtendiendo: z.array(z.string()).optional(),
-  idsUsuariosAtendiendo: z.array(z.string()).optional(),
+  // @Prop({type: ObjectId}) SIN ref: el populate corre por los virtuals con
+  // nombre propio (tracker/alarma/luminaria/...), no en este path.
+  idEntidad: z.string().optional().meta({ 'x-bson': 'objectId' }), // Lo que generó el evento
+  idReporte: z.string().optional().meta({ 'x-bson': 'objectId', 'x-ref': 'ReporteGenericoSchema' }), // En caso de ser un evento generado por un reporte automático
+  idConfigEventoUsuario: z.string().optional().meta({ 'x-bson': 'objectId', 'x-ref': 'ConfigEventoUsuarioSchema' }),
+  // @Prop({type: Object}) en el legacy: Mixed.
+  detallesTecnicos: DetallesTecnicosSchema.optional().meta({ 'x-bson': 'mixed' }),
+  detallesEmergencias: DetallesEmergenciasSchema.optional().meta({ 'x-bson': 'mixed' }),
+  idsClientesQuePuedenAtender: z.array(z.string()).optional().meta({ 'x-bson': 'objectId', 'x-ref': 'ClienteSchema' }),
+  // @Prop({type: [Object]}) en el legacy: array real de Mixed.
+  configHorariosAtencion: z.array(ConfigHorarioSchema).optional().meta({ 'x-bson': 'mixed' }),
+  idsClientesAtendiendo: z.array(z.string()).optional().meta({ 'x-bson': 'objectId', 'x-ref': 'ClienteSchema' }),
+  idsUsuariosAtendiendo: z.array(z.string()).optional().meta({ 'x-bson': 'objectId', 'x-ref': 'UsuarioSchema' }),
   // Populates fuera del SCC (directas)
-  cliente: ClienteSchema.optional(),
-  ancestros: z.array(ClienteSchema).optional(),
-  botonBluetooth: BotonBluetoothSchema.optional(),
-  sirena: SirenaSchema.optional(),
-  gateway: GatewaySchema.optional(),
+  cliente: ClienteSchema.optional().meta({
+    'x-populate': { ref: 'ClienteSchema', localField: 'idCliente', foreignField: '_id', justOne: true },
+  }),
+  ancestros: z.array(ClienteSchema).optional().meta({
+    'x-populate': { ref: 'ClienteSchema', localField: 'idsAncestros', foreignField: '_id', justOne: false },
+  }),
+  botonBluetooth: BotonBluetoothSchema.optional().meta({
+    'x-populate': { ref: 'BotonBluetoothSchema', localField: 'idEntidad', foreignField: '_id', justOne: true },
+  }),
+  sirena: SirenaSchema.optional().meta({
+    'x-populate': { ref: 'SirenaSchema', localField: 'idEntidad', foreignField: '_id', justOne: true },
+  }),
+  gateway: GatewaySchema.optional().meta({
+    'x-populate': { ref: 'GatewaySchema', localField: 'idEntidad', foreignField: '_id', justOne: true },
+  }),
   // Populates intra-SCC → z.custom
-  usuariosAtendiendo: z.array(z.custom<IUsuario>()).optional(),
-  tracker: z.custom<ITracker>().optional(),
-  alarma: z.custom<IDispositivoAlarma>().optional(),
-  luminaria: z.custom<ILuminaria>().optional(),
-  usuario: z.custom<IUsuario>().optional(),
-  activo: z.custom<IActivo>().optional(),
-  configEventoUsuario: z.custom<IConfigEventoUsuario>().optional(),
+  usuariosAtendiendo: z.array(z.custom<IUsuario>()).optional().meta({
+    'x-populate': { ref: 'UsuarioSchema', localField: 'idsUsuariosAtendiendo', foreignField: '_id', justOne: false },
+  }),
+  tracker: z.custom<ITracker>().optional().meta({
+    'x-populate': { ref: 'TrackerSchema', localField: 'idEntidad', foreignField: '_id', justOne: true },
+  }),
+  alarma: z.custom<IDispositivoAlarma>().optional().meta({
+    'x-populate': { ref: 'DispositivoAlarmaSchema', localField: 'idEntidad', foreignField: '_id', justOne: true },
+  }),
+  luminaria: z.custom<ILuminaria>().optional().meta({
+    'x-populate': { ref: 'LuminariaSchema', localField: 'idEntidad', foreignField: '_id', justOne: true },
+  }),
+  usuario: z.custom<IUsuario>().optional().meta({
+    'x-populate': { ref: 'UsuarioSchema', localField: 'idEntidad', foreignField: '_id', justOne: true },
+  }),
+  activo: z.custom<IActivo>().optional().meta({
+    'x-populate': { ref: 'ActivoSchema', localField: 'idEntidad', foreignField: '_id', justOne: true },
+  }),
+  configEventoUsuario: z.custom<IConfigEventoUsuario>().optional().meta({
+    'x-populate': { ref: 'ConfigEventoUsuarioSchema', localField: 'idConfigEventoUsuario', foreignField: '_id', justOne: true },
+  }),
   // Tipo legacy con discriminante opcional → z.custom conserva compatibilidad
-  reporte: z.custom<IReporteGenerico>().optional(),
+  reporte: z.custom<IReporteGenerico>().optional().meta({
+    'x-populate': { ref: 'ReporteGenericoSchema', localField: 'idReporte', foreignField: '_id', justOne: true },
+  }),
 };
 
 const varianteEvento = <
@@ -775,7 +811,7 @@ export const EventoGenericoSchema: z.ZodType<IEventoGenerico> =
   vEvtTecGateway,
   vEvtEmergenciaMedica,
   vEvtEmergenciaBomberos,
-]);
+]).meta({ 'x-collection': 'eventogenericos' });
 
 // Mismo set que el type OmitirCreate de arriba (sirena NO se omite, igual que el original)
 const omitirCreateUpdateEvento = {

--- a/src/interfaces/excepcion.ts
+++ b/src/interfaces/excepcion.ts
@@ -1,21 +1,44 @@
 import { z } from 'zod';
 import { ClienteSchema } from './cliente';
 
-export const ExcepcionSchema = z.object({
-  _id: z.string().optional(),
-  fechaCreacion: z.string().optional(),
-  idCliente: z.string().optional(),
-  idsAncestros: z.array(z.string()).optional(),
-  tipoEntidad: z.enum(['Cliente', 'Alarma']).optional(),
-  idEntidad: z.string().optional(),
-  tipoExcepcion: z.enum(['Control Horario']).optional(),
-  fechaDesde: z.string().optional(),
-  fechaHasta: z.string().optional(),
+export const ExcepcionSchema = z
+  .object({
+    _id: z.string().optional(),
+    fechaCreacion: z.string().optional().meta({ 'x-bson': 'date' }),
+    idCliente: z
+      .string()
+      .optional()
+      .meta({ 'x-bson': 'objectId', 'x-ref': 'ClienteSchema' }),
+    idsAncestros: z
+      .array(z.string())
+      .optional()
+      .meta({ 'x-bson': 'objectId', 'x-ref': 'ClienteSchema' }),
+    tipoEntidad: z.enum(['Cliente', 'Alarma']).optional(),
+    // ObjectId sin `ref` en el legacy (excepcion/schema.ts): sin x-ref.
+    idEntidad: z.string().optional().meta({ 'x-bson': 'objectId' }),
+    tipoExcepcion: z.enum(['Control Horario']).optional(),
+    fechaDesde: z.string().optional().meta({ 'x-bson': 'date' }),
+    fechaHasta: z.string().optional().meta({ 'x-bson': 'date' }),
 
-  // Populate
-  cliente: ClienteSchema.optional(),
-  ancestros: z.array(ClienteSchema).optional(),
-});
+    // Populate
+    cliente: ClienteSchema.optional().meta({
+      'x-populate': {
+        ref: 'ClienteSchema',
+        localField: 'idCliente',
+        foreignField: '_id',
+        justOne: true,
+      },
+    }),
+    ancestros: z.array(ClienteSchema).optional().meta({
+      'x-populate': {
+        ref: 'ClienteSchema',
+        localField: 'idsAncestros',
+        foreignField: '_id',
+        justOne: false,
+      },
+    }),
+  })
+  .meta({ 'x-collection': 'excepcions' });
 export type IExcepcion = z.infer<typeof ExcepcionSchema>;
 
 export const CreateExcepcionSchema = ExcepcionSchema.omit({

--- a/src/interfaces/export-job.ts
+++ b/src/interfaces/export-job.ts
@@ -1,0 +1,83 @@
+import { z } from 'zod';
+
+export const EstadoExportJobSchema = z.enum([
+  'pendiente',
+  'procesando',
+  'completado',
+  'error',
+]);
+export type EstadoExportJob = z.infer<typeof EstadoExportJobSchema>;
+
+export const TipoExportJobSchema = z.enum([
+  'recorrido',
+  'vehiculosPorZona',
+  'reportesVehiculo',
+  'reportesCliente',
+]);
+export type TipoExportJob = z.infer<typeof TipoExportJobSchema>;
+
+// Cola de exports asíncronos (export-job.model.ts, 17 @Prop). El controller
+// legacy NO expone CRUD estándar: solo 3 endpoints custom (crear / obtener /
+// adjuntar paradas) — ver gestion-datos-go/internal/entidades/exportacionjobs.
+// El worker que procesa los jobs pollea { estado: 'pendiente' } ordenado por
+// fechaCreacion (índice compuesto del legacy, no modelado acá: es infra de
+// Mongo, no forma del dato).
+//
+// Metadata de persistencia por `.meta()` — convención documentada arriba de
+// `ProveedorSchema` en proveedor.ts. `idCliente`/`idUsuario` son
+// `@Prop({type: String})` en el legacy — String plano, SIN `ref` — por eso
+// van sin `x-bson`/`x-ref` acá, a diferencia de la mayoría de los
+// `idCliente` del resto del repo (verificado contra el legacy real,
+// docs/MIGRACION.md §7 item 28). Solo `tipo` y `query` son
+// `required: true`; el resto tiene a lo sumo un `default` (no bloquea el
+// save si falta), así que solo esos dos quedan sin `.optional()`.
+export const ExportJobSchema = z
+  .object({
+    _id: z.string().optional(),
+    fechaCreacion: z.string().optional().meta({ 'x-bson': 'date' }),
+    fechaInicio: z.string().optional().meta({ 'x-bson': 'date' }),
+    fechaFin: z.string().optional().meta({ 'x-bson': 'date' }),
+    estado: EstadoExportJobSchema.optional(), // default 'pendiente'
+    tipo: TipoExportJobSchema,
+    // @Prop({type: Object, required: true}) en el legacy: Mixed, sin casteo
+    // adentro. Lo que el generador necesita: { vehiculoId, rango, opciones,
+    // vehiculoNombre, clienteNombre }.
+    query: z.record(z.string(), z.unknown()).meta({ 'x-bson': 'mixed' }),
+    // @Prop({type: [Object], default: []}) en el legacy: array real de
+    // Mixed (paradas de tripero que gestion resuelve en background y
+    // adjunta acá).
+    paradas: z
+      .array(z.record(z.string(), z.unknown()))
+      .optional()
+      .meta({ 'x-bson': 'mixed' }),
+    listoParaProcesar: z.boolean().optional(), // default true
+    idCliente: z.string().optional(),
+    idUsuario: z.string().optional(),
+    nombreArchivo: z.string().optional(),
+    objetoStorage: z.string().optional(),
+    urlDescarga: z.string().optional(),
+    progreso: z.number().optional(), // default 0
+    cantidad: z.number().optional(),
+    error: z.string().optional(),
+    intentos: z.number().optional(), // default 0
+  })
+  .meta({ 'x-collection': 'exportjobs' });
+export type IExportJob = z.infer<typeof ExportJobSchema>;
+
+// Espejo de CreateDownlinkJobSchema: se omite `fechaCreacion` porque la pone
+// el propio servicio al crear (default Date.now / nowUTC() en el handler
+// Go), nunca el cliente.
+export const CreateExportJobSchema = ExportJobSchema.omit({
+  _id: true,
+  fechaCreacion: true,
+});
+export type ICreateExportJob = z.infer<typeof CreateExportJobSchema>;
+
+// La base tiene un campo required (`tipo`; `query` también lo es pero ambos
+// sobreviven al omit), así que el `.partial()` acá NO es no-op — mismo
+// motivo que UpdateDownlinkJobSchema.
+export const UpdateExportJobSchema = ExportJobSchema.omit({
+  _id: true,
+  fechaCreacion: true,
+}).partial();
+export type IUpdateExportJob = z.infer<typeof UpdateExportJobSchema>;

--- a/src/interfaces/facturacion-cliente.ts
+++ b/src/interfaces/facturacion-cliente.ts
@@ -4,21 +4,43 @@ import { ClienteSchema, TipoClienteSchema } from './cliente';
 export const MonedaFacturacionSchema = z.enum(['ARS', 'USD']);
 export type MonedaFacturacion = z.infer<typeof MonedaFacturacionSchema>;
 
-export const FacturacionClienteSchema = z.object({
-  _id: z.string().optional(),
-  idCliente: z.string().optional(),
-  idsAncestros: z.array(z.string()).optional(),
-  activa: z.boolean().optional(),
-  /**
-   * Si true, el cliente no se cobra: su costo se descuenta del cliente
-   * facturable padre (línea de bonificación). Si false/undefined y el
-   * cliente no es nivel 1, se considera raíz independiente de facturación.
-   */
-  bonificado: z.boolean().optional(),
-  // Populate
-  cliente: ClienteSchema.optional(),
-  ancestros: z.array(ClienteSchema).optional(),
-});
+export const FacturacionClienteSchema = z
+  .object({
+    _id: z.string().optional(),
+    idCliente: z
+      .string()
+      .optional()
+      .meta({ 'x-bson': 'objectId', 'x-ref': 'ClienteSchema' }),
+    idsAncestros: z
+      .array(z.string())
+      .optional()
+      .meta({ 'x-bson': 'objectId', 'x-ref': 'ClienteSchema' }),
+    activa: z.boolean().optional(),
+    /**
+     * Si true, el cliente no se cobra: su costo se descuenta del cliente
+     * facturable padre (línea de bonificación). Si false/undefined y el
+     * cliente no es nivel 1, se considera raíz independiente de facturación.
+     */
+    bonificado: z.boolean().optional(),
+    // Populate
+    cliente: ClienteSchema.optional().meta({
+      'x-populate': {
+        ref: 'ClienteSchema',
+        localField: 'idCliente',
+        foreignField: '_id',
+        justOne: true,
+      },
+    }),
+    ancestros: z.array(ClienteSchema).optional().meta({
+      'x-populate': {
+        ref: 'ClienteSchema',
+        localField: 'idsAncestros',
+        foreignField: '_id',
+        justOne: false,
+      },
+    }),
+  })
+  .meta({ 'x-collection': 'facturacionclientes' });
 export type IFacturacionCliente = z.infer<typeof FacturacionClienteSchema>;
 
 export const CreateFacturacionClienteSchema = FacturacionClienteSchema.omit({

--- a/src/interfaces/gateway.ts
+++ b/src/interfaces/gateway.ts
@@ -2,45 +2,71 @@ import { z } from 'zod';
 import { ClienteSchema } from './cliente';
 import { GeoJSONPointSchema } from '../auxiliares';
 
-//Esta es la interfaz del gateway que se va a guardar en nuestra base de datos. Va a requerir que ya exista creado el gateway en Chirpstack
-export const GatewaySchema = z.object({
-  //Propios de nuestra base de datos
-  _id: z.string().optional(),
-  idCliente: z.string().optional(),
-  idsAncestros: z.array(z.string()).optional(),
-  fechaCreacion: z.string().optional(),
-  nombre: z.string().optional(),
-  /** true si fue creado automáticamente por el cron de métricas */
-  autoCreado: z.boolean().optional(),
-  //Propios de Chirpstack
-  fechaCreacionChirpstack: z.string().optional(), //Fecha de creación en Chirpstack
-  gatewayEui: z.string().optional(),
-  nombreChirpstack: z.string().optional(),
-  description: z.string().optional(),
-  statsInterval: z.number().optional(),
-  ubicacion: GeoJSONPointSchema.optional(), //De Chirpstack vienen en otro formato, pero acá lo guardamos como GeoJSON Point
-  tags: z.record(z.string(), z.string()).optional(),
-  metadata: z.record(z.string(), z.string()).optional(),
+// Metadata de persistencia por `.meta()` — convención documentada arriba de
+// `ProveedorSchema` en proveedor.ts. Esta es la interfaz del gateway que se va
+// a guardar en nuestra base de datos. Va a requerir que ya exista creado el
+// gateway en Chirpstack
+export const GatewaySchema = z
+  .object({
+    //Propios de nuestra base de datos
+    _id: z.string().optional(),
+    idCliente: z
+      .string()
+      .optional()
+      .meta({ 'x-bson': 'objectId', 'x-ref': 'ClienteSchema' }),
+    idsAncestros: z
+      .array(z.string())
+      .optional()
+      .meta({ 'x-bson': 'objectId', 'x-ref': 'ClienteSchema' }),
+    fechaCreacion: z.string().optional().meta({ 'x-bson': 'date' }),
+    nombre: z.string().optional(),
+    /** true si fue creado automáticamente por el cron de métricas */
+    autoCreado: z.boolean().optional(),
+    //Propios de Chirpstack
+    fechaCreacionChirpstack: z.string().optional(), //Fecha de creación en Chirpstack
+    gatewayEui: z.string().optional().meta({ 'x-setter': 'uppercase' }),
+    nombreChirpstack: z.string().optional(),
+    description: z.string().optional(),
+    statsInterval: z.number().optional(),
+    // @Prop({type: Object}) en el legacy: Mixed, Mongoose no castea adentro.
+    ubicacion: GeoJSONPointSchema.optional().meta({ 'x-bson': 'mixed' }), //De Chirpstack vienen en otro formato, pero acá lo guardamos como GeoJSON Point
+    tags: z.record(z.string(), z.string()).optional(),
+    metadata: z.record(z.string(), z.string()).optional(),
 
-  cliente: ClienteSchema.optional(),
-  ancestros: z.array(ClienteSchema).optional(),
+    cliente: ClienteSchema.optional().meta({
+      'x-populate': {
+        ref: 'ClienteSchema',
+        localField: 'idCliente',
+        foreignField: '_id',
+        justOne: true,
+      },
+    }),
+    ancestros: z.array(ClienteSchema).optional().meta({
+      'x-populate': {
+        ref: 'ClienteSchema',
+        localField: 'idsAncestros',
+        foreignField: '_id',
+        justOne: false,
+      },
+    }),
 
-  // Estadísticas calculadas por cron (actualización horaria)
-  /** ToA promedio por canal en ms de la última hora */
-  toaPromedioHora: z.number().optional(),
-  /** Estado de salud basado en ToA: ok (<5%), warning (5-17%), error (>17%) */
-  estadoSalud: z.enum(['ok', 'warning', 'error']).optional(),
-  /** Fecha de última actualización de estadísticas */
-  estadisticasActualizadas: z.string().optional(),
+    // Estadísticas calculadas por cron (actualización horaria)
+    /** ToA promedio por canal en ms de la última hora */
+    toaPromedioHora: z.number().optional(),
+    /** Estado de salud basado en ToA: ok (<5%), warning (5-17%), error (>17%) */
+    estadoSalud: z.enum(['ok', 'warning', 'error']).optional(),
+    /** Fecha de última actualización de estadísticas */
+    estadisticasActualizadas: z.string().optional(),
 
-  // Snapshot de ENVÍO DE STATS de la última franja de 10 min (cron). Solo los
-  // dos crudos; ratio/estado/histórico se derivan/sacan de los IResumenDatos
-  // ('Gateway Stats'). INDEPENDIENTE de estadoSalud/ToA.
-  /** stats recibidos en la última franja de 10 min */
-  statsRecibidos: z.number().optional(),
-  /** stats esperados = (rangoMinutos*60) / statsInterval — ej. 600/30 = 20 */
-  statsEsperados: z.number().optional(),
-});
+    // Snapshot de ENVÍO DE STATS de la última franja de 10 min (cron). Solo los
+    // dos crudos; ratio/estado/histórico se derivan/sacan de los IResumenDatos
+    // ('Gateway Stats'). INDEPENDIENTE de estadoSalud/ToA.
+    /** stats recibidos en la última franja de 10 min */
+    statsRecibidos: z.number().optional(),
+    /** stats esperados = (rangoMinutos*60) / statsInterval — ej. 600/30 = 20 */
+    statsEsperados: z.number().optional(),
+  })
+  .meta({ 'x-collection': 'gateways' });
 export type IGateway = z.infer<typeof GatewaySchema>;
 
 export const CreateGatewaySchema = GatewaySchema.omit({ _id: true });

--- a/src/interfaces/geo-cache.ts
+++ b/src/interfaces/geo-cache.ts
@@ -13,15 +13,18 @@ export const PartesDireccionSchema = z.object({
 });
 export type IPartesDireccion = z.infer<typeof PartesDireccionSchema>;
 
+// Metadata de persistencia por `.meta()` — convención documentada arriba de
+// `ProveedorSchema` en proveedor.ts.
 export const GeoCacheSchema = z.object({
   _id: z.string().optional(),
-  fechaCreacion: z.string().optional(),
-  geojson: GeoJSONPointSchema.optional(),
+  fechaCreacion: z.string().optional().meta({ 'x-bson': 'date' }),
+  // @Prop({type: Object}) en el legacy: Mixed, Mongoose no castea adentro.
+  geojson: GeoJSONPointSchema.optional().meta({ 'x-bson': 'mixed' }),
   geohash: z.string().optional(),
   direccion: z.string().optional(),
-  partes: PartesDireccionSchema.optional(),
+  partes: PartesDireccionSchema.optional().meta({ 'x-bson': 'mixed' }),
   fuente: z.string().optional(), // Fuente de los datos (ej. Google Maps, OpenStreetMap, etc.)
-});
+}).meta({ 'x-collection': 'geocaches' });
 export type IGeoCache = z.infer<typeof GeoCacheSchema>;
 
 export const CreateGeoCacheSchema = GeoCacheSchema.omit({ _id: true });

--- a/src/interfaces/grupo-usuario.ts
+++ b/src/interfaces/grupo-usuario.ts
@@ -2,21 +2,65 @@ import { z } from 'zod';
 import { ClienteSchema } from './cliente';
 import { UsuarioSchema } from './usuario';
 
-export const GrupoUsuarioSchema = z.object({
-  _id: z.string().optional(),
-  idCliente: z.string().optional(),
-  idsAncestros: z.array(z.string()).optional(),
-  nombre: z.string().optional(),
-  idAdmin: z.string().optional(),
-  idsMiembros: z.array(z.string()).optional(),
-  fechaCreacion: z.string().optional(),
+// Metadata de persistencia por `.meta()` — convención documentada arriba de
+// `ProveedorSchema` en proveedor.ts.
+export const GrupoUsuarioSchema = z
+  .object({
+    _id: z.string().optional(),
+    idCliente: z
+      .string()
+      .optional()
+      .meta({ 'x-bson': 'objectId', 'x-ref': 'ClienteSchema' }),
+    idsAncestros: z
+      .array(z.string())
+      .optional()
+      .meta({ 'x-bson': 'objectId', 'x-ref': 'ClienteSchema' }),
+    nombre: z.string().optional(),
+    idAdmin: z
+      .string()
+      .optional()
+      .meta({ 'x-bson': 'objectId', 'x-ref': 'UsuarioSchema' }),
+    idsMiembros: z
+      .array(z.string())
+      .optional()
+      .meta({ 'x-bson': 'objectId', 'x-ref': 'UsuarioSchema' }),
+    fechaCreacion: z.string().optional().meta({ 'x-bson': 'date' }),
 
-  // Populate
-  cliente: ClienteSchema.optional(),
-  ancestros: z.array(ClienteSchema).optional(),
-  admin: UsuarioSchema.optional(),
-  miembros: z.array(UsuarioSchema).optional(),
-});
+    // Populate
+    cliente: ClienteSchema.optional().meta({
+      'x-populate': {
+        ref: 'ClienteSchema',
+        localField: 'idCliente',
+        foreignField: '_id',
+        justOne: true,
+      },
+    }),
+    ancestros: z.array(ClienteSchema).optional().meta({
+      'x-populate': {
+        ref: 'ClienteSchema',
+        localField: 'idsAncestros',
+        foreignField: '_id',
+        justOne: false,
+      },
+    }),
+    admin: UsuarioSchema.optional().meta({
+      'x-populate': {
+        ref: 'UsuarioSchema',
+        localField: 'idAdmin',
+        foreignField: '_id',
+        justOne: true,
+      },
+    }),
+    miembros: z.array(UsuarioSchema).optional().meta({
+      'x-populate': {
+        ref: 'UsuarioSchema',
+        localField: 'idsMiembros',
+        foreignField: '_id',
+        justOne: false,
+      },
+    }),
+  })
+  .meta({ 'x-collection': 'grupousuarios' });
 export type IGrupoUsuario = z.infer<typeof GrupoUsuarioSchema>;
 
 export const CreateGrupoUsuarioSchema = GrupoUsuarioSchema.omit({
@@ -46,24 +90,78 @@ export type EstadoSolicitudGrupoUsuario = z.infer<
   typeof EstadoSolicitudGrupoUsuarioSchema
 >;
 
-export const SolicitudGrupoUsuarioSchema = z.object({
-  _id: z.string().optional(),
-  idCliente: z.string().optional(),
-  idsAncestros: z.array(z.string()).optional(),
-  idGrupoUsuario: z.string().optional(),
-  idRemitente: z.string().optional(),
-  idDestinatario: z.string().optional(),
-  estado: EstadoSolicitudGrupoUsuarioSchema.optional(),
-  fechaCreacion: z.string().optional(),
-  fechaRespuesta: z.string().optional(),
+// Metadata de persistencia por `.meta()` — convención documentada arriba de
+// `ProveedorSchema` en proveedor.ts.
+export const SolicitudGrupoUsuarioSchema = z
+  .object({
+    _id: z.string().optional(),
+    idCliente: z
+      .string()
+      .optional()
+      .meta({ 'x-bson': 'objectId', 'x-ref': 'ClienteSchema' }),
+    idsAncestros: z
+      .array(z.string())
+      .optional()
+      .meta({ 'x-bson': 'objectId', 'x-ref': 'ClienteSchema' }),
+    idGrupoUsuario: z
+      .string()
+      .optional()
+      .meta({ 'x-bson': 'objectId', 'x-ref': 'GrupoUsuarioSchema' }),
+    idRemitente: z
+      .string()
+      .optional()
+      .meta({ 'x-bson': 'objectId', 'x-ref': 'UsuarioSchema' }),
+    idDestinatario: z
+      .string()
+      .optional()
+      .meta({ 'x-bson': 'objectId', 'x-ref': 'UsuarioSchema' }),
+    estado: EstadoSolicitudGrupoUsuarioSchema.optional(),
+    fechaCreacion: z.string().optional().meta({ 'x-bson': 'date' }),
+    fechaRespuesta: z.string().optional().meta({ 'x-bson': 'date' }),
 
-  // Populate
-  cliente: ClienteSchema.optional(),
-  ancestros: z.array(ClienteSchema).optional(),
-  grupoUsuario: GrupoUsuarioSchema.optional(),
-  remitente: UsuarioSchema.optional(),
-  destinatario: UsuarioSchema.optional(),
-});
+    // Populate
+    cliente: ClienteSchema.optional().meta({
+      'x-populate': {
+        ref: 'ClienteSchema',
+        localField: 'idCliente',
+        foreignField: '_id',
+        justOne: true,
+      },
+    }),
+    ancestros: z.array(ClienteSchema).optional().meta({
+      'x-populate': {
+        ref: 'ClienteSchema',
+        localField: 'idsAncestros',
+        foreignField: '_id',
+        justOne: false,
+      },
+    }),
+    grupoUsuario: GrupoUsuarioSchema.optional().meta({
+      'x-populate': {
+        ref: 'GrupoUsuarioSchema',
+        localField: 'idGrupoUsuario',
+        foreignField: '_id',
+        justOne: true,
+      },
+    }),
+    remitente: UsuarioSchema.optional().meta({
+      'x-populate': {
+        ref: 'UsuarioSchema',
+        localField: 'idRemitente',
+        foreignField: '_id',
+        justOne: true,
+      },
+    }),
+    destinatario: UsuarioSchema.optional().meta({
+      'x-populate': {
+        ref: 'UsuarioSchema',
+        localField: 'idDestinatario',
+        foreignField: '_id',
+        justOne: true,
+      },
+    }),
+  })
+  .meta({ 'x-collection': 'solicitudgrupousuarios' });
 export type ISolicitudGrupoUsuario = z.infer<
   typeof SolicitudGrupoUsuarioSchema
 >;

--- a/src/interfaces/grupo.ts
+++ b/src/interfaces/grupo.ts
@@ -15,14 +15,25 @@ export type CategoriaGrupo = z.infer<typeof CategoriaGrupoSchema>;
 // Populates intra-SCC como z.custom (import type-only): un schema real acá
 // arrastra el shape completo del ciclo y revienta la serialización de
 // declarations (TS7056) acá y en los consumidores NestJS.
+// Metadata de persistencia por `.meta()` — convención documentada arriba de
+// `ProveedorSchema` en proveedor.ts.
 export const GrupoSchema = z.object({
   _id: z.string().optional(),
-  idCliente: z.string().optional(),
-  idsAncestros: z.array(z.string()).optional(),
+  idCliente: z
+    .string()
+    .optional()
+    .meta({ 'x-bson': 'objectId', 'x-ref': 'ClienteSchema' }),
+  idsAncestros: z
+    .array(z.string())
+    .optional()
+    .meta({ 'x-bson': 'objectId', 'x-ref': 'ClienteSchema' }),
   nombre: z.string().optional(),
   color: z.string().optional(),
   categoria: CategoriaGrupoSchema.optional(),
-  idsPerfilConfig: z.array(z.string()).optional(),
+  idsPerfilConfig: z
+    .array(z.string())
+    .optional()
+    .meta({ 'x-bson': 'objectId', 'x-ref': 'ConfigPerfilSchema' }),
   prioridad: z.number().optional(),
 
   // Integracion Soflex (los 3 campos van juntos: sin los 3 no hay sync ni reenvío)
@@ -31,9 +42,30 @@ export const GrupoSchema = z.object({
   fleetName: z.string().optional(),
 
   // Populate
-  cliente: ClienteSchema.optional(),
-  ancestros: z.array(ClienteSchema).optional(),
-  perfilConfigs: z.array(z.custom<IConfigPerfil>()).optional(),
+  cliente: ClienteSchema.optional().meta({
+    'x-populate': {
+      ref: 'ClienteSchema',
+      localField: 'idCliente',
+      foreignField: '_id',
+      justOne: true,
+    },
+  }),
+  ancestros: z.array(ClienteSchema).optional().meta({
+    'x-populate': {
+      ref: 'ClienteSchema',
+      localField: 'idsAncestros',
+      foreignField: '_id',
+      justOne: false,
+    },
+  }),
+  perfilConfigs: z.array(z.custom<IConfigPerfil>()).optional().meta({
+    'x-populate': {
+      ref: 'ConfigPerfilSchema',
+      localField: 'idsPerfilConfig',
+      foreignField: '_id',
+      justOne: false,
+    },
+  }),
 }).meta({ 'x-collection': 'grupos' });
 
 /**

--- a/src/interfaces/index.ts
+++ b/src/interfaces/index.ts
@@ -73,6 +73,7 @@ export * from './metricas-gateway';
 export * from './resumen-datos';
 export * from './chirpstack';
 export * from './reporte-generico';
+export * from './ultimo-reporte-generico';
 export * from './evento-generico';
 export * from './excepcion';
 export * from './certificado-entidad';

--- a/src/interfaces/index.ts
+++ b/src/interfaces/index.ts
@@ -43,6 +43,7 @@ export * from './tipo-evento';
 export * from './token';
 export * from './token-push';
 export * from './trackeo';
+export * from './ultimo-trackeo';
 export * from './tracker';
 export * from './tratamiento-evento';
 export * from './twilio-templates';

--- a/src/interfaces/index.ts
+++ b/src/interfaces/index.ts
@@ -20,6 +20,7 @@ export * from './downlink-job';
 export * from './envio-vehiculo';
 export * from './estado-entidad';
 export * from './excepcion';
+export * from './export-job';
 export * from './grupo';
 export * from './grupo-usuario';
 export * from './log-despacho';

--- a/src/interfaces/informacion-tecnica.ts
+++ b/src/interfaces/informacion-tecnica.ts
@@ -15,12 +15,19 @@ export const InfoEndPointSchema = z.object({
 });
 export type IInfoEndPoint = z.infer<typeof InfoEndPointSchema>;
 
+// Metadata de persistencia por `.meta()` — convención documentada arriba de
+// `ProveedorSchema` en proveedor.ts.
 export const InformacionTecnicaSchema = z.object({
   _id: z.string().optional(),
   titulo: z.string().optional(),
   descripcion: z.string().optional(),
-  infoEndPoints: z.array(InfoEndPointSchema).optional(),
-});
+  // @Prop({type: Object}) en el legacy: Mixed — escalar para Mongoose pese al
+  // array de TS (exento en arraysQueNoSonArrays de gestion-datos-go).
+  infoEndPoints: z
+    .array(InfoEndPointSchema)
+    .optional()
+    .meta({ 'x-bson': 'mixed' }),
+}).meta({ 'x-collection': 'informaciontecnicas' });
 export type IInformacionTecnica = z.infer<typeof InformacionTecnicaSchema>;
 
 export const CreateInformacionTecnicaSchema = InformacionTecnicaSchema.omit({

--- a/src/interfaces/listado-categoria.ts
+++ b/src/interfaces/listado-categoria.ts
@@ -23,19 +23,41 @@ export const TipoListadoCategoriaSchema = z.enum([
 ]);
 export type ITipoListadoCategoria = z.infer<typeof TipoListadoCategoriaSchema>;
 
-export const ListadoCategoriaSchema = z.object({
-  _id: z.string().optional(),
-  //
-  nombre: z.string().optional(),
-  categoria: TipoListadoCategoriaSchema.optional(),
-  idCliente: z.string().optional(),
-  idsAncestros: z.array(z.string()).optional(),
-  default: z.boolean().optional(),
-  global: z.boolean().optional(),
-  //Populate
-  cliente: ClienteSchema.optional(),
-  ancestros: z.array(ClienteSchema).optional(),
-});
+export const ListadoCategoriaSchema = z
+  .object({
+    _id: z.string().optional(),
+    //
+    nombre: z.string().optional(),
+    categoria: TipoListadoCategoriaSchema.optional(),
+    idCliente: z
+      .string()
+      .optional()
+      .meta({ 'x-bson': 'objectId', 'x-ref': 'ClienteSchema' }),
+    idsAncestros: z
+      .array(z.string())
+      .optional()
+      .meta({ 'x-bson': 'objectId', 'x-ref': 'ClienteSchema' }),
+    default: z.boolean().optional(),
+    global: z.boolean().optional(),
+    //Populate
+    cliente: ClienteSchema.optional().meta({
+      'x-populate': {
+        ref: 'ClienteSchema',
+        localField: 'idCliente',
+        foreignField: '_id',
+        justOne: true,
+      },
+    }),
+    ancestros: z.array(ClienteSchema).optional().meta({
+      'x-populate': {
+        ref: 'ClienteSchema',
+        localField: 'idsAncestros',
+        foreignField: '_id',
+        justOne: false,
+      },
+    }),
+  })
+  .meta({ 'x-collection': 'listadocategorias' });
 export type IListadoCategoria = z.infer<typeof ListadoCategoriaSchema>;
 
 export const CreateListadoCategoriaSchema = ListadoCategoriaSchema.omit({

--- a/src/interfaces/log-despacho.ts
+++ b/src/interfaces/log-despacho.ts
@@ -1,20 +1,51 @@
 import { z } from 'zod';
 import { ClienteSchema } from './cliente';
 
-export const LogDespachoSchema = z.object({
-  _id: z.string(),
-  idCliente: z.string().optional(),
-  idsAncestros: z.array(z.string()).optional(),
-  fechaCreacion: z.string().optional(),
-  expireAt: z.string().optional(),
-  idExternoVehiculo: z.string().optional(),
-  idExternoRecorrido: z.string().optional(),
-  idExternoChofer: z.string().optional(),
-  fecha: z.string().optional(),
-  // Populate
-  cliente: ClienteSchema.optional(),
-  ancestros: z.array(ClienteSchema).optional(),
-});
+// Metadata de persistencia por `.meta()` — convención documentada arriba de
+// `ProveedorSchema` en proveedor.ts.
+export const LogDespachoSchema = z
+  .object({
+    _id: z.string(),
+    idCliente: z
+      .string()
+      .optional()
+      .meta({ 'x-bson': 'objectId', 'x-ref': 'ClienteSchema' }),
+    idsAncestros: z
+      .array(z.string())
+      .optional()
+      .meta({ 'x-bson': 'objectId', 'x-ref': 'ClienteSchema' }),
+    fechaCreacion: z.string().optional().meta({ 'x-bson': 'date' }),
+    expireAt: z.string().optional().meta({ 'x-bson': 'date' }),
+    idExternoVehiculo: z.string().optional(),
+    idExternoRecorrido: z.string().optional(),
+    idExternoChofer: z.string().optional(),
+    // SIN x-bson: divergencia encontrada, no corregida acá (docs/MIGRACION.md
+    // §7). meta.go de logdespachos castea "fecha" como TypeDate, pero el
+    // @Prop legacy es `@Prop() fecha?: string;` sin `type: Date` — Mongoose
+    // infiere String por reflexión de TS, y legacy-schemas.json lo confirma
+    // (tipo:"" en vez de "Date"). Anotar acá 'x-bson':'date' silenciaría el
+    // hallazgo en vez de exponerlo: se documenta y no se toca ninguno de los
+    // dos lados.
+    fecha: z.string().optional(),
+    // Populate
+    cliente: ClienteSchema.optional().meta({
+      'x-populate': {
+        ref: 'ClienteSchema',
+        localField: 'idCliente',
+        foreignField: '_id',
+        justOne: true,
+      },
+    }),
+    ancestros: z.array(ClienteSchema).optional().meta({
+      'x-populate': {
+        ref: 'ClienteSchema',
+        localField: 'idsAncestros',
+        foreignField: '_id',
+        justOne: false,
+      },
+    }),
+  })
+  .meta({ 'x-collection': 'logdespachos' });
 export type ILogDespacho = z.infer<typeof LogDespachoSchema>;
 
 ////// CREATE

--- a/src/interfaces/log-evento.ts
+++ b/src/interfaces/log-evento.ts
@@ -24,29 +24,48 @@ export const MetadatosUplinkSchema = z.object({
 });
 export type IMetadatosUplink = z.infer<typeof MetadatosUplinkSchema>;
 
-export const LogEventoSchema = z.object({
-  _id: z.string().optional(),
-  fechaCreacion: z.string().optional(),
-  expireAt: z.string().optional(),
-  tipo: TipoLogEventoSchema.optional(),
-  deveui: z.string().optional(),
-  deviceName: z.string().optional(),
-  payload: z.string().optional(),
-  puerto: z.number().optional(),
-  battery: z.number().optional(),
-  fCnt: z.number().optional(),
-  margin: z.number().optional(),
-  metadatosUplink: MetadatosUplinkSchema.optional(),
+// Metadata de persistencia por `.meta()` — convención documentada arriba de
+// `ProveedorSchema` en proveedor.ts.
+export const LogEventoSchema = z
+  .object({
+    _id: z.string().optional(),
+    fechaCreacion: z.string().optional().meta({ 'x-bson': 'date' }),
+    expireAt: z.string().optional().meta({ 'x-bson': 'date' }),
+    tipo: TipoLogEventoSchema.optional(),
+    deveui: z.string().optional().meta({ 'x-setter': 'uppercase' }),
+    deviceName: z.string().optional().meta({ 'x-setter': 'uppercase' }),
+    payload: z.string().optional(),
+    puerto: z.number().optional(),
+    battery: z.number().optional(),
+    fCnt: z.number().optional(),
+    margin: z.number().optional(),
+    // @Prop({type: Object}) en el legacy: Mixed, Mongoose no castea adentro.
+    metadatosUplink: MetadatosUplinkSchema.optional().meta({
+      'x-bson': 'mixed',
+    }),
 
-  // Campos específicos para mensajes de tipo 'log' de ChirpStack
-  level: z.string().optional(), // "ERROR", "WARNING", "INFO"
-  code: z.string().optional(), // Código del tipo de log (ej: "DOWNLINK_GATEWAY", "UPLINK_F_CNT_RETRANSMISSION")
-  description: z.string().optional(), // Descripción del evento
-  context: z.record(z.string(), z.any()).optional(), // Contexto adicional del log
+    // Campos específicos para mensajes de tipo 'log' de ChirpStack
+    level: z.string().optional(), // "ERROR", "WARNING", "INFO"
+    code: z.string().optional(), // Código del tipo de log (ej: "DOWNLINK_GATEWAY", "UPLINK_F_CNT_RETRANSMISSION")
+    description: z.string().optional(), // Descripción del evento
+    // @Prop({type: Object}) en el legacy: Mixed, Mongoose no castea adentro.
+    context: z.record(z.string(), z.any()).optional().meta({
+      'x-bson': 'mixed',
+    }), // Contexto adicional del log
 
-  //Populate
-  dispositivoLorawan: DispositivoLorawanSchema.optional(),
-});
+    // Populate. sic legacy: el virtual real se llama "dispositivo" (localField
+    // deveui, foreignField deveui); getById pide "dispositivoLorawan" → bug de
+    // strictPopulate documentado en el meta.go de logEventoMqtts.
+    dispositivoLorawan: DispositivoLorawanSchema.optional().meta({
+      'x-populate': {
+        ref: 'DispositivoLorawanSchema',
+        localField: 'deveui',
+        foreignField: 'deveui',
+        justOne: true,
+      },
+    }),
+  })
+  .meta({ 'x-collection': 'logeventos' });
 export type ILogEvento = z.infer<typeof LogEventoSchema>;
 
 export const CreateLogEventoSchema = LogEventoSchema.omit({

--- a/src/interfaces/log-generico.ts
+++ b/src/interfaces/log-generico.ts
@@ -44,20 +44,43 @@ export interface ILogBase<T extends keyof MapaValoresLog> {
   ancestros?: ICliente[];
 }
 
-export const LogGenericoSchema = z.object({
-  _id: z.string(),
-  fechaCreacion: z.string().optional(),
-  idCliente: z.string().optional(),
-  expireAt: z.string().optional(),
-  //
-  idsAncestros: z.array(z.string()).optional(),
-  tipoEntidad: TipoEntidadLogSchema.optional(),
-  tipoReporte: TipoLogsSchema.optional(),
-  valores: LogMensajeSchema.optional(),
-  // Populate
-  cliente: ClienteSchema.optional(),
-  ancestros: z.array(ClienteSchema).optional(),
-});
+export const LogGenericoSchema = z
+  .object({
+    _id: z.string(),
+    fechaCreacion: z.string().optional().meta({ 'x-bson': 'date' }),
+    idCliente: z
+      .string()
+      .optional()
+      .meta({ 'x-bson': 'objectId', 'x-ref': 'ClienteSchema' }),
+    expireAt: z.string().optional().meta({ 'x-bson': 'date' }),
+    //
+    idsAncestros: z
+      .array(z.string())
+      .optional()
+      .meta({ 'x-bson': 'objectId', 'x-ref': 'ClienteSchema' }),
+    tipoEntidad: TipoEntidadLogSchema.optional(),
+    tipoReporte: TipoLogsSchema.optional(),
+    // @Prop({type: Object}) en el legacy: Mixed, Mongoose no castea adentro.
+    valores: LogMensajeSchema.optional().meta({ 'x-bson': 'mixed' }),
+    // Populate
+    cliente: ClienteSchema.optional().meta({
+      'x-populate': {
+        ref: 'ClienteSchema',
+        localField: 'idCliente',
+        foreignField: '_id',
+        justOne: true,
+      },
+    }),
+    ancestros: z.array(ClienteSchema).optional().meta({
+      'x-populate': {
+        ref: 'ClienteSchema',
+        localField: 'idsAncestros',
+        foreignField: '_id',
+        justOne: false,
+      },
+    }),
+  })
+  .meta({ 'x-collection': 'loggenericos' });
 export type ILogGenerico = z.infer<typeof LogGenericoSchema>;
 
 ////// CREATE

--- a/src/interfaces/log-https.ts
+++ b/src/interfaces/log-https.ts
@@ -1,9 +1,11 @@
 import { z } from 'zod';
 
+// Metadata de persistencia por `.meta()` — convención documentada arriba de
+// `ProveedorSchema` en proveedor.ts.
 export const LogHttpSchema = z.object({
   _id: z.string().optional(),
-  fechaCreacion: z.string().optional(),
-  expireAt: z.string().optional(),
+  fechaCreacion: z.string().optional().meta({ 'x-bson': 'date' }),
+  expireAt: z.string().optional().meta({ 'x-bson': 'date' }),
   method: z.string().optional(),
   url: z.string().optional(),
   path: z.string().optional(),
@@ -11,7 +13,7 @@ export const LogHttpSchema = z.object({
   headers: z.string().optional(),
   query: z.string().optional(),
   params: z.string().optional(),
-});
+}).meta({ 'x-collection': 'loghttps' });
 export type ILogHttp = z.infer<typeof LogHttpSchema>;
 
 export const CreateLogHttpSchema = LogHttpSchema.omit({

--- a/src/interfaces/log-reenvio.ts
+++ b/src/interfaces/log-reenvio.ts
@@ -3,28 +3,68 @@ import { ClienteSchema } from './cliente';
 import { DispositivoAlarmaSchema } from './dispositivo-alarma';
 import { TrackerSchema } from './tracker';
 
-export const LogReenvioSchema = z.object({
-  _id: z.string().optional(),
-  expireAt: z.string().optional(),
-  //
-  idCliente: z.string().optional(),
-  idsAncestros: z.array(z.string()).optional(),
-  fecha: z.string().optional(),
-  idEntidad: z.string().optional(),
+// Metadata de persistencia por `.meta()` — convención documentada arriba de
+// `ProveedorSchema` en proveedor.ts.
+export const LogReenvioSchema = z
+  .object({
+    _id: z.string().optional(),
+    expireAt: z.string().optional().meta({ 'x-bson': 'date' }),
+    //
+    idCliente: z
+      .string()
+      .optional()
+      .meta({ 'x-bson': 'objectId', 'x-ref': 'ClienteSchema' }),
+    idsAncestros: z
+      .array(z.string())
+      .optional()
+      .meta({ 'x-bson': 'objectId', 'x-ref': 'ClienteSchema' }),
+    fecha: z.string().optional().meta({ 'x-bson': 'date' }),
+    // Sin x-ref propio: se popula bajo los nombres "dispositivoAlarma"/
+    // "tracker" (virtuals con nombre distinto al path).
+    idEntidad: z.string().optional().meta({ 'x-bson': 'objectId' }),
 
-  protocolo: z.enum(['UDP', 'TCP']).optional(),
-  host: z.string().optional(),
-  puerto: z.number().optional(),
-  body: z.string().optional(),
-  ack: z.boolean().optional(),
-  error: z.string().optional(),
+    protocolo: z.enum(['UDP', 'TCP']).optional(),
+    host: z.string().optional(),
+    puerto: z.number().optional(),
+    body: z.string().optional(),
+    ack: z.boolean().optional(),
+    error: z.string().optional(),
 
-  // Populate
-  cliente: ClienteSchema.optional(),
-  ancestros: z.array(ClienteSchema).optional(),
-  dispositivoAlarma: DispositivoAlarmaSchema.optional(),
-  tracker: TrackerSchema.optional(),
-});
+    // Populate
+    cliente: ClienteSchema.optional().meta({
+      'x-populate': {
+        ref: 'ClienteSchema',
+        localField: 'idCliente',
+        foreignField: '_id',
+        justOne: true,
+      },
+    }),
+    ancestros: z.array(ClienteSchema).optional().meta({
+      'x-populate': {
+        ref: 'ClienteSchema',
+        localField: 'idsAncestros',
+        foreignField: '_id',
+        justOne: false,
+      },
+    }),
+    dispositivoAlarma: DispositivoAlarmaSchema.optional().meta({
+      'x-populate': {
+        ref: 'DispositivoAlarmaSchema',
+        localField: 'idEntidad',
+        foreignField: '_id',
+        justOne: true,
+      },
+    }),
+    tracker: TrackerSchema.optional().meta({
+      'x-populate': {
+        ref: 'TrackerSchema',
+        localField: 'idEntidad',
+        foreignField: '_id',
+        justOne: true,
+      },
+    }),
+  })
+  .meta({ 'x-collection': 'logreenvios' });
 export type ILogReenvio = z.infer<typeof LogReenvioSchema>;
 
 export const CreateLogReenvioSchema = LogReenvioSchema.omit({

--- a/src/interfaces/log-trackeo.ts
+++ b/src/interfaces/log-trackeo.ts
@@ -2,27 +2,61 @@ import { z } from 'zod';
 import { ActivoSchema } from './activo';
 import { ClienteSchema } from './cliente';
 
-export const LogTrackeoSchema = z.object({
-  _id: z.string().optional(),
-  expireAt: z.string().optional(),
-  //
-  idCliente: z.string().optional(),
-  idsAncestros: z.array(z.string()).optional(),
-  idActivo: z.string().optional(),
-  fecha: z.string().optional(),
-  nuevaParada: z.boolean().optional(),
-  indexUltimaParada: z.number().optional(),
-  indexParadaActual: z.number().optional(),
-  ultimaParada: z.string().optional(),
-  paradaActual: z.string().optional(),
-  totalParadas: z.number().optional(),
-  motivo: z.string().optional(),
+// Metadata de persistencia por `.meta()` — convención documentada arriba de
+// `ProveedorSchema` en proveedor.ts.
+export const LogTrackeoSchema = z
+  .object({
+    _id: z.string().optional(),
+    expireAt: z.string().optional().meta({ 'x-bson': 'date' }),
+    //
+    idCliente: z
+      .string()
+      .optional()
+      .meta({ 'x-bson': 'objectId', 'x-ref': 'ClienteSchema' }),
+    idsAncestros: z
+      .array(z.string())
+      .optional()
+      .meta({ 'x-bson': 'objectId', 'x-ref': 'ClienteSchema' }),
+    idActivo: z
+      .string()
+      .optional()
+      .meta({ 'x-bson': 'objectId', 'x-ref': 'ActivoSchema' }),
+    fecha: z.string().optional().meta({ 'x-bson': 'date' }),
+    nuevaParada: z.boolean().optional(),
+    indexUltimaParada: z.number().optional(),
+    indexParadaActual: z.number().optional(),
+    ultimaParada: z.string().optional(),
+    paradaActual: z.string().optional(),
+    totalParadas: z.number().optional(),
+    motivo: z.string().optional(),
 
-  // Populate
-  cliente: ClienteSchema.optional(),
-  ancestros: z.array(ClienteSchema).optional(),
-  activo: ActivoSchema.optional(),
-});
+    // Populate
+    cliente: ClienteSchema.optional().meta({
+      'x-populate': {
+        ref: 'ClienteSchema',
+        localField: 'idCliente',
+        foreignField: '_id',
+        justOne: true,
+      },
+    }),
+    ancestros: z.array(ClienteSchema).optional().meta({
+      'x-populate': {
+        ref: 'ClienteSchema',
+        localField: 'idsAncestros',
+        foreignField: '_id',
+        justOne: false,
+      },
+    }),
+    activo: ActivoSchema.optional().meta({
+      'x-populate': {
+        ref: 'ActivoSchema',
+        localField: 'idActivo',
+        foreignField: '_id',
+        justOne: true,
+      },
+    }),
+  })
+  .meta({ 'x-collection': 'logtrackeos' });
 export type ILogTrackeo = z.infer<typeof LogTrackeoSchema>;
 
 export const CreateLogTrackeoSchema = LogTrackeoSchema.omit({

--- a/src/interfaces/log-twilio.ts
+++ b/src/interfaces/log-twilio.ts
@@ -28,24 +28,46 @@ export type TwilioMessageDirection = z.infer<
   typeof TwilioMessageDirectionSchema
 >;
 
-export const LogTwilioSchema = z.object({
-  _id: z.string(),
-  fechaCreacion: z.string().optional(),
-  idCliente: z.string().optional(),
-  idsAncestros: z.array(z.string()).optional(),
-  phone: z.string().optional(),
-  sid: z.string().optional(),
-  body: z.string().optional(),
-  direction: TwilioMessageDirectionSchema.optional(),
-  status: TwilioMessageStatusSchema.optional(),
-  error: z.boolean().optional(),
-  /// Solo en error
-  errorCode: z.string().optional(),
-  errorMessage: z.string().optional(),
-  // Populate
-  cliente: ClienteSchema.optional(),
-  ancestros: z.array(ClienteSchema).optional(),
-});
+export const LogTwilioSchema = z
+  .object({
+    _id: z.string(),
+    fechaCreacion: z.string().optional().meta({ 'x-bson': 'date' }),
+    idCliente: z
+      .string()
+      .optional()
+      .meta({ 'x-bson': 'objectId', 'x-ref': 'ClienteSchema' }),
+    idsAncestros: z
+      .array(z.string())
+      .optional()
+      .meta({ 'x-bson': 'objectId', 'x-ref': 'ClienteSchema' }),
+    phone: z.string().optional(),
+    sid: z.string().optional(),
+    body: z.string().optional(),
+    direction: TwilioMessageDirectionSchema.optional(),
+    status: TwilioMessageStatusSchema.optional(),
+    error: z.boolean().optional(),
+    /// Solo en error
+    errorCode: z.string().optional(),
+    errorMessage: z.string().optional(),
+    // Populate
+    cliente: ClienteSchema.optional().meta({
+      'x-populate': {
+        ref: 'ClienteSchema',
+        localField: 'idCliente',
+        foreignField: '_id',
+        justOne: true,
+      },
+    }),
+    ancestros: z.array(ClienteSchema).optional().meta({
+      'x-populate': {
+        ref: 'ClienteSchema',
+        localField: 'idsAncestros',
+        foreignField: '_id',
+        justOne: false,
+      },
+    }),
+  })
+  .meta({ 'x-collection': 'logtwilios' });
 export type ILogTwilio = z.infer<typeof LogTwilioSchema>;
 
 ////// CREATE

--- a/src/interfaces/login-evento.ts
+++ b/src/interfaces/login-evento.ts
@@ -25,26 +25,55 @@ export type PlataformaLogin = z.infer<typeof PlataformaLoginSchema>;
  *
  * La colección tiene un índice TTL sobre `fecha` (retención 1 año).
  */
-export const LoginEventoSchema = z.object({
-  _id: z.string().optional(),
-  // Vínculo con el usuario que inició sesión.
-  idUsuario: z.string().optional(),
-  // Nombre de usuario denormalizado (lowercase), por si el usuario se borra.
-  usuario: z.string().optional(),
-  // Cliente del usuario al momento del login (puede no tener).
-  idCliente: z.string().optional(),
-  // Cadena de clientes ancestros del idCliente, para roll-up por subárbol.
-  idsAncestros: z.array(z.string()).optional(),
-  // Momento del login. Ancla del índice TTL.
-  fecha: z.string().optional(),
-  metodo: MetodoLoginSchema.optional(),
-  plataforma: PlataformaLoginSchema.optional(),
-  // User-Agent crudo (best-effort), por si luego se quiere afinar plataforma.
-  userAgent: z.string().optional(),
-  // Populate / Virtual
-  usuarioDoc: UsuarioSchema.optional(),
-  cliente: ClienteSchema.optional(),
-});
+// Metadata de persistencia por `.meta()` — convención documentada arriba de
+// `ProveedorSchema` en proveedor.ts.
+export const LoginEventoSchema = z
+  .object({
+    _id: z.string().optional(),
+    // Vínculo con el usuario que inició sesión.
+    idUsuario: z
+      .string()
+      .optional()
+      .meta({ 'x-bson': 'objectId', 'x-ref': 'UsuarioSchema' }),
+    // Nombre de usuario denormalizado (lowercase), por si el usuario se borra.
+    // Setter lowercase del @Prop legacy: corre TAMBIÉN en el cast de las
+    // queries, así que sin esto un filtro por "JUAN" no matchea "juan".
+    usuario: z.string().optional().meta({ 'x-setter': 'lowercase' }),
+    // Cliente del usuario al momento del login (puede no tener).
+    idCliente: z
+      .string()
+      .optional()
+      .meta({ 'x-bson': 'objectId', 'x-ref': 'ClienteSchema' }),
+    // Cadena de clientes ancestros del idCliente, para roll-up por subárbol.
+    idsAncestros: z
+      .array(z.string())
+      .optional()
+      .meta({ 'x-bson': 'objectId', 'x-ref': 'ClienteSchema' }),
+    // Momento del login. Ancla del índice TTL.
+    fecha: z.string().optional().meta({ 'x-bson': 'date' }),
+    metodo: MetodoLoginSchema.optional(),
+    plataforma: PlataformaLoginSchema.optional(),
+    // User-Agent crudo (best-effort), por si luego se quiere afinar plataforma.
+    userAgent: z.string().optional(),
+    // Populate / Virtual
+    usuarioDoc: UsuarioSchema.optional().meta({
+      'x-populate': {
+        ref: 'UsuarioSchema',
+        localField: 'idUsuario',
+        foreignField: '_id',
+        justOne: true,
+      },
+    }),
+    cliente: ClienteSchema.optional().meta({
+      'x-populate': {
+        ref: 'ClienteSchema',
+        localField: 'idCliente',
+        foreignField: '_id',
+        justOne: true,
+      },
+    }),
+  })
+  .meta({ 'x-collection': 'logineventos' });
 export type ILoginEvento = z.infer<typeof LoginEventoSchema>;
 
 export const CreateLoginEventoSchema = LoginEventoSchema.omit({

--- a/src/interfaces/luminaria.ts
+++ b/src/interfaces/luminaria.ts
@@ -107,47 +107,74 @@ export interface ILuminariaGenerica<T extends TipoDispositivoLuminaria> {
   } | null;
 }
 
+// SPIKE etapa 1 + tarea 3 (2026-08-06): metadata de persistencia por
+// `.meta()`. Convención documentada arriba de ProveedorSchema
+// (src/interfaces/proveedor.ts) — copiada acá, no reinventada.
+//
 // Campos comunes a las dos variantes (sin tipoDispositivo/ultimoReporte*, que discriminan)
 const LuminariaCamposSchema = z.object({
   _id: z.string().optional(),
-  fechaCreacion: z.string().optional(), // Default: Date.now
-  idCliente: z.string().optional(),
-  idsAncestros: z.array(z.string()).optional(),
-  deveui: z.string().optional(), // Deveui del dispositivo lorawan
+  fechaCreacion: z.string().optional().meta({ 'x-bson': 'date' }), // Default: Date.now
+  idCliente: z.string().optional().meta({ 'x-bson': 'objectId', 'x-ref': 'ClienteSchema' }),
+  idsAncestros: z.array(z.string()).optional().meta({ 'x-bson': 'objectId', 'x-ref': 'ClienteSchema' }),
+  deveui: z.string().optional().meta({ 'x-setter': 'uppercase' }), // Deveui del dispositivo lorawan
   identificacion: z.string().optional(),
-  ubicacion: GeoJSONPointSchema.optional(), // GeoJSON de la ubicacion de la luminaria (si hay idPuesta, se coloca la de la puesta)
+  // @Prop({type: Object}) en el legacy: Mixed.
+  ubicacion: GeoJSONPointSchema.optional().meta({ 'x-bson': 'mixed' }), // GeoJSON de la ubicacion de la luminaria (si hay idPuesta, se coloca la de la puesta)
   direccion: z.string().optional(), // Direccion de la luminaria
-  idModeloDispositivo: z.string().optional(), // ID del modelo de dispositivo
-  idPuesta: z.string().optional(), // (opcional, solo clientes con moduloLuminarias.usaPuestas)
-  idsGrupos: z.array(z.string()).optional(),
+  idModeloDispositivo: z.string().optional().meta({ 'x-bson': 'objectId', 'x-ref': 'ModeloDispositivoSchema' }), // ID del modelo de dispositivo
+  idPuesta: z.string().optional().meta({ 'x-bson': 'objectId', 'x-ref': 'PuestaSchema' }), // (opcional, solo clientes con moduloLuminarias.usaPuestas)
+  idsGrupos: z.array(z.string()).optional().meta({ 'x-bson': 'objectId', 'x-ref': 'GrupoSchema' }),
   tiempoEncendida: z.number().optional(), // En horas
-  fechaUltimaComunicacion: z.string().optional(), // Fecha del ultima comunicacion recibida por el dispositivo
-  idPerfilConfig: z.string().optional(),
+  fechaUltimaComunicacion: z.string().optional().meta({ 'x-bson': 'date' }), // Fecha del ultima comunicacion recibida por el dispositivo
+  idPerfilConfig: z.string().optional().meta({ 'x-bson': 'objectId', 'x-ref': 'ConfigPerfilSchema' }),
   tipoEnergizado: TipoEnergizadoSchema.optional(),
   estadoOperativo: EstadoOperativoLuminariaSchema.optional(), // Condición administrativa (Operativa/Mantenimiento)
-  estado: EstadoLuminariaCalculadoSchema.optional(), // Estado calculado de funcionamiento (6 estados). Escrito por backend (uplinks + cron); persiste hasta el próximo cambio.
+  // @Prop({type: Object}) en el legacy: Mixed.
+  estado: EstadoLuminariaCalculadoSchema.optional().meta({ 'x-bson': 'mixed' }), // Estado calculado de funcionamiento (6 estados). Escrito por backend (uplinks + cron); persiste hasta el próximo cambio.
 
   // Habilitación de Servicio Técnico
   puedeSolicitarServicioTecnico: z.boolean().optional(), // Si esta luminaria puede recibir servicio técnico
-  idsClientesQuePuedenAtenderEventosTecnicos: z.array(z.string()).optional(), // Clientes habilitados a atender el ST de esta luminaria
-  configHorariosAtencionTecnica: z.array(ConfigHorarioSchema).optional(), // Clientes que atienden + ventanas horarias
+  idsClientesQuePuedenAtenderEventosTecnicos: z.array(z.string()).optional().meta({ 'x-bson': 'objectId', 'x-ref': 'ClienteSchema' }), // Clientes habilitados a atender el ST de esta luminaria
+  // @Prop({type: [Object]}) en el legacy: array real (se inicializa a []) de Mixed.
+  configHorariosAtencionTecnica: z.array(ConfigHorarioSchema).optional().meta({ 'x-bson': 'mixed' }), // Clientes que atienden + ventanas horarias
 
   // Virtuals
   // Populates intra-SCC como z.custom (import type-only): un schema real acá
   // arrastra el shape completo del ciclo y revienta la serialización de
   // declarations (TS7056) acá y en los consumidores NestJS.
-  cliente: ClienteSchema.optional(),
-  ancestros: z.array(ClienteSchema).optional(),
-  clientesQuePuedenAtenderEventosTecnicos: z.array(ClienteSchema).optional(), // populate de idsClientesQuePuedenAtenderEventosTecnicos
-  dispositivo: z.custom<IDispositivoLorawan>().optional(),
-  modeloDispositivo: ModeloDispositivoSchema.optional(),
-  grupos: z.array(z.custom<IGrupo>()).optional(),
-  perfilConfig: z.custom<IConfigPerfil>().optional(),
-  puesta: z.custom<IPuesta>().optional(),
+  cliente: ClienteSchema.optional().meta({
+    'x-populate': { ref: 'ClienteSchema', localField: 'idCliente', foreignField: '_id', justOne: true },
+  }),
+  // sic legacy: ancestros con justOne TRUE (schema.ts) — devuelve un solo
+  // cliente aunque el localField sea array.
+  ancestros: z.array(ClienteSchema).optional().meta({
+    'x-populate': { ref: 'ClienteSchema', localField: 'idsAncestros', foreignField: '_id', justOne: true },
+  }),
+  clientesQuePuedenAtenderEventosTecnicos: z.array(ClienteSchema).optional().meta({
+    'x-populate': { ref: 'ClienteSchema', localField: 'idsClientesQuePuedenAtenderEventosTecnicos', foreignField: '_id', justOne: false },
+  }), // populate de idsClientesQuePuedenAtenderEventosTecnicos
+  dispositivo: z.custom<IDispositivoLorawan>().optional().meta({
+    'x-populate': { ref: 'DispositivoLorawanSchema', localField: 'deveui', foreignField: 'deveui', justOne: true },
+  }),
+  modeloDispositivo: ModeloDispositivoSchema.optional().meta({
+    'x-populate': { ref: 'ModeloDispositivoSchema', localField: 'idModeloDispositivo', foreignField: '_id', justOne: true },
+  }),
+  grupos: z.array(z.custom<IGrupo>()).optional().meta({
+    'x-populate': { ref: 'GrupoSchema', localField: 'idsGrupos', foreignField: '_id', justOne: false },
+  }),
+  perfilConfig: z.custom<IConfigPerfil>().optional().meta({
+    'x-populate': { ref: 'ConfigPerfilSchema', localField: 'idPerfilConfig', foreignField: '_id', justOne: true },
+  }),
+  puesta: z.custom<IPuesta>().optional().meta({
+    'x-populate': { ref: 'PuestaSchema', localField: 'idPuesta', foreignField: '_id', justOne: true },
+  }),
 
   // Computado (no persistido): perfil efectivo resuelto por jerarquía
   // (luminaria > grupo por prioridad > puesta > grupo de puestas). Solo se
-  // completa cuando la query pide `incluirPerfilEfectivo`.
+  // completa cuando la query pide `incluirPerfilEfectivo`. Hallazgo tarea 2
+  // bis (docs/MIGRACION.md §7 item 20): sin `x-computed` sync.py no puede
+  // distinguirlo de un campo real.
   perfilEfectivo: z
     .object({
       get nivel() {
@@ -157,32 +184,37 @@ const LuminariaCamposSchema = z.object({
       nombre: z.string().nullable().optional(),
     })
     .nullable()
-    .optional(),
+    .optional()
+    .meta({ 'x-computed': true }),
 });
 
 const VarianteLuminariaGPE = LuminariaCamposSchema.extend({
   tipoDispositivo: z.literal('Luminaria GPE').optional(), // Tipo de dispositivo (Luminaria GPE, Luminaria ACTIS FING, etc)
+  // @Prop({type: Object}) en el legacy: Mixed.
   ultimoReportePeriodico: z
     .custom<IReporteBase<'Luminaria GPE Periódico'>>()
-    .optional(), // Ultimo reporte periodico recibido
+    .optional()
+    .meta({ 'x-bson': 'mixed' }), // Ultimo reporte periodico recibido
   ultimoReporteEnergia: z
     .custom<IReporteBase<'Luminaria GPE Energía'>>()
-    .optional(), // Ultimo reporte energia recibido
+    .optional()
+    .meta({ 'x-bson': 'mixed' }), // Ultimo reporte energia recibido
 });
 const VarianteLuminariaACTISFING = LuminariaCamposSchema.extend({
   tipoDispositivo: z.literal('Luminaria ACTIS FING').optional(), // Tipo de dispositivo (Luminaria GPE, Luminaria ACTIS FING, etc)
   ultimoReportePeriodico: z
     .custom<IReporteBase<'Luminaria ACTIS FING Estado'>>()
-    .optional(), // Ultimo reporte periodico recibido
+    .optional()
+    .meta({ 'x-bson': 'mixed' }), // Ultimo reporte periodico recibido
   ultimoReporteEnergia: z
     .custom<IReporteBase<'Luminaria ACTIS FING Energía'>>()
-    .optional(), // Ultimo reporte energia recibido
+    .optional()
+    .meta({ 'x-bson': 'mixed' }), // Ultimo reporte energia recibido
 });
 
-export const LuminariaSchema = z.union([
-  VarianteLuminariaGPE,
-  VarianteLuminariaACTISFING,
-]);
+export const LuminariaSchema = z
+  .union([VarianteLuminariaGPE, VarianteLuminariaACTISFING])
+  .meta({ 'x-collection': 'luminarias' });
 
 /**
  * Tipo legacy hand-written (NO z.infer): el ciclo luminaria ↔ puesta ↔

--- a/src/interfaces/material-servicio-tecnico.ts
+++ b/src/interfaces/material-servicio-tecnico.ts
@@ -33,29 +33,85 @@ export const EstadoPedidoMaterialSchema = z.enum([
 ]);
 export type EstadoPedidoMaterial = z.infer<typeof EstadoPedidoMaterialSchema>;
 
-export const MaterialServicioTecnicoSchema = z.object({
-  _id: z.string().optional(),
-  idCliente: z.string().optional(),
-  idsAncestros: z.array(z.string()).optional(),
-  idEventoGenerico: z.string().optional(), //Ausente cuando el material es stock asignado a la caja del técnico (tipo 'asignado').
-  idUsuario: z.string().optional(), //quien registró/solicitó el material, o a quien está asignado el stock
-  tipo: TipoMaterialServicioTecnicoSchema.optional(),
-  descripcion: z.string().optional(),
-  cantidad: z.number().optional(),
-  imagenes: z.array(z.string()).optional(),
-  estado: EstadoPedidoMaterialSchema.optional(),
-  idEntidad: z.string().optional(), //Entidad del sistema referenciada por este material (opcional).
-  tipoEntidad: z.custom<IEntidades>().optional(),
-  /** Reservado para stock futuro: vínculo a artículo de inventario. No usar aún. */
-  idArticulo: z.string().optional(),
-  fechaCreacion: z.string().optional(),
-  // Populate
-  cliente: ClienteSchema.optional(),
-  ancestros: z.array(ClienteSchema).optional(),
-  evento: z.custom<IEventoGenerico>().optional(),
-  usuario: UsuarioSchema.optional(),
-  dispositivoLorawan: z.custom<IDispositivoLorawan>().optional(), // populate de idEntidad cuando tipoEntidad === 'Dispositivo Lorawan'
-});
+// Metadata de persistencia por `.meta()` — convención documentada arriba de
+// `ProveedorSchema` en proveedor.ts. Populates intra-SCC como z.custom
+// (import type-only): ver comentario de esa convención en activo.ts/recorrido.ts.
+export const MaterialServicioTecnicoSchema = z
+  .object({
+    _id: z.string().optional(),
+    idCliente: z
+      .string()
+      .optional()
+      .meta({ 'x-bson': 'objectId', 'x-ref': 'ClienteSchema' }),
+    idsAncestros: z
+      .array(z.string())
+      .optional()
+      .meta({ 'x-bson': 'objectId', 'x-ref': 'ClienteSchema' }),
+    idEventoGenerico: z
+      .string()
+      .optional()
+      .meta({ 'x-bson': 'objectId', 'x-ref': 'EventoGenericoSchema' }), //Ausente cuando el material es stock asignado a la caja del técnico (tipo 'asignado').
+    idUsuario: z
+      .string()
+      .optional()
+      .meta({ 'x-bson': 'objectId', 'x-ref': 'UsuarioSchema' }), //quien registró/solicitó el material, o a quien está asignado el stock
+    tipo: TipoMaterialServicioTecnicoSchema.optional(),
+    descripcion: z.string().optional(),
+    cantidad: z.number().optional(),
+    imagenes: z.array(z.string()).optional(),
+    estado: EstadoPedidoMaterialSchema.optional(),
+    // Entidad del sistema referenciada por este material (opcional). Sin
+    // x-ref propio: se popula bajo el nombre "dispositivoLorawan" (virtual
+    // con nombre distinto al path), no en el lugar de idEntidad.
+    idEntidad: z.string().optional().meta({ 'x-bson': 'objectId' }),
+    tipoEntidad: z.custom<IEntidades>().optional(),
+    /** Reservado para stock futuro: vínculo a artículo de inventario. No usar aún. */
+    idArticulo: z.string().optional().meta({ 'x-bson': 'objectId' }),
+    fechaCreacion: z.string().optional().meta({ 'x-bson': 'date' }),
+    // Populate
+    cliente: ClienteSchema.optional().meta({
+      'x-populate': {
+        ref: 'ClienteSchema',
+        localField: 'idCliente',
+        foreignField: '_id',
+        justOne: true,
+      },
+    }),
+    ancestros: z.array(ClienteSchema).optional().meta({
+      'x-populate': {
+        ref: 'ClienteSchema',
+        localField: 'idsAncestros',
+        foreignField: '_id',
+        justOne: false,
+      },
+    }),
+    evento: z.custom<IEventoGenerico>().optional().meta({
+      'x-populate': {
+        ref: 'EventoGenericoSchema',
+        localField: 'idEventoGenerico',
+        foreignField: '_id',
+        justOne: true,
+      },
+    }),
+    usuario: UsuarioSchema.optional().meta({
+      'x-populate': {
+        ref: 'UsuarioSchema',
+        localField: 'idUsuario',
+        foreignField: '_id',
+        justOne: true,
+      },
+    }),
+    // populate de idEntidad cuando tipoEntidad === 'Dispositivo Lorawan'
+    dispositivoLorawan: z.custom<IDispositivoLorawan>().optional().meta({
+      'x-populate': {
+        ref: 'DispositivoLorawanSchema',
+        localField: 'idEntidad',
+        foreignField: '_id',
+        justOne: true,
+      },
+    }),
+  })
+  .meta({ 'x-collection': 'materialserviciotecnicos' });
 export type IMaterialServicioTecnico = z.infer<
   typeof MaterialServicioTecnicoSchema
 >;

--- a/src/interfaces/metricas-gateway.ts
+++ b/src/interfaces/metricas-gateway.ts
@@ -8,30 +8,54 @@ export type PeriodoMetrica = z.infer<typeof PeriodoMetricaSchema>;
 /**
  * Métricas agregadas de Time on Air por gateway y canal
  */
-export const MetricasGatewaySchema = z.object({
-  _id: z.string().optional(),
-  /** Referencia al Gateway en MongoDB */
-  idGateway: z.string().optional(),
-  /** EUI del gateway (para queries directas sin join) */
-  gatewayEui: z.string(),
-  /** Cliente dueño del dispositivo que generó el uplink (para filtro cross-tenant) */
-  idClienteDispositivo: z.string().optional(),
-  /** Inicio del periodo de agregación (ISO string) */
-  fecha: z.string(),
-  /** Granularidad de la agregación */
-  periodo: PeriodoMetricaSchema,
-  /** Frecuencia/canal en Hz (ej: 915400000) */
-  canal: z.number(),
+// Metadata de persistencia por `.meta()` — convención documentada arriba de
+// `ProveedorSchema` en proveedor.ts.
+export const MetricasGatewaySchema = z
+  .object({
+    _id: z.string().optional(),
+    /** Referencia al Gateway en MongoDB */
+    idGateway: z
+      .string()
+      .optional()
+      .meta({ 'x-bson': 'objectId', 'x-ref': 'GatewaySchema' }),
+    /** EUI del gateway (para queries directas sin join) */
+    gatewayEui: z.string().meta({ 'x-setter': 'uppercase' }),
+    /** Cliente dueño del dispositivo que generó el uplink (para filtro cross-tenant) */
+    idClienteDispositivo: z
+      .string()
+      .optional()
+      .meta({ 'x-bson': 'objectId', 'x-ref': 'ClienteSchema' }),
+    /** Inicio del periodo de agregación (ISO string) */
+    fecha: z.string().meta({ 'x-bson': 'date' }),
+    /** Granularidad de la agregación */
+    periodo: PeriodoMetricaSchema,
+    /** Frecuencia/canal en Hz (ej: 915400000) */
+    canal: z.number(),
 
-  /** Suma total de Time on Air en milisegundos */
-  totalToA: z.number(),
-  /** Cantidad de uplinks en el periodo */
-  cantidadUplinks: z.number(),
+    /** Suma total de Time on Air en milisegundos */
+    totalToA: z.number(),
+    /** Cantidad de uplinks en el periodo */
+    cantidadUplinks: z.number(),
 
-  // Virtuals
-  gateway: GatewaySchema.optional(),
-  clienteDispositivo: ClienteSchema.optional(),
-});
+    // Virtuals
+    gateway: GatewaySchema.optional().meta({
+      'x-populate': {
+        ref: 'GatewaySchema',
+        localField: 'idGateway',
+        foreignField: '_id',
+        justOne: true,
+      },
+    }),
+    clienteDispositivo: ClienteSchema.optional().meta({
+      'x-populate': {
+        ref: 'ClienteSchema',
+        localField: 'idClienteDispositivo',
+        foreignField: '_id',
+        justOne: true,
+      },
+    }),
+  })
+  .meta({ 'x-collection': 'metricasgateways' });
 export type IMetricasGateway = z.infer<typeof MetricasGatewaySchema>;
 
 export const CreateMetricasGatewaySchema = MetricasGatewaySchema.omit({

--- a/src/interfaces/modelo-dispositivo.ts
+++ b/src/interfaces/modelo-dispositivo.ts
@@ -76,6 +76,8 @@ export const DetallesLuminariasSchema = z.object({
 });
 export type IDetallesLuminarias = z.infer<typeof DetallesLuminariasSchema>;
 
+// Metadata de persistencia por `.meta()` — convención documentada arriba de
+// `ProveedorSchema` en proveedor.ts.
 export const ModeloDispositivoSchema = z.object({
   _id: z.string().optional(),
 
@@ -84,18 +86,49 @@ export const ModeloDispositivoSchema = z.object({
   marca: z.string().optional(),
   modelo: z.string().optional(),
   formatoMensaje: FormatosMensajeComunicadorSchema.optional(),
-  idCodigos: z.string().optional(),
-  idCliente: z.string().optional(),
-  idsAncestros: z.array(z.string()).optional(),
+  idCodigos: z
+    .string()
+    .optional()
+    .meta({ 'x-bson': 'objectId', 'x-ref': 'CodigosDispositivoSchema' }),
+  idCliente: z
+    .string()
+    .optional()
+    .meta({ 'x-bson': 'objectId', 'x-ref': 'ClienteSchema' }),
+  idsAncestros: z
+    .array(z.string())
+    .optional()
+    .meta({ 'x-bson': 'objectId', 'x-ref': 'ClienteSchema' }),
 
   //Datos técnicos para luminarias
-  luminarias: DetallesLuminariasSchema.optional(),
+  // @Prop({type: Object}) en el legacy: Mixed, Mongoose no castea adentro.
+  luminarias: DetallesLuminariasSchema.optional().meta({ 'x-bson': 'mixed' }),
   global: z.boolean().optional(),
   // Populate
-  cliente: ClienteSchema.optional(),
-  ancestros: z.array(ClienteSchema).optional(),
-  codigos: CodigosDispositivoSchema.optional(),
-});
+  cliente: ClienteSchema.optional().meta({
+    'x-populate': {
+      ref: 'ClienteSchema',
+      localField: 'idCliente',
+      foreignField: '_id',
+      justOne: true,
+    },
+  }),
+  ancestros: z.array(ClienteSchema).optional().meta({
+    'x-populate': {
+      ref: 'ClienteSchema',
+      localField: 'idsAncestros',
+      foreignField: '_id',
+      justOne: false,
+    },
+  }),
+  codigos: CodigosDispositivoSchema.optional().meta({
+    'x-populate': {
+      ref: 'CodigosDispositivoSchema',
+      localField: 'idCodigos',
+      foreignField: '_id',
+      justOne: true,
+    },
+  }),
+}).meta({ 'x-collection': 'modelodispositivos' });
 export type IModeloDispositivo = z.infer<typeof ModeloDispositivoSchema>;
 
 export const CreateModeloDispositivoSchema = ModeloDispositivoSchema.omit({

--- a/src/interfaces/nota.ts
+++ b/src/interfaces/nota.ts
@@ -52,30 +52,87 @@ export const InformacionSchema = InformacionNotaSchema.extend(
 );
 export type IInformacion = z.infer<typeof InformacionSchema>;
 
+// Metadata de persistencia por `.meta()` — convención documentada arriba de
+// `ProveedorSchema` en proveedor.ts.
 export const NotaSchema = z.object({
   _id: z.string().optional(),
-  idCliente: z.string().optional(),
-  idsAncestros: z.array(z.string()).optional(),
-  idAsignado: z.string().optional(),
+  idCliente: z
+    .string()
+    .optional()
+    .meta({ 'x-bson': 'objectId', 'x-ref': 'ClienteSchema' }),
+  idsAncestros: z
+    .array(z.string())
+    .optional()
+    .meta({ 'x-bson': 'objectId', 'x-ref': 'ClienteSchema' }),
+  // Polimórfico (Activo/Alarma/Luminaria según no hay un tipo dedicado en
+  // Nota, se resuelve por los 3 virtuals activo/alarma/luminaria): sin ref
+  // fijo en el legacy (@Prop sin `ref`), por eso sin x-ref acá tampoco.
+  idAsignado: z.string().optional().meta({ 'x-bson': 'objectId' }),
   permanente: z.boolean().optional(),
-  vigenciaDesde: z.string().optional(),
-  vigenciaHasta: z.string().optional(),
+  vigenciaDesde: z.string().optional().meta({ 'x-bson': 'date' }),
+  vigenciaHasta: z.string().optional().meta({ 'x-bson': 'date' }),
   tipo: TipoNotaSchema.optional(),
-  informacion: InformacionSchema.optional(),
+  // @Prop({type: Object}) en el legacy: Mixed, Mongoose no castea adentro.
+  informacion: InformacionSchema.optional().meta({ 'x-bson': 'mixed' }),
   orden: z.number().optional(),
   //Para contactos
-  inhabilitadoDesde: z.string().optional(), //Durante el período inhabilitado, no se mostrará el conatcto en el tratamiento de los eventos
-  inhabilitadoHasta: z.string().optional(),
+  inhabilitadoDesde: z.string().optional().meta({ 'x-bson': 'date' }), //Durante el período inhabilitado, no se mostrará el conatcto en el tratamiento de los eventos
+  inhabilitadoHasta: z.string().optional().meta({ 'x-bson': 'date' }),
   // Categoría de evento a la que aplica esta nota/contacto. Sin valor = aplica a todos los eventos
-  idCategoriaEvento: z.string().optional(),
+  idCategoriaEvento: z
+    .string()
+    .optional()
+    .meta({ 'x-bson': 'objectId', 'x-ref': 'CategoriaEventoSchema' }),
   // Populate
-  cliente: ClienteSchema.optional(),
-  ancestros: z.array(ClienteSchema).optional(),
-  activo: ActivoSchema.optional(),
-  alarma: DispositivoAlarmaSchema.optional(),
-  luminaria: LuminariaSchema.optional(),
-  categoriaEvento: CategoriaEventoSchema.optional(),
-});
+  cliente: ClienteSchema.optional().meta({
+    'x-populate': {
+      ref: 'ClienteSchema',
+      localField: 'idCliente',
+      foreignField: '_id',
+      justOne: true,
+    },
+  }),
+  ancestros: z.array(ClienteSchema).optional().meta({
+    'x-populate': {
+      ref: 'ClienteSchema',
+      localField: 'idsAncestros',
+      foreignField: '_id',
+      justOne: false,
+    },
+  }),
+  activo: ActivoSchema.optional().meta({
+    'x-populate': {
+      ref: 'ActivoSchema',
+      localField: 'idAsignado',
+      foreignField: '_id',
+      justOne: true,
+    },
+  }),
+  alarma: DispositivoAlarmaSchema.optional().meta({
+    'x-populate': {
+      ref: 'DispositivoAlarmaSchema',
+      localField: 'idAsignado',
+      foreignField: '_id',
+      justOne: true,
+    },
+  }),
+  luminaria: LuminariaSchema.optional().meta({
+    'x-populate': {
+      ref: 'LuminariaSchema',
+      localField: 'idAsignado',
+      foreignField: '_id',
+      justOne: true,
+    },
+  }),
+  categoriaEvento: CategoriaEventoSchema.optional().meta({
+    'x-populate': {
+      ref: 'CategoriaEventoSchema',
+      localField: 'idCategoriaEvento',
+      foreignField: '_id',
+      justOne: true,
+    },
+  }),
+}).meta({ 'x-collection': 'notas' });
 export type INota = z.infer<typeof NotaSchema>;
 
 export const CreateNotaSchema = NotaSchema.omit({

--- a/src/interfaces/notificacion.ts
+++ b/src/interfaces/notificacion.ts
@@ -2,23 +2,59 @@ import { z } from 'zod';
 import { ClienteSchema } from './cliente';
 import { UsuarioSchema } from './usuario';
 
-export const NotificacionSchema = z.object({
-  _id: z.string().optional(),
-  idCliente: z.string().optional(),
-  idsAncestros: z.array(z.string()).optional(),
-  idUsuario: z.string().optional(),
-  fechaCreacion: z.string().optional(),
-  fechaLeido: z.string().optional(),
-  leido: z.boolean().optional(),
-  archivado: z.boolean().optional(),
-  titulo: z.string().optional(),
-  mensaje: z.string().optional(),
+// Metadata de persistencia por `.meta()` — convención documentada arriba de
+// `ProveedorSchema` en proveedor.ts.
+export const NotificacionSchema = z
+  .object({
+    _id: z.string().optional(),
+    idCliente: z
+      .string()
+      .optional()
+      .meta({ 'x-bson': 'objectId', 'x-ref': 'ClienteSchema' }),
+    idsAncestros: z
+      .array(z.string())
+      .optional()
+      .meta({ 'x-bson': 'objectId', 'x-ref': 'ClienteSchema' }),
+    idUsuario: z
+      .string()
+      .optional()
+      .meta({ 'x-bson': 'objectId', 'x-ref': 'UsuarioSchema' }),
+    fechaCreacion: z.string().optional().meta({ 'x-bson': 'date' }),
+    // Sin cast: no está en el schema legacy (agregado a Fields en el meta.go
+    // por drift 2026-08-04, pero nunca tuvo @Prop({type: Date})).
+    fechaLeido: z.string().optional(),
+    leido: z.boolean().optional(),
+    archivado: z.boolean().optional(),
+    titulo: z.string().optional(),
+    mensaje: z.string().optional(),
 
-  // Populate
-  cliente: ClienteSchema.optional(),
-  ancestros: z.array(ClienteSchema).optional(),
-  usuario: UsuarioSchema.optional(),
-});
+    // Populate
+    cliente: ClienteSchema.optional().meta({
+      'x-populate': {
+        ref: 'ClienteSchema',
+        localField: 'idCliente',
+        foreignField: '_id',
+        justOne: true,
+      },
+    }),
+    ancestros: z.array(ClienteSchema).optional().meta({
+      'x-populate': {
+        ref: 'ClienteSchema',
+        localField: 'idsAncestros',
+        foreignField: '_id',
+        justOne: false,
+      },
+    }),
+    usuario: UsuarioSchema.optional().meta({
+      'x-populate': {
+        ref: 'UsuarioSchema',
+        localField: 'idUsuario',
+        foreignField: '_id',
+        justOne: true,
+      },
+    }),
+  })
+  .meta({ 'x-collection': 'notificacions' });
 export type INotificacion = z.infer<typeof NotificacionSchema>;
 
 export const CreateNotificacionSchema = NotificacionSchema.omit({

--- a/src/interfaces/password-reset.ts
+++ b/src/interfaces/password-reset.ts
@@ -1,17 +1,29 @@
 import { z } from 'zod';
 import { UsuarioSchema } from './usuario';
 
+// Metadata de persistencia por `.meta()` — convención documentada arriba de
+// `ProveedorSchema` en proveedor.ts.
 export const PasswordResetSchema = z.object({
   _id: z.string().optional(),
-  fechaCreacion: z.string().optional(),
-  idUsuario: z.string().optional(),
+  fechaCreacion: z.string().optional().meta({ 'x-bson': 'date' }),
+  idUsuario: z
+    .string()
+    .optional()
+    .meta({ 'x-bson': 'objectId', 'x-ref': 'UsuarioSchema' }),
   token: z.string().optional(),
-  vencimiento: z.string().optional(),
+  vencimiento: z.string().optional().meta({ 'x-bson': 'date' }),
   utilizado: z.boolean().optional(),
 
   // virtuals
-  usuario: UsuarioSchema.optional(),
-});
+  usuario: UsuarioSchema.optional().meta({
+    'x-populate': {
+      ref: 'UsuarioSchema',
+      localField: 'idUsuario',
+      foreignField: '_id',
+      justOne: true,
+    },
+  }),
+}).meta({ 'x-collection': 'passwordresets' });
 export type IPasswordReset = z.infer<typeof PasswordResetSchema>;
 
 export const CreatePasswordResetSchema = PasswordResetSchema.omit({

--- a/src/interfaces/permiso.ts
+++ b/src/interfaces/permiso.ts
@@ -55,48 +55,132 @@ export type IUpdateCredencialesSeguridad = z.infer<
 // Populates intra-SCC como z.custom (import type-only): un schema real acá
 // arrastra el shape completo del ciclo y revienta la serialización de
 // declarations (TS7056) acá y en los consumidores NestJS.
+//
+// Metadata de persistencia por `.meta()` — convención documentada arriba de
+// `ProveedorSchema` en proveedor.ts.
 export const PermisoSchema = z.object({
   _id: z.string().optional(),
   // Vínculo con el usuario: nombre de usuario normalizado (lowercase/trim).
   // El permiso puede existir aunque el usuario todavía no esté registrado.
-  nombreUsuario: z.string().optional(),
-  fechaCreacion: z.string().optional(),
+  nombreUsuario: z.string().optional().meta({ 'x-setter': 'lowercase' }),
+  fechaCreacion: z.string().optional().meta({ 'x-bson': 'date' }),
   //
   nivel: NivelSchema.optional(),
   // Para nivel Cliente
-  idCliente: z.string().optional(),
+  idCliente: z
+    .string()
+    .optional()
+    .meta({ 'x-bson': 'objectId', 'x-ref': 'ClienteSchema' }),
   includeChildren: z.boolean().optional(),
-  idsAncestros: z.array(z.string()).optional(),
+  idsAncestros: z
+    .array(z.string())
+    .optional()
+    .meta({ 'x-bson': 'objectId', 'x-ref': 'ClienteSchema' }),
   // Para nivel Grupo
-  idsGrupos: z.array(z.string()).optional(),
+  idsGrupos: z
+    .array(z.string())
+    .optional()
+    .meta({ 'x-bson': 'objectId', 'x-ref': 'GrupoSchema' }),
   // Para nivel Entidad
   tipoEntidad: TipoEntidadPermisoSchema.optional(),
-  idsEntidades: z.array(z.string()).optional(),
+  // Polimórfico según tipoEntidad (Activo/Luminaria/Alarma/...): sin ref fijo
+  // en el legacy (@Prop sin `ref`), por eso sin x-ref acá tampoco.
+  idsEntidades: z.array(z.string()).optional().meta({ 'x-bson': 'objectId' }),
   //
   activo: z.boolean().optional(), // Si el permiso está activo o no
-  vencimiento: VencimientoPermisoUsuarioSchema.optional(),
-  modulos: z.custom<IModulos>().optional(),
+  // @Prop({type: Object}) en el legacy: Mixed, Mongoose no castea adentro.
+  vencimiento: VencimientoPermisoUsuarioSchema.optional().meta({
+    'x-bson': 'mixed',
+  }),
+  modulos: z.custom<IModulos>().optional().meta({ 'x-bson': 'mixed' }),
 
   /**
    * @deprecated El campo 'roles' está en desuso. Se eliminará en futuras versiones. Los reemplaza "idsRoles" y el virtual "Rols"
    */
   roles: z.array(z.custom<Rol>()).optional(),
 
-  idsRoles: z.array(z.string()).optional(), // IDs de los roles asignados al permiso
+  idsRoles: z
+    .array(z.string())
+    .optional()
+    .meta({ 'x-bson': 'objectId', 'x-ref': 'RolSchema' }), // IDs de los roles asignados al permiso
 
-  credencialesSeguridad: CredencialesSeguridadSchema.optional(), // Credenciales del sistema de seguridad (AES encriptadas)
-  tieneCredencialesSeguridad: z.boolean().optional(), // Virtual: true si el permiso tiene credenciales configuradas
+  // @Prop({type: Object}) en el legacy: Mixed, Mongoose no castea adentro.
+  credencialesSeguridad: CredencialesSeguridadSchema.optional().meta({
+    'x-bson': 'mixed',
+  }), // Credenciales del sistema de seguridad (AES encriptadas)
+  // Virtual GETTER computado (ToJSONVirtuals): no es un campo real ni un
+  // populate, lo calcula credencialesSeguridad.claveEncriptada.
+  tieneCredencialesSeguridad: z
+    .boolean()
+    .optional()
+    .meta({ 'x-computed': true }), // Virtual: true si el permiso tiene credenciales configuradas
 
   // Virtual
-  usuario: z.custom<IUsuario>().optional(), // Usuario vinculado, populado por nombreUsuario
-  cliente: ClienteSchema.optional(),
-  ancestros: z.array(ClienteSchema).optional(),
-  grupos: z.array(z.custom<IGrupo>()).optional(),
-  activos: z.array(z.custom<IActivo>()).optional(), // Entidades pobladas según el tipoEntidad
-  luminarias: z.array(z.custom<ILuminaria>()).optional(), // Entidades pobladas según el tipoEntidad
-  alarmas: z.array(z.custom<IDispositivoAlarma>()).optional(), // Entidades pobladas según el tipoEntidad
-  rols: z.array(RolSchema).optional(), // Roles poblados según idsRoles
-});
+  usuario: z.custom<IUsuario>().optional().meta({
+    'x-populate': {
+      ref: 'UsuarioSchema',
+      localField: 'nombreUsuario',
+      foreignField: 'usuario',
+      justOne: true,
+    },
+  }), // Usuario vinculado, populado por nombreUsuario
+  cliente: ClienteSchema.optional().meta({
+    'x-populate': {
+      ref: 'ClienteSchema',
+      localField: 'idCliente',
+      foreignField: '_id',
+      justOne: true,
+    },
+  }),
+  ancestros: z.array(ClienteSchema).optional().meta({
+    'x-populate': {
+      ref: 'ClienteSchema',
+      localField: 'idsAncestros',
+      foreignField: '_id',
+      justOne: false,
+    },
+  }),
+  grupos: z.array(z.custom<IGrupo>()).optional().meta({
+    'x-populate': {
+      ref: 'GrupoSchema',
+      localField: 'idsGrupos',
+      foreignField: '_id',
+      justOne: false,
+    },
+  }),
+  activos: z.array(z.custom<IActivo>()).optional().meta({
+    'x-populate': {
+      ref: 'ActivoSchema',
+      localField: 'idsEntidades',
+      foreignField: '_id',
+      justOne: false,
+    },
+  }), // Entidades pobladas según el tipoEntidad
+  luminarias: z.array(z.custom<ILuminaria>()).optional().meta({
+    'x-populate': {
+      ref: 'LuminariaSchema',
+      localField: 'idsEntidades',
+      foreignField: '_id',
+      justOne: false,
+    },
+  }), // Entidades pobladas según el tipoEntidad
+  alarmas: z.array(z.custom<IDispositivoAlarma>()).optional().meta({
+    'x-populate': {
+      ref: 'DispositivoAlarmaSchema',
+      localField: 'idsEntidades',
+      foreignField: '_id',
+      justOne: false,
+    },
+  }), // Entidades pobladas según el tipoEntidad
+  rols: z.array(RolSchema).optional().meta({
+    'x-populate': {
+      ref: 'RolSchema',
+      localField: 'idsRoles',
+      foreignField: '_id',
+      justOne: false,
+    },
+  }), // Roles poblados según idsRoles
+}).meta({ 'x-collection': 'permisos' });
 
 /**
  * Interface hand-written (misma forma que el schema): los tipos de entidad del

--- a/src/interfaces/personal-salud.ts
+++ b/src/interfaces/personal-salud.ts
@@ -1,24 +1,46 @@
 import { z } from 'zod';
 import { ClienteSchema } from './cliente';
 
-export const PersonalSaludSchema = z.object({
-  _id: z.string().optional(),
-  idCliente: z.string().optional(),
-  idsAncestros: z.array(z.string()).optional(),
+export const PersonalSaludSchema = z
+  .object({
+    _id: z.string().optional(),
+    idCliente: z
+      .string()
+      .optional()
+      .meta({ 'x-bson': 'objectId', 'x-ref': 'ClienteSchema' }),
+    idsAncestros: z
+      .array(z.string())
+      .optional()
+      .meta({ 'x-bson': 'objectId', 'x-ref': 'ClienteSchema' }),
 
-  fechaCreacion: z.string().optional(),
-  nombre: z.string().optional(), // Nombre completo
-  rol: z.enum(['Médico', 'Enfermero']).optional(),
-  matricula: z.string().optional(), // Matrícula profesional
-  dni: z.string().optional(),
-  telefono: z.string().optional(),
-  email: z.string().optional(),
-  activo: z.boolean().optional(), // Disponibilidad laboral
+    fechaCreacion: z.string().optional().meta({ 'x-bson': 'date' }),
+    nombre: z.string().optional(), // Nombre completo
+    rol: z.enum(['Médico', 'Enfermero']).optional(),
+    matricula: z.string().optional(), // Matrícula profesional
+    dni: z.string().optional(),
+    telefono: z.string().optional(),
+    email: z.string().optional(),
+    activo: z.boolean().optional(), // Disponibilidad laboral
 
-  //Populate
-  cliente: ClienteSchema.optional(),
-  ancestros: z.array(ClienteSchema).optional(),
-});
+    //Populate
+    cliente: ClienteSchema.optional().meta({
+      'x-populate': {
+        ref: 'ClienteSchema',
+        localField: 'idCliente',
+        foreignField: '_id',
+        justOne: true,
+      },
+    }),
+    ancestros: z.array(ClienteSchema).optional().meta({
+      'x-populate': {
+        ref: 'ClienteSchema',
+        localField: 'idsAncestros',
+        foreignField: '_id',
+        justOne: false,
+      },
+    }),
+  })
+  .meta({ 'x-collection': 'personalsaluds' });
 export type IPersonalSalud = z.infer<typeof PersonalSaludSchema>;
 
 export const CreatePersonalSaludSchema = PersonalSaludSchema.omit({

--- a/src/interfaces/puesta.ts
+++ b/src/interfaces/puesta.ts
@@ -12,29 +12,82 @@ import type { ILuminaria } from './luminaria';
  * Es OPCIONAL en el sistema: solo se usa para clientes con
  * `cliente.config.moduloLuminarias.usaPuestas`. La luminaria adquiere la `ubicacion` desde su puesta.
  */
-export const PuestaSchema = z.object({
-  _id: z.string().optional(),
-  idCliente: z.string().optional(),
-  idsAncestros: z.array(z.string()).optional(),
-  fechaCreacion: z.string().optional(),
+// Metadata de persistencia por `.meta()` — convención documentada arriba de
+// `ProveedorSchema` en proveedor.ts.
+export const PuestaSchema = z
+  .object({
+    _id: z.string().optional(),
+    idCliente: z
+      .string()
+      .optional()
+      .meta({ 'x-bson': 'objectId', 'x-ref': 'ClienteSchema' }),
+    idsAncestros: z
+      .array(z.string())
+      .optional()
+      .meta({ 'x-bson': 'objectId', 'x-ref': 'ClienteSchema' }),
+    fechaCreacion: z.string().optional().meta({ 'x-bson': 'date' }),
 
-  identificacion: z.string().optional(),
-  ubicacion: GeoJSONPointSchema.optional(), // fuente de verdad de la georreferencia, es la que adquieren las luminarias asignadas a esta puesta
-  direccion: z.string().optional(),
+    identificacion: z.string().optional(),
+    ubicacion: GeoJSONPointSchema.optional(), // fuente de verdad de la georreferencia, es la que adquieren las luminarias asignadas a esta puesta
+    direccion: z.string().optional(),
 
-  idsGrupos: z.array(z.string()).optional(),
-  idsPerfilConfig: z.array(z.string()).optional(), // Perfil(es) a nivel puesta
+    idsGrupos: z
+      .array(z.string())
+      .optional()
+      .meta({ 'x-bson': 'objectId', 'x-ref': 'GrupoSchema' }),
+    idsPerfilConfig: z
+      .array(z.string())
+      .optional()
+      .meta({ 'x-bson': 'objectId', 'x-ref': 'ConfigPerfilSchema' }), // Perfil(es) a nivel puesta
 
-  // Virtuals
-  // Populates intra-SCC como z.custom (import type-only): un schema real acá
-  // arrastra el shape completo del ciclo y revienta la serialización de
-  // declarations (TS7056) acá y en los consumidores NestJS.
-  luminarias: z.array(z.custom<ILuminaria>()).optional(), // luminaria.idPuesta == puesta._id
-  grupos: z.array(z.custom<IGrupo>()).optional(),
-  perfilConfigs: z.array(z.custom<IConfigPerfil>()).optional(),
-  cliente: ClienteSchema.optional(),
-  ancestros: z.array(ClienteSchema).optional(),
-});
+    // Virtuals
+    // Populates intra-SCC como z.custom (import type-only): un schema real acá
+    // arrastra el shape completo del ciclo y revienta la serialización de
+    // declarations (TS7056) acá y en los consumidores NestJS.
+    // luminaria.idPuesta == puesta._id: membresía inversa (localField "_id",
+    // foreignField "idPuesta"), no un @Prop({ref}) de este lado.
+    luminarias: z.array(z.custom<ILuminaria>()).optional().meta({
+      'x-populate': {
+        ref: 'LuminariaSchema',
+        localField: '_id',
+        foreignField: 'idPuesta',
+        justOne: false,
+      },
+    }),
+    grupos: z.array(z.custom<IGrupo>()).optional().meta({
+      'x-populate': {
+        ref: 'GrupoSchema',
+        localField: 'idsGrupos',
+        foreignField: '_id',
+        justOne: false,
+      },
+    }),
+    perfilConfigs: z.array(z.custom<IConfigPerfil>()).optional().meta({
+      'x-populate': {
+        ref: 'ConfigPerfilSchema',
+        localField: 'idsPerfilConfig',
+        foreignField: '_id',
+        justOne: false,
+      },
+    }),
+    cliente: ClienteSchema.optional().meta({
+      'x-populate': {
+        ref: 'ClienteSchema',
+        localField: 'idCliente',
+        foreignField: '_id',
+        justOne: true,
+      },
+    }),
+    ancestros: z.array(ClienteSchema).optional().meta({
+      'x-populate': {
+        ref: 'ClienteSchema',
+        localField: 'idsAncestros',
+        foreignField: '_id',
+        justOne: false,
+      },
+    }),
+  })
+  .meta({ 'x-collection': 'puestas' });
 
 /**
  * Interface hand-written (misma forma que z.infer<typeof PuestaSchema>).

--- a/src/interfaces/recordatorio.ts
+++ b/src/interfaces/recordatorio.ts
@@ -45,32 +45,86 @@ export type SubcategoriaRecordatorio = z.infer<
 //- La documentación de licencia/seguro es para choferes y conductores, se crean desde el listado de choferes/conductores en la acción documentos
 
 //💡💡💡 Creo que esto de los recordatorios debería ser mas genérico porque podría servir para otras entidades. Además, actualmente es confuso porque se mezclan recordatorios de mantenimiento con los de documentación. Podríamos agregar un campo "tipo" que indique si es un recordatorio de mantenimiento o de documentación, y así podríamos tener campos específicos para cada tipo sin que queden confusos.
-export const RecordatorioSchema = z.object({
-  _id: z.string().optional(),
-  categoria: CategoriaRecordatorioSchema.optional(),
-  subcategoria: SubcategoriaRecordatorioSchema.optional(),
-  idCliente: z.string().optional(),
-  idsAncestros: z.array(z.string()).optional(),
-  idUsuario: z.string().optional(),
-  tipo: z.array(TipoRecordatorioSchema).optional(),
-  notificado: z.boolean().optional(),
-  fechaLimite: z.string().optional(),
-  fechaCreacion: z.string().optional(),
-  kmLimite: z.number().optional(),
-  idActivo: z.string().optional(),
-  idDocumentacion: z.string().optional(),
-  detallesDelMantenimiento: z.string().optional(),
-  repetible: z.boolean().optional(),
-  frecuenciaKm: z.number().optional(),
-  frecuenciaDia: z.number().optional(),
+// Metadata de persistencia por `.meta()` — convención documentada arriba de
+// `ProveedorSchema` en proveedor.ts.
+export const RecordatorioSchema = z
+  .object({
+    _id: z.string().optional(),
+    categoria: CategoriaRecordatorioSchema.optional(),
+    subcategoria: SubcategoriaRecordatorioSchema.optional(),
+    idCliente: z
+      .string()
+      .optional()
+      .meta({ 'x-bson': 'objectId', 'x-ref': 'ClienteSchema' }),
+    idsAncestros: z
+      .array(z.string())
+      .optional()
+      .meta({ 'x-bson': 'objectId', 'x-ref': 'ClienteSchema' }),
+    idUsuario: z
+      .string()
+      .optional()
+      .meta({ 'x-bson': 'objectId', 'x-ref': 'UsuarioSchema' }),
+    tipo: z.array(TipoRecordatorioSchema).optional(),
+    notificado: z.boolean().optional(),
+    fechaLimite: z.string().optional().meta({ 'x-bson': 'date' }),
+    fechaCreacion: z.string().optional().meta({ 'x-bson': 'date' }),
+    kmLimite: z.number().optional(),
+    idActivo: z
+      .string()
+      .optional()
+      .meta({ 'x-bson': 'objectId', 'x-ref': 'ActivoSchema' }),
+    idDocumentacion: z
+      .string()
+      .optional()
+      .meta({ 'x-bson': 'objectId', 'x-ref': 'DocumentacionSchema' }),
+    detallesDelMantenimiento: z.string().optional(),
+    repetible: z.boolean().optional(),
+    frecuenciaKm: z.number().optional(),
+    frecuenciaDia: z.number().optional(),
 
-  // Populate
-  cliente: ClienteSchema.optional(),
-  ancestros: z.array(ClienteSchema).optional(),
-  usuario: UsuarioSchema.optional(),
-  activo: ActivoSchema.optional(),
-  documentacion: DocumentacionSchema.optional(),
-});
+    // Populate
+    cliente: ClienteSchema.optional().meta({
+      'x-populate': {
+        ref: 'ClienteSchema',
+        localField: 'idCliente',
+        foreignField: '_id',
+        justOne: true,
+      },
+    }),
+    ancestros: z.array(ClienteSchema).optional().meta({
+      'x-populate': {
+        ref: 'ClienteSchema',
+        localField: 'idsAncestros',
+        foreignField: '_id',
+        justOne: false,
+      },
+    }),
+    usuario: UsuarioSchema.optional().meta({
+      'x-populate': {
+        ref: 'UsuarioSchema',
+        localField: 'idUsuario',
+        foreignField: '_id',
+        justOne: true,
+      },
+    }),
+    activo: ActivoSchema.optional().meta({
+      'x-populate': {
+        ref: 'ActivoSchema',
+        localField: 'idActivo',
+        foreignField: '_id',
+        justOne: true,
+      },
+    }),
+    documentacion: DocumentacionSchema.optional().meta({
+      'x-populate': {
+        ref: 'DocumentacionSchema',
+        localField: 'idDocumentacion',
+        foreignField: '_id',
+        justOne: true,
+      },
+    }),
+  })
+  .meta({ 'x-collection': 'recordatorios' });
 export type IRecordatorio = z.infer<typeof RecordatorioSchema>;
 
 export const CreateRecordatorioSchema = RecordatorioSchema.omit({

--- a/src/interfaces/reporte-generico.ts
+++ b/src/interfaces/reporte-generico.ts
@@ -431,24 +431,100 @@ export type IUpdateReporteGenerico =
 // Populates intra-SCC como z.custom (import type-only): un schema real acá
 // arrastra el shape completo del ciclo y revienta la serialización de
 // declarations (TS7056) acá y en los consumidores NestJS.
+//
+// Metadata de persistencia por `.meta()` — convención documentada arriba de
+// `ProveedorSchema` en proveedor.ts. `idEntidad`/`idsAsignados` SON ObjectId
+// (a diferencia de `UltimoReporteGenerico`, donde son string plano) pero sin
+// `x-ref`: no tienen virtual con su propio nombre — se populan bajo otro
+// nombre (dispositivoLora/tracker desde idEntidad; grupos/activo/recorrido/
+// usuario/luminaria desde idsAsignados), igual que en evento-generico.ts.
 const camposComunesReporte = {
   _id: z.string().optional(),
-  fechaCreacion: z.string().optional(),
-  expireAt: z.string().optional(),
-  idCliente: z.string().optional(),
-  idsAncestros: z.array(z.string()).optional(),
-  idEntidad: z.string().optional(),
-  idsAsignados: z.array(z.string()).optional(),
+  fechaCreacion: z.string().optional().meta({ 'x-bson': 'date' }),
+  expireAt: z.string().optional().meta({ 'x-bson': 'date' }),
+  idCliente: z
+    .string()
+    .optional()
+    .meta({ 'x-bson': 'objectId', 'x-ref': 'ClienteSchema' }),
+  idsAncestros: z
+    .array(z.string())
+    .optional()
+    .meta({ 'x-bson': 'objectId', 'x-ref': 'ClienteSchema' }),
+  idEntidad: z.string().optional().meta({ 'x-bson': 'objectId' }),
+  idsAsignados: z.array(z.string()).optional().meta({ 'x-bson': 'objectId' }),
   tipoEntidad: TipoEntidadReporteSchema.optional(),
-  cliente: ClienteSchema.optional(),
-  ancestros: z.array(ClienteSchema).optional(),
-  dispositivoLora: z.custom<IDispositivoLorawan>().optional(),
-  tracker: z.custom<ITracker>().optional(),
-  grupos: z.array(z.custom<IGrupo>()).optional(),
-  activo: z.custom<IActivo>().optional(),
-  recorrido: z.custom<IRecorrido>().optional(),
-  usuario: z.custom<IUsuario>().optional(),
-  luminaria: z.custom<ILuminaria>().optional(),
+  cliente: ClienteSchema.optional().meta({
+    'x-populate': {
+      ref: 'ClienteSchema',
+      localField: 'idCliente',
+      foreignField: '_id',
+      justOne: true,
+    },
+  }),
+  ancestros: z.array(ClienteSchema).optional().meta({
+    'x-populate': {
+      ref: 'ClienteSchema',
+      localField: 'idsAncestros',
+      foreignField: '_id',
+      justOne: false,
+    },
+  }),
+  dispositivoLora: z.custom<IDispositivoLorawan>().optional().meta({
+    'x-populate': {
+      ref: 'DispositivoLorawanSchema',
+      localField: 'idEntidad',
+      foreignField: '_id',
+      justOne: true,
+    },
+  }),
+  tracker: z.custom<ITracker>().optional().meta({
+    'x-populate': {
+      ref: 'TrackerSchema',
+      localField: 'idEntidad',
+      foreignField: '_id',
+      justOne: true,
+    },
+  }),
+  grupos: z.array(z.custom<IGrupo>()).optional().meta({
+    'x-populate': {
+      ref: 'GrupoSchema',
+      localField: 'idsAsignados',
+      foreignField: '_id',
+      justOne: false,
+    },
+  }),
+  activo: z.custom<IActivo>().optional().meta({
+    'x-populate': {
+      ref: 'ActivoSchema',
+      localField: 'idsAsignados',
+      foreignField: '_id',
+      justOne: false,
+    },
+  }),
+  recorrido: z.custom<IRecorrido>().optional().meta({
+    'x-populate': {
+      ref: 'RecorridoSchema',
+      localField: 'idsAsignados',
+      foreignField: '_id',
+      justOne: false,
+    },
+  }),
+  usuario: z.custom<IUsuario>().optional().meta({
+    'x-populate': {
+      ref: 'UsuarioSchema',
+      localField: 'idsAsignados',
+      foreignField: '_id',
+      justOne: false,
+    },
+  }),
+  luminaria: z.custom<ILuminaria>().optional().meta({
+    'x-populate': {
+      ref: 'LuminariaSchema',
+      localField: 'idsAsignados',
+      foreignField: '_id',
+      justOne: false,
+    },
+  }),
 };
 
 const varianteReporte = <T extends TipoValoresReporte, V extends z.ZodRawShape>(
@@ -458,7 +534,18 @@ const varianteReporte = <T extends TipoValoresReporte, V extends z.ZodRawShape>(
   z.object({
     ...camposComunesReporte,
     tipoReporte: z.literal(tipo),
-    valores: valores.extend({ timestamp: z.string().optional() }).optional(),
+    // @Prop({type: Object}) en el legacy: Mixed, Mongoose no castea adentro.
+    // OJO — `valores.timestamp` es un STRING en BSON, NO una fecha
+    // (CLAUDE.md §3 de gestion-datos-go, el bug silencioso más caro del
+    // repo): NUNCA anotar `timestamp` con `x-bson: 'date'`. Un bound Date
+    // contra un valor string no matchea nunca (type bracketing de Mongo) y
+    // los exports de reportes devuelven vacío sin ningún error. Lo fija
+    // `TestCastStringTypeStaysString` (gestion-datos-go,
+    // internal/db/query/cast_test.go:73).
+    valores: valores
+      .extend({ timestamp: z.string().optional() })
+      .optional()
+      .meta({ 'x-bson': 'mixed' }),
   });
 
 const vRepLumGPE = varianteReporte('Luminaria GPE Periódico', ReporteLuminariaGPESchema);
@@ -485,7 +572,7 @@ export const ReporteGenericoSchema = z.discriminatedUnion('tipoReporte', [
   vRepTrackerCombustible,
   vRepTrackerTemperatura,
   vRepTrackerTelefono,
-]);
+]).meta({ 'x-collection': 'reportegenericos' });
 
 // Mismo set que el type Omitir de arriba
 const omitirCreateUpdateReporte = {

--- a/src/interfaces/resumen-datos.ts
+++ b/src/interfaces/resumen-datos.ts
@@ -414,26 +414,54 @@ export interface IResumenDatosBase<T extends keyof MapaResumenDatos> {
   ancestros?: ICliente[];
 }
 
+// Metadata de persistencia por `.meta()` — convención documentada arriba de
+// `ProveedorSchema` en proveedor.ts. `x-collection` va en el z.union() de
+// ResumenDatosSchema más abajo (una sola colección para las 13 variantes).
 // Campos comunes a todas las variantes (sin tipo/resumen, que discriminan)
 const ResumenDatosCamposSchema = z.object({
   _id: z.string().optional(),
-  idCliente: z.string().optional(),
-  idsAncestros: z.array(z.string()).optional(),
-  fechaCreacion: z.string().optional(),
+  idCliente: z
+    .string()
+    .optional()
+    .meta({ 'x-bson': 'objectId', 'x-ref': 'ClienteSchema' }),
+  idsAncestros: z
+    .array(z.string())
+    .optional()
+    .meta({ 'x-bson': 'objectId', 'x-ref': 'ClienteSchema' }),
+  fechaCreacion: z.string().optional().meta({ 'x-bson': 'date' }),
 
   tipoEntidad: TipoEntidadResumenSchema.optional(),
   agrupacion: AgrupacionResumenSchema.optional(),
   agrupacionTiempo: AgrupacionTiempoSchema.optional(),
 
   rangoMinutos: z.number().optional(),
-  idsAsignados: z.array(z.string()).optional(),
-  periodoInicio: z.string().optional(),
-  periodoFin: z.string().optional(),
+  // Cast a ObjectId pero sin virtual propio: el meta.go no tiene un populate
+  // para este path (a diferencia de idCliente/idsAncestros).
+  idsAsignados: z
+    .array(z.string())
+    .optional()
+    .meta({ 'x-bson': 'objectId' }),
+  periodoInicio: z.string().optional().meta({ 'x-bson': 'date' }),
+  periodoFin: z.string().optional().meta({ 'x-bson': 'date' }),
   cerrado: z.boolean().optional(), //indica que el resumen ya no se va a actualizar más
 
   //Populate
-  cliente: ClienteSchema.optional(),
-  ancestros: z.array(ClienteSchema).optional(),
+  cliente: ClienteSchema.optional().meta({
+    'x-populate': {
+      ref: 'ClienteSchema',
+      localField: 'idCliente',
+      foreignField: '_id',
+      justOne: true,
+    },
+  }),
+  ancestros: z.array(ClienteSchema).optional().meta({
+    'x-populate': {
+      ref: 'ClienteSchema',
+      localField: 'idsAncestros',
+      foreignField: '_id',
+      justOne: false,
+    },
+  }),
 });
 
 const VarianteConsumoMensualLuminarias = ResumenDatosCamposSchema.extend({
@@ -495,21 +523,23 @@ const VarianteGatewayStats = ResumenDatosCamposSchema.extend({
  *  TIPO DISCRIMINADO
  * ────────────────────────────────────────────────*/
 
-export const ResumenDatosSchema = z.union([
-  VarianteConsumoMensualLuminarias,
-  VarianteEncendidoDiarioLuminarias,
-  VarianteInformeDiarioLuminarias,
-  VarianteConsumoMensualCombustibleVehiculos,
-  VarianteTemperaturaHorariaVehiculos,
-  VarianteCombustibleHorarioVehiculos,
-  VarianteInformeCargasCombustible,
-  VarianteInformeEventosSospechososCombustible,
-  VarianteInformeMensualFlotaCombustible,
-  VarianteGastosDelCliente,
-  VarianteDownlinksSistema,
-  VarianteDownlinksLuminaria,
-  VarianteGatewayStats,
-]);
+export const ResumenDatosSchema = z
+  .union([
+    VarianteConsumoMensualLuminarias,
+    VarianteEncendidoDiarioLuminarias,
+    VarianteInformeDiarioLuminarias,
+    VarianteConsumoMensualCombustibleVehiculos,
+    VarianteTemperaturaHorariaVehiculos,
+    VarianteCombustibleHorarioVehiculos,
+    VarianteInformeCargasCombustible,
+    VarianteInformeEventosSospechososCombustible,
+    VarianteInformeMensualFlotaCombustible,
+    VarianteGastosDelCliente,
+    VarianteDownlinksSistema,
+    VarianteDownlinksLuminaria,
+    VarianteGatewayStats,
+  ])
+  .meta({ 'x-collection': 'resumendatos' });
 export type IResumenDatos = z.infer<typeof ResumenDatosSchema>;
 
 /* ────────────────────────────────────────────────

--- a/src/interfaces/road-speed-cache.ts
+++ b/src/interfaces/road-speed-cache.ts
@@ -11,17 +11,20 @@ export const SpeedLimitResultSchema = z.object({
 });
 export type ISpeedLimitResult = z.infer<typeof SpeedLimitResultSchema>;
 
+// Metadata de persistencia por `.meta()` — convención documentada arriba de
+// `ProveedorSchema` en proveedor.ts.
 export const RoadSpeedCacheSchema = z.object({
   _id: z.string().optional(),
-  fechaCreacion: z.string().optional(),
-  geojson: GeoJSONPointSchema.optional(),
+  fechaCreacion: z.string().optional().meta({ 'x-bson': 'date' }),
+  // @Prop({type: Object}) en el legacy: Mixed, Mongoose no castea adentro.
+  geojson: GeoJSONPointSchema.optional().meta({ 'x-bson': 'mixed' }),
   geohash: z.string().optional(),
   maxspeed: z.number().optional(), // km/h ya normalizado
   unidad: z.string().optional(), // 'km/h' | 'mph' (unidad original de la fuente)
   desconocido: z.boolean().optional(), // true si no se pudo determinar ningún límite usable
   confianza: z.string().optional(), // 'explicito' | 'inferido' (informativo, no configurable)
   fuente: z.string().optional(), // 'tomtom' | 'osm' | 'fallback'
-});
+}).meta({ 'x-collection': 'roadspeedcaches' });
 export type IRoadSpeedCache = z.infer<typeof RoadSpeedCacheSchema>;
 
 export const CreateRoadSpeedCacheSchema = RoadSpeedCacheSchema.omit({

--- a/src/interfaces/rol.ts
+++ b/src/interfaces/rol.ts
@@ -383,22 +383,44 @@ export const FuncionesRolSchema = z.enum([
 ]);
 export type FuncionesRol = z.infer<typeof FuncionesRolSchema>;
 
-export const RolSchema = z.object({
-  _id: z.string().optional(),
-  //
-  idCliente: z.string().optional(),
-  idsAncestros: z.array(z.string()).optional(),
-  default: z.boolean().optional(),
-  global: z.boolean().optional(),
+export const RolSchema = z
+  .object({
+    _id: z.string().optional(),
+    //
+    idCliente: z
+      .string()
+      .optional()
+      .meta({ 'x-bson': 'objectId', 'x-ref': 'ClienteSchema' }),
+    idsAncestros: z
+      .array(z.string())
+      .optional()
+      .meta({ 'x-bson': 'objectId', 'x-ref': 'ClienteSchema' }),
+    default: z.boolean().optional(),
+    global: z.boolean().optional(),
 
-  nombre: z.string().optional(),
-  acciones: z.array(AccionesRolSchema).optional(),
-  funciones: z.array(FuncionesRolSchema).optional(),
+    nombre: z.string().optional(),
+    acciones: z.array(AccionesRolSchema).optional(),
+    funciones: z.array(FuncionesRolSchema).optional(),
 
-  //Populate
-  cliente: ClienteSchema.optional(),
-  ancestros: z.array(ClienteSchema).optional(),
-});
+    //Populate
+    cliente: ClienteSchema.optional().meta({
+      'x-populate': {
+        ref: 'ClienteSchema',
+        localField: 'idCliente',
+        foreignField: '_id',
+        justOne: true,
+      },
+    }),
+    ancestros: z.array(ClienteSchema).optional().meta({
+      'x-populate': {
+        ref: 'ClienteSchema',
+        localField: 'idsAncestros',
+        foreignField: '_id',
+        justOne: false,
+      },
+    }),
+  })
+  .meta({ 'x-collection': 'rols' });
 export type IRol = z.infer<typeof RolSchema>;
 
 export const CreateRolSchema = RolSchema.omit({ _id: true, cliente: true });

--- a/src/interfaces/servicio-contratado.ts
+++ b/src/interfaces/servicio-contratado.ts
@@ -1,18 +1,40 @@
 import { z } from 'zod';
 import { ClienteSchema } from './cliente';
 
-export const ServicioContratadoSchema = z.object({
-  _id: z.string().optional(),
-  idCliente: z.string().optional(),
-  idsAncestros: z.array(z.string()).optional(),
-  nombre: z.string().optional(),
-  icono: z.string().optional(),
-  costo: z.number().optional(),
-  global: z.boolean().optional(),
-  // Populate
-  cliente: ClienteSchema.optional(),
-  ancestros: z.array(ClienteSchema).optional(),
-});
+export const ServicioContratadoSchema = z
+  .object({
+    _id: z.string().optional(),
+    idCliente: z
+      .string()
+      .optional()
+      .meta({ 'x-bson': 'objectId', 'x-ref': 'ClienteSchema' }),
+    idsAncestros: z
+      .array(z.string())
+      .optional()
+      .meta({ 'x-bson': 'objectId', 'x-ref': 'ClienteSchema' }),
+    nombre: z.string().optional(),
+    icono: z.string().optional(),
+    costo: z.number().optional(),
+    global: z.boolean().optional(),
+    // Populate
+    cliente: ClienteSchema.optional().meta({
+      'x-populate': {
+        ref: 'ClienteSchema',
+        localField: 'idCliente',
+        foreignField: '_id',
+        justOne: true,
+      },
+    }),
+    ancestros: z.array(ClienteSchema).optional().meta({
+      'x-populate': {
+        ref: 'ClienteSchema',
+        localField: 'idsAncestros',
+        foreignField: '_id',
+        justOne: false,
+      },
+    }),
+  })
+  .meta({ 'x-collection': 'serviciocontratados' });
 export type IServicioContratado = z.infer<typeof ServicioContratadoSchema>;
 
 export const CreateServicioContratadoSchema = ServicioContratadoSchema.omit({

--- a/src/interfaces/servicio.ts
+++ b/src/interfaces/servicio.ts
@@ -31,31 +31,85 @@ export const SubcategoriaServicioSchema = z.enum([
 ]);
 export type SubcategoriaServicio = z.infer<typeof SubcategoriaServicioSchema>;
 
-export const ServicioSchema = z.object({
-  _id: z.string().optional(),
-  tipo: TipoServicioSchema.optional(),
-  categoria: CategoriaServicioSchema.optional(),
-  subcategoria: SubcategoriaServicioSchema.optional(),
-  idCliente: z.string().optional(),
-  idsAncestros: z.array(z.string()).optional(),
-  idActivo: z.string().optional(),
-  fechaRealizacion: z.string().optional(),
-  fechaCreacion: z.string().optional(),
-  nombreChofer: z.string().optional(),
-  detalles: z.string().optional(),
-  kmDelMantenimiento: z.number().optional(),
-  costo: z.number().optional(),
-  litrosCargados: z.number().optional(),
-  idProveedor: z.string().optional(),
-  fotos: z.array(z.string()).optional(),
-  idUsuario: z.string().optional(),
-  // Populate
-  cliente: ClienteSchema.optional(),
-  ancestros: z.array(ClienteSchema).optional(),
-  proveedor: ProveedorSchema.optional(),
-  activo: ActivoSchema.optional(),
-  usuario: UsuarioSchema.optional(),
-});
+// Metadata de persistencia por `.meta()` — convención documentada arriba de
+// `ProveedorSchema` en proveedor.ts.
+export const ServicioSchema = z
+  .object({
+    _id: z.string().optional(),
+    tipo: TipoServicioSchema.optional(),
+    categoria: CategoriaServicioSchema.optional(),
+    subcategoria: SubcategoriaServicioSchema.optional(),
+    idCliente: z
+      .string()
+      .optional()
+      .meta({ 'x-bson': 'objectId', 'x-ref': 'ClienteSchema' }),
+    idsAncestros: z
+      .array(z.string())
+      .optional()
+      .meta({ 'x-bson': 'objectId', 'x-ref': 'ClienteSchema' }),
+    idActivo: z
+      .string()
+      .optional()
+      .meta({ 'x-bson': 'objectId', 'x-ref': 'ActivoSchema' }),
+    fechaRealizacion: z.string().optional().meta({ 'x-bson': 'date' }),
+    fechaCreacion: z.string().optional().meta({ 'x-bson': 'date' }),
+    nombreChofer: z.string().optional(),
+    detalles: z.string().optional(),
+    kmDelMantenimiento: z.number().optional(),
+    costo: z.number().optional(),
+    litrosCargados: z.number().optional(),
+    idProveedor: z
+      .string()
+      .optional()
+      .meta({ 'x-bson': 'objectId', 'x-ref': 'ProveedorSchema' }),
+    fotos: z.array(z.string()).optional(),
+    // @Prop() pelado (String en Mongoose, NO ObjectId — docs/MIGRACION.md):
+    // sin x-bson. El virtual "usuario" igual popula matcheando contra
+    // usuarios._id.
+    idUsuario: z.string().optional(),
+    // Populate
+    cliente: ClienteSchema.optional().meta({
+      'x-populate': {
+        ref: 'ClienteSchema',
+        localField: 'idCliente',
+        foreignField: '_id',
+        justOne: true,
+      },
+    }),
+    ancestros: z.array(ClienteSchema).optional().meta({
+      'x-populate': {
+        ref: 'ClienteSchema',
+        localField: 'idsAncestros',
+        foreignField: '_id',
+        justOne: false,
+      },
+    }),
+    proveedor: ProveedorSchema.optional().meta({
+      'x-populate': {
+        ref: 'ProveedorSchema',
+        localField: 'idProveedor',
+        foreignField: '_id',
+        justOne: true,
+      },
+    }),
+    activo: ActivoSchema.optional().meta({
+      'x-populate': {
+        ref: 'ActivoSchema',
+        localField: 'idActivo',
+        foreignField: '_id',
+        justOne: true,
+      },
+    }),
+    usuario: UsuarioSchema.optional().meta({
+      'x-populate': {
+        ref: 'UsuarioSchema',
+        localField: 'idUsuario',
+        foreignField: '_id',
+        justOne: true,
+      },
+    }),
+  })
+  .meta({ 'x-collection': 'servicios' });
 export type IServicio = z.infer<typeof ServicioSchema>;
 
 export const CreateServicioSchema = ServicioSchema.omit({

--- a/src/interfaces/sirena.ts
+++ b/src/interfaces/sirena.ts
@@ -7,34 +7,74 @@ import { ModeloDispositivoSchema } from './modelo-dispositivo';
 export const EstadoSirenaSchema = z.enum(['Online', 'Offline']);
 export type EstadoSirena = z.infer<typeof EstadoSirenaSchema>;
 
-export const SirenaSchema = z.object({
-  _id: z.string().optional(),
-  /// Cosas de IRIX
-  idCliente: z.string().optional(),
-  idsAncestros: z.array(z.string()).optional(),
-  fechaCreacion: z.string().optional(),
-  idModelo: z.string().optional(),
-  idsAsignados: z.array(z.string()).optional(), // Camaras, sensores, etc
+// Metadata de persistencia por `.meta()` — convención documentada arriba de
+// `ProveedorSchema` en proveedor.ts.
+export const SirenaSchema = z
+  .object({
+    _id: z.string().optional(),
+    /// Cosas de IRIX
+    idCliente: z
+      .string()
+      .optional()
+      .meta({ 'x-bson': 'objectId', 'x-ref': 'ClienteSchema' }),
+    idsAncestros: z
+      .array(z.string())
+      .optional()
+      .meta({ 'x-bson': 'objectId', 'x-ref': 'ClienteSchema' }),
+    fechaCreacion: z.string().optional().meta({ 'x-bson': 'date' }),
+    idModelo: z
+      .string()
+      .optional()
+      .meta({ 'x-bson': 'objectId', 'x-ref': 'ModeloDispositivoSchema' }),
+    // Camaras, sensores, etc. Sin x-ref propio: se popula bajo el nombre
+    // "camaras" (virtual con nombre distinto al path).
+    idsAsignados: z
+      .array(z.string())
+      .optional()
+      .meta({ 'x-bson': 'objectId' }),
 
-  // Datos de sincronizacion de seguridad
-  idExterno: z.string().optional(), /// El _id que tiene la sirena en seguridad
-  chipId: z.string().optional(), /// El chipId de la sirena en seguridad
-  fechaSincronizacion: z.string().optional(),
-  ubicacion: GeoJSONPointSchema.optional(),
-  direccion: z.string().optional(),
-  activa: z.boolean().optional(),
-  estado: EstadoSirenaSchema.optional(),
-  tipo: z.string().optional(),
-  onlineDesde: z.string().optional(),
-  offlineDesde: z.string().optional(),
-  iccidSim: z.string().optional(),
-  telefono: z.string().optional(),
+    // Datos de sincronizacion de seguridad
+    idExterno: z.string().optional(), /// El _id que tiene la sirena en seguridad
+    chipId: z.string().optional(), /// El chipId de la sirena en seguridad
+    fechaSincronizacion: z.string().optional().meta({ 'x-bson': 'date' }),
+    ubicacion: GeoJSONPointSchema.optional(),
+    direccion: z.string().optional(),
+    activa: z.boolean().optional(),
+    estado: EstadoSirenaSchema.optional(),
+    tipo: z.string().optional(),
+    onlineDesde: z.string().optional().meta({ 'x-bson': 'date' }),
+    offlineDesde: z.string().optional().meta({ 'x-bson': 'date' }),
+    iccidSim: z.string().optional(),
+    telefono: z.string().optional(),
 
-  /// Populates
-  cliente: ClienteSchema.optional(),
-  camaras: z.array(CamaraSchema).optional(),
-  modelo: ModeloDispositivoSchema.optional(),
-});
+    /// Populates
+    cliente: ClienteSchema.optional().meta({
+      'x-populate': {
+        ref: 'ClienteSchema',
+        localField: 'idCliente',
+        foreignField: '_id',
+        justOne: true,
+      },
+    }),
+    // camaras: virtual poblado desde idsAsignados (Camaras, sensores, etc).
+    camaras: z.array(CamaraSchema).optional().meta({
+      'x-populate': {
+        ref: 'CamaraSchema',
+        localField: 'idsAsignados',
+        foreignField: '_id',
+        justOne: false,
+      },
+    }),
+    modelo: ModeloDispositivoSchema.optional().meta({
+      'x-populate': {
+        ref: 'ModeloDispositivoSchema',
+        localField: 'idModelo',
+        foreignField: '_id',
+        justOne: true,
+      },
+    }),
+  })
+  .meta({ 'x-collection': 'sirenas' });
 export type ISirena = z.infer<typeof SirenaSchema>;
 
 export const CreateSirenaSchema = SirenaSchema.omit({

--- a/src/interfaces/soap.ts
+++ b/src/interfaces/soap.ts
@@ -88,24 +88,54 @@ export const SoapBajaSchema = z.object({
 });
 export type ISoapBaja = z.infer<typeof SoapBajaSchema>;
 
-export const SoapSchema = z.object({
-  _id: z.string().optional(),
-  idCliente: z.string().optional(),
-  idsAncestros: z.array(z.string()).optional(),
-  fechaCreacion: z.string().optional(),
+export const SoapSchema = z
+  .object({
+    _id: z.string().optional(),
+    idCliente: z
+      .string()
+      .optional()
+      .meta({ 'x-bson': 'objectId', 'x-ref': 'ClienteSchema' }),
+    idsAncestros: z
+      .array(z.string())
+      .optional()
+      .meta({ 'x-bson': 'objectId', 'x-ref': 'ClienteSchema' }),
+    fechaCreacion: z.string().optional().meta({ 'x-bson': 'date' }),
 
-  alta: SoapAltaSchema.optional(),
-  create: SoapCreateSchema.optional(),
-  altaChofer: SoapAltaChoferSchema.optional(),
-  obtenerChoferes: SoapObtenerChoferesSchema.optional(),
-  altaPorMinuta: SoapAltaPorMinutaSchema.optional(),
-  altaPorMinutaChofer: SoapAltaPorMinutaChoferSchema.optional(),
-  baja: SoapBajaSchema.optional(),
+    // Los siete son @Prop({type: Object}) en el legacy (soap/schema.ts): Mixed,
+    // pese a tener un schema tipado en zod cada uno.
+    alta: SoapAltaSchema.optional().meta({ 'x-bson': 'mixed' }),
+    create: SoapCreateSchema.optional().meta({ 'x-bson': 'mixed' }),
+    altaChofer: SoapAltaChoferSchema.optional().meta({ 'x-bson': 'mixed' }),
+    obtenerChoferes: SoapObtenerChoferesSchema.optional().meta({
+      'x-bson': 'mixed',
+    }),
+    altaPorMinuta: SoapAltaPorMinutaSchema.optional().meta({
+      'x-bson': 'mixed',
+    }),
+    altaPorMinutaChofer: SoapAltaPorMinutaChoferSchema.optional().meta({
+      'x-bson': 'mixed',
+    }),
+    baja: SoapBajaSchema.optional().meta({ 'x-bson': 'mixed' }),
 
-  // Populate
-  cliente: ClienteSchema.optional(),
-  ancestros: z.array(ClienteSchema).optional(),
-});
+    // Populate
+    cliente: ClienteSchema.optional().meta({
+      'x-populate': {
+        ref: 'ClienteSchema',
+        localField: 'idCliente',
+        foreignField: '_id',
+        justOne: true,
+      },
+    }),
+    ancestros: z.array(ClienteSchema).optional().meta({
+      'x-populate': {
+        ref: 'ClienteSchema',
+        localField: 'idsAncestros',
+        foreignField: '_id',
+        justOne: false,
+      },
+    }),
+  })
+  .meta({ 'x-collection': 'soaps' });
 export type ISoap = z.infer<typeof SoapSchema>;
 
 export const CreateSoapSchema = SoapSchema.omit({

--- a/src/interfaces/tema.ts
+++ b/src/interfaces/tema.ts
@@ -50,26 +50,51 @@ export const TemaPayloadSchema = z.object({
 });
 export type ITemaPayload = z.infer<typeof TemaPayloadSchema>;
 
-export const TemaSchema = z.object({
-  _id: z.string().optional(),
-  //
-  nombre: z.string().optional(),
-  descripcion: z.string().optional(),
-  activa: z.boolean().optional(),
-  fechaInicio: z.string().optional(),
-  fechaFin: z.string().optional(),
-  diasRecurrentes: RangoRecurrenteAnualSchema.optional(),
-  prioridad: z.number().optional(), // 0-100
-  global: z.boolean().optional(),
-  idCliente: z.string().optional(),
-  idsAncestros: z.array(z.string()).optional(),
-  payload: TemaPayloadSchema.optional(),
-  fechaCreacion: z.string().optional(),
-  fechaActualizacion: z.string().optional(),
-  // Populate
-  cliente: ClienteSchema.optional(),
-  ancestros: z.array(ClienteSchema).optional(),
-});
+// Metadata de persistencia por `.meta()` — convención documentada arriba de
+// `ProveedorSchema` en proveedor.ts.
+export const TemaSchema = z
+  .object({
+    _id: z.string().optional(),
+    //
+    nombre: z.string().optional(),
+    descripcion: z.string().optional(),
+    activa: z.boolean().optional(),
+    // @Prop() pelados en el legacy → String, sin cast.
+    fechaInicio: z.string().optional(),
+    fechaFin: z.string().optional(),
+    diasRecurrentes: RangoRecurrenteAnualSchema.optional(),
+    prioridad: z.number().optional(), // 0-100
+    global: z.boolean().optional(),
+    idCliente: z
+      .string()
+      .optional()
+      .meta({ 'x-bson': 'objectId', 'x-ref': 'ClienteSchema' }),
+    idsAncestros: z
+      .array(z.string())
+      .optional()
+      .meta({ 'x-bson': 'objectId', 'x-ref': 'ClienteSchema' }),
+    payload: TemaPayloadSchema.optional(),
+    fechaCreacion: z.string().optional().meta({ 'x-bson': 'date' }),
+    fechaActualizacion: z.string().optional().meta({ 'x-bson': 'date' }),
+    // Populate
+    cliente: ClienteSchema.optional().meta({
+      'x-populate': {
+        ref: 'ClienteSchema',
+        localField: 'idCliente',
+        foreignField: '_id',
+        justOne: true,
+      },
+    }),
+    ancestros: z.array(ClienteSchema).optional().meta({
+      'x-populate': {
+        ref: 'ClienteSchema',
+        localField: 'idsAncestros',
+        foreignField: '_id',
+        justOne: false,
+      },
+    }),
+  })
+  .meta({ 'x-collection': 'temas' });
 export type ITema = z.infer<typeof TemaSchema>;
 
 export const CreateTemaSchema = TemaSchema.omit({

--- a/src/interfaces/tipo-evento.ts
+++ b/src/interfaces/tipo-evento.ts
@@ -8,19 +8,43 @@ export const CategoriaTipoEventoSchema = z.enum([
 ]);
 export type ICategoriaTipoEvento = z.infer<typeof CategoriaTipoEventoSchema>;
 
-export const TipoEventoSchema = z.object({
-  _id: z.string().optional(),
-  //
-  nombre: z.string().optional(),
-  categoria: CategoriaTipoEventoSchema.optional(),
-  idCliente: z.string().optional(),
-  idsAncestros: z.array(z.string()).optional(),
-  default: z.boolean().optional(),
-  global: z.boolean().optional(),
-  //Populate
-  cliente: ClienteSchema.optional(),
-  ancestros: z.array(ClienteSchema).optional(),
-});
+export const TipoEventoSchema = z
+  .object({
+    _id: z.string().optional(),
+    //
+    nombre: z.string().optional(),
+    categoria: CategoriaTipoEventoSchema.optional(),
+    idCliente: z
+      .string()
+      .optional()
+      .meta({ 'x-bson': 'objectId', 'x-ref': 'ClienteSchema' }),
+    idsAncestros: z
+      .array(z.string())
+      .optional()
+      .meta({ 'x-bson': 'objectId', 'x-ref': 'ClienteSchema' }),
+    default: z.boolean().optional(),
+    global: z.boolean().optional(),
+    //Populate
+    cliente: ClienteSchema.optional().meta({
+      'x-populate': {
+        ref: 'ClienteSchema',
+        localField: 'idCliente',
+        foreignField: '_id',
+        justOne: true,
+      },
+    }),
+    ancestros: z.array(ClienteSchema).optional().meta({
+      'x-populate': {
+        ref: 'ClienteSchema',
+        localField: 'idsAncestros',
+        foreignField: '_id',
+        justOne: false,
+      },
+    }),
+  })
+  // Collection real de Mongoose (pluraliza "TipoEvento"): "tipoeventos", NO
+  // "tiposeventos" (ese es el RouteBase/MQTTName del meta.go).
+  .meta({ 'x-collection': 'tipoeventos' });
 export type ITipoEvento = z.infer<typeof TipoEventoSchema>;
 
 export const CreateTipoEventoSchema = TipoEventoSchema.omit({

--- a/src/interfaces/token-push.ts
+++ b/src/interfaces/token-push.ts
@@ -3,19 +3,25 @@ import { z } from 'zod';
 export const PlataformaTokenPushSchema = z.enum(['android', 'ios']);
 export type PlataformaTokenPush = z.infer<typeof PlataformaTokenPushSchema>;
 
+// Metadata de persistencia por `.meta()` — convención documentada arriba de
+// `ProveedorSchema` en proveedor.ts.
 export const TokenPushSchema = z.object({
   _id: z.string().optional(),
-  fechaCreacion: z.string().optional(),
-  fechaActualizacion: z.string().optional(),
+  fechaCreacion: z.string().optional().meta({ 'x-bson': 'date' }),
+  fechaActualizacion: z.string().optional().meta({ 'x-bson': 'date' }),
   tokenPush: z.string().optional(),
-  idUsuario: z.string().optional(),
+  idUsuario: z
+    .string()
+    .optional()
+    .meta({ 'x-bson': 'objectId', 'x-ref': 'UsuarioSchema' }),
   // Identificador estable del dispositivo (Android: ANDROID_ID, iOS:
   // identifierForVendor). Permite 1 fila por (idUsuario, idDispositivo):
   // al rotar el FCM token se reemplaza el de ese device (sin huerfanos) y
   // el logout borra limpio por device.
   idDispositivo: z.string().optional(),
   plataforma: PlataformaTokenPushSchema.optional(),
-});
+  // OJO colección: "tokenpushes" (pluralize de push), no "tokenpushs".
+}).meta({ 'x-collection': 'tokenpushes' });
 export type ITokenPush = z.infer<typeof TokenPushSchema>;
 
 export const CreateTokenPushSchema = TokenPushSchema.omit({

--- a/src/interfaces/token.ts
+++ b/src/interfaces/token.ts
@@ -2,6 +2,10 @@ import { z } from 'zod';
 import { ClientSchema } from './client';
 import { UsuarioSchema } from './usuario';
 
+// Metadata de persistencia por `.meta()` — convención documentada arriba de
+// `ProveedorSchema` en proveedor.ts. `client`/`user` NO son populate: el
+// legacy los declara `@Prop({type: Object})` (Mixed) — una copia embebida,
+// no un ObjectId con ref — así que van sin virtual en tokens/meta.go.
 export const TokenSchema = z.object({
   _id: z.string().optional(),
   accessToken: z.string().optional(),
@@ -9,9 +13,9 @@ export const TokenSchema = z.object({
   refreshToken: z.string().optional(),
   refreshTokenExpiresAt: z.string().optional(),
   scope: z.union([z.string(), z.array(z.string())]).optional(),
-  client: ClientSchema.optional(),
-  user: UsuarioSchema.optional(),
-});
+  client: ClientSchema.optional().meta({ 'x-bson': 'mixed' }),
+  user: UsuarioSchema.optional().meta({ 'x-bson': 'mixed' }),
+}).meta({ 'x-collection': 'tokens' });
 export type IToken = z.infer<typeof TokenSchema>;
 
 export const CreateTokenSchema = TokenSchema.omit({

--- a/src/interfaces/tracker.ts
+++ b/src/interfaces/tracker.ts
@@ -44,46 +44,114 @@ export type ITelefono = z.infer<typeof TelefonoSchema>;
 // Populates intra-SCC como z.custom (import type-only): un schema real acá
 // arrastra el shape completo del ciclo y revienta la serialización de
 // declarations (TS7056) acá y en los consumidores NestJS.
+// Metadata de persistencia por `.meta()` — convención documentada arriba de
+// `ProveedorSchema` en proveedor.ts.
 export const TrackerSchema = z.object({
   _id: z.string().optional(),
   //
-  fechaCreacion: z.string().optional(),
-  fechaAlta: z.string().optional(),
+  fechaCreacion: z.string().optional().meta({ 'x-bson': 'date' }),
+  fechaAlta: z.string().optional().meta({ 'x-bson': 'date' }),
   imagenes: z.array(z.string()).optional(),
-  idCliente: z.string().optional(),
-  idsAncestros: z.array(z.string()).optional(),
-  idsClientesQuePuedenAtenderEventos: z.array(z.string()).optional(),
-  idsClientesQuePuedenAtenderEventosTecnicos: z.array(z.string()).optional(),
+  idCliente: z
+    .string()
+    .optional()
+    .meta({ 'x-bson': 'objectId', 'x-ref': 'ClienteSchema' }),
+  idsAncestros: z
+    .array(z.string())
+    .optional()
+    .meta({ 'x-bson': 'objectId', 'x-ref': 'ClienteSchema' }),
+  idsClientesQuePuedenAtenderEventos: z
+    .array(z.string())
+    .optional()
+    .meta({ 'x-bson': 'objectId', 'x-ref': 'ClienteSchema' }),
+  idsClientesQuePuedenAtenderEventosTecnicos: z
+    .array(z.string())
+    .optional()
+    .meta({ 'x-bson': 'objectId', 'x-ref': 'ClienteSchema' }),
   puedeSolicitarServicioTecnico: z.boolean().optional(),
-  configHorariosAtencion: z.array(ConfigHorarioSchema).optional(),
-  configHorariosAtencionTecnica: z.array(ConfigHorarioSchema).optional(),
-  idModelo: z.string().optional(),
+  // @Prop({type: [Object]}) en el legacy: array real de Mixed.
+  configHorariosAtencion: z
+    .array(ConfigHorarioSchema)
+    .optional()
+    .meta({ 'x-bson': 'mixed' }),
+  configHorariosAtencionTecnica: z
+    .array(ConfigHorarioSchema)
+    .optional()
+    .meta({ 'x-bson': 'mixed' }),
+  idModelo: z
+    .string()
+    .optional()
+    .meta({ 'x-bson': 'objectId', 'x-ref': 'ModeloDispositivoSchema' }),
   nombre: z.string().optional(),
   identificacion: z.string().optional(),
+  // @Prop() string plano: el populate por "activo" castea hex → OID
+  // (CLAUDE.md §7 de gestion-datos-go). Sin x-ref: no tiene virtual con su
+  // propio nombre, solo el virtual "activo" (localField distinto).
   asignadoA: z.string().optional(),
   tipo: TipoTrackerSchema.optional(),
   /**
    * Id del tracker fisico
    */
   uniqueId: z.string().optional(),
-  qualcomm: QualcommDeviceSchema.optional(),
-  t1000b: T100bDeviceSchema.optional(),
-  telefono: TelefonoSchema.optional(),
+  // @Prop({type: Object}) en el legacy: Mixed, Mongoose no castea adentro.
+  qualcomm: QualcommDeviceSchema.optional().meta({ 'x-bson': 'mixed' }),
+  t1000b: T100bDeviceSchema.optional().meta({ 'x-bson': 'mixed' }),
+  telefono: TelefonoSchema.optional().meta({ 'x-bson': 'mixed' }),
   estadoCuenta: z.custom<estadoCuenta>().optional(),
   numeroAbonado: z.string().optional(),
-  sim1: z.custom<ISim>().optional(),
-  sim2: z.custom<ISim>().optional(),
+  sim1: z.custom<ISim>().optional().meta({ 'x-bson': 'mixed' }),
+  sim2: z.custom<ISim>().optional().meta({ 'x-bson': 'mixed' }),
   frecReporte: z.number().optional(),
   // Activa/desactiva remotamente el tracking GPS (solo aplica a tipo='Telefono').
+  // Post-cutover (comentado/PAUSADO en el legacy archivado); sin @Prop ahí,
+  // por eso sin x-bson: el meta lo castea Bool igual (drift 2026-08-04).
   trackingActivo: z.boolean().optional(),
   //
-  idServiciosContratados: z.array(z.string()).optional(),
+  idServiciosContratados: z
+    .array(z.string())
+    .optional()
+    .meta({ 'x-bson': 'objectId', 'x-ref': 'ServicioContratadoSchema' }),
   // Populate
-  cliente: ClienteSchema.optional(),
-  ancestros: z.array(ClienteSchema).optional(),
-  activo: z.custom<IActivo>().optional(),
-  modelo: ModeloDispositivoSchema.optional(),
-  serviciosContratados: z.array(ServicioContratadoSchema).optional(),
+  cliente: ClienteSchema.optional().meta({
+    'x-populate': {
+      ref: 'ClienteSchema',
+      localField: 'idCliente',
+      foreignField: '_id',
+      justOne: true,
+    },
+  }),
+  ancestros: z.array(ClienteSchema).optional().meta({
+    'x-populate': {
+      ref: 'ClienteSchema',
+      localField: 'idsAncestros',
+      foreignField: '_id',
+      justOne: false,
+    },
+  }),
+  activo: z.custom<IActivo>().optional().meta({
+    'x-populate': {
+      ref: 'ActivoSchema',
+      localField: 'asignadoA',
+      foreignField: '_id',
+      justOne: true,
+    },
+  }),
+  modelo: ModeloDispositivoSchema.optional().meta({
+    'x-populate': {
+      ref: 'ModeloDispositivoSchema',
+      localField: 'idModelo',
+      foreignField: '_id',
+      justOne: true,
+    },
+  }),
+  serviciosContratados: z.array(ServicioContratadoSchema).optional().meta({
+    'x-populate': {
+      ref: 'ServicioContratadoSchema',
+      localField: 'idServiciosContratados',
+      foreignField: '_id',
+      justOne: false,
+    },
+  }),
 }).meta({ 'x-collection': 'trackers' });
 
 /**

--- a/src/interfaces/tratamiento-evento.ts
+++ b/src/interfaces/tratamiento-evento.ts
@@ -6,24 +6,48 @@ import {
 } from './evento-generico';
 import type { IEventoGenerico } from './evento-generico';
 
+// Metadata de persistencia por `.meta()` — convención documentada arriba de
+// `ProveedorSchema` en proveedor.ts.
 export const TratamientoEventoSchema = z.object({
   _id: z.string().optional(),
   //
   nota: z.string().optional(),
   notaInterna: z.string().optional(),
   imagenes: z.array(z.string()).optional(),
-  fechaCreacion: z.string().optional(),
-  estado: EstadoEventoSchema.optional(),
+  fechaCreacion: z.string().optional().meta({ 'x-bson': 'date' }),
+  // @Prop({type: Object}) en el legacy: Mixed (a diferencia de
+  // estadoTecnico, que es un @Prop() sin `type` — sin cast, pero no Mixed).
+  estado: EstadoEventoSchema.optional().meta({ 'x-bson': 'mixed' }),
   // Separados para no hinche las bolas el overlap.
   estadoTecnico: EstadoEventoTecnicoSchema.optional(),
-  esperaHasta: z.string().optional(),
+  esperaHasta: z.string().optional().meta({ 'x-bson': 'date' }),
   //
-  idsEventos: z.array(z.string()).optional(),
-  idUsuario: z.string().optional(),
+  idsEventos: z
+    .array(z.string())
+    .optional()
+    .meta({ 'x-bson': 'objectId', 'x-ref': 'EventoGenericoSchema' }),
+  idUsuario: z
+    .string()
+    .optional()
+    .meta({ 'x-bson': 'objectId', 'x-ref': 'UsuarioSchema' }),
   // Populate
-  eventos: z.array(z.custom<IEventoGenerico>()).optional(),
-  usuario: UsuarioSchema.optional(),
-});
+  eventos: z.array(z.custom<IEventoGenerico>()).optional().meta({
+    'x-populate': {
+      ref: 'EventoGenericoSchema',
+      localField: 'idsEventos',
+      foreignField: '_id',
+      justOne: false,
+    },
+  }),
+  usuario: UsuarioSchema.optional().meta({
+    'x-populate': {
+      ref: 'UsuarioSchema',
+      localField: 'idUsuario',
+      foreignField: '_id',
+      justOne: true,
+    },
+  }),
+}).meta({ 'x-collection': 'tratamientoeventos' });
 export type ITratamientoEvento = z.infer<typeof TratamientoEventoSchema>;
 
 export const CreateTratamientoEventoSchema = TratamientoEventoSchema.omit({

--- a/src/interfaces/ubicacion.ts
+++ b/src/interfaces/ubicacion.ts
@@ -140,53 +140,96 @@ export interface IUbicacionBase<T extends keyof MapaValoresUbicacion> {
 }
 
 // Campos comunes a todas las variantes (sin categoria/valores, que discriminan)
+//
+// Metadata de persistencia por `.meta()` — convención documentada arriba de
+// `ProveedorSchema` en proveedor.ts.
 const UbicacionCamposSchema = z.object({
   _id: z.string().optional(),
   //
-  idCliente: z.string().optional(),
-  idsAncestros: z.array(z.string()).optional(),
+  idCliente: z
+    .string()
+    .optional()
+    .meta({ 'x-bson': 'objectId', 'x-ref': 'ClienteSchema' }),
+  idsAncestros: z
+    .array(z.string())
+    .optional()
+    .meta({ 'x-bson': 'objectId', 'x-ref': 'ClienteSchema' }),
   identificacion: z.string().optional(),
-  fechaCreacion: z.string().optional(),
+  fechaCreacion: z.string().optional().meta({ 'x-bson': 'date' }),
   direccion: z.string().optional(),
-  geojson: GeoJSONSchema.optional(),
+  // @Prop({type: Object}) en el legacy: Mixed, Mongoose no castea adentro.
+  geojson: GeoJSONSchema.optional().meta({ 'x-bson': 'mixed' }),
   fotos: z.array(z.string()).optional(),
   color: z.string().optional(),
   // Virtuals
-  cliente: ClienteSchema.optional(),
-  ancestros: z.array(ClienteSchema).optional(),
+  cliente: ClienteSchema.optional().meta({
+    'x-populate': {
+      ref: 'ClienteSchema',
+      localField: 'idCliente',
+      foreignField: '_id',
+      justOne: true,
+    },
+  }),
+  ancestros: z.array(ClienteSchema).optional().meta({
+    'x-populate': {
+      ref: 'ClienteSchema',
+      localField: 'idsAncestros',
+      foreignField: '_id',
+      justOne: false,
+    },
+  }),
 });
 
+// `valores` es @Prop({type: Object}) en el legacy (Mixed) para las OCHO
+// categorías: Mongoose no castea adentro pese a que algunas variantes (Centro
+// de Atención, Hospital) tengan forma tipada acá.
 const VarianteUbicacionTerminal = UbicacionCamposSchema.extend({
   categoria: z.literal('Terminal').optional(),
-  valores: ValoresUbicacionTerminalSchema.optional(),
+  valores: ValoresUbicacionTerminalSchema.optional().meta({
+    'x-bson': 'mixed',
+  }),
 });
 const VarianteUbicacionDomicilio = UbicacionCamposSchema.extend({
   categoria: z.literal('Domicilio').optional(),
-  valores: ValoresUbicacionDomicilioSchema.optional(),
+  valores: ValoresUbicacionDomicilioSchema.optional().meta({
+    'x-bson': 'mixed',
+  }),
 });
 const VarianteUbicacionActivos = UbicacionCamposSchema.extend({
   categoria: z.literal('Activos').optional(),
-  valores: ValoresUbicacionActivosSchema.optional(),
+  valores: ValoresUbicacionActivosSchema.optional().meta({
+    'x-bson': 'mixed',
+  }),
 });
 const VarianteUbicacionCentroAtencion = UbicacionCamposSchema.extend({
   categoria: z.literal('Centro de Atención').optional(),
-  valores: ValoresUbicacionCentroAtencionSchema.optional(),
+  valores: ValoresUbicacionCentroAtencionSchema.optional().meta({
+    'x-bson': 'mixed',
+  }),
 });
 const VarianteUbicacionHospital = UbicacionCamposSchema.extend({
   categoria: z.literal('Hospital').optional(),
-  valores: ValoresUbicacionHospitalSchema.optional(),
+  valores: ValoresUbicacionHospitalSchema.optional().meta({
+    'x-bson': 'mixed',
+  }),
 });
 const VarianteUbicacionDestinoEmergencia = UbicacionCamposSchema.extend({
   categoria: z.literal('Destino Emergencia').optional(),
-  valores: ValoresUbicacionDestinoEmergenciaSchema.optional(),
+  valores: ValoresUbicacionDestinoEmergenciaSchema.optional().meta({
+    'x-bson': 'mixed',
+  }),
 });
 const VarianteUbicacionVehiculos = UbicacionCamposSchema.extend({
   categoria: z.literal('Vehiculos').optional(),
-  valores: ValoresUbicacionVehiculosSchema.optional(),
+  valores: ValoresUbicacionVehiculosSchema.optional().meta({
+    'x-bson': 'mixed',
+  }),
 });
 const VarianteUbicacionLuminarias = UbicacionCamposSchema.extend({
   categoria: z.literal('Luminarias').optional(),
-  valores: ValoresUbicacionLuminariasSchema.optional(),
+  valores: ValoresUbicacionLuminariasSchema.optional().meta({
+    'x-bson': 'mixed',
+  }),
 });
 
 /* ────────────────────────────────────────────────

--- a/src/interfaces/ultimo-reporte-generico.ts
+++ b/src/interfaces/ultimo-reporte-generico.ts
@@ -1,0 +1,176 @@
+import { z } from 'zod';
+import type { IActivo } from './activo';
+import { ClienteSchema } from './cliente';
+import type { IDispositivoLorawan } from './dispositivo-lorawan';
+import type { IGrupo } from './grupo';
+import type { ILuminaria } from './luminaria';
+import {
+  TipoEntidadReporteSchema,
+  TipoValoresReporteSchema,
+} from './reporte-generico';
+import type { IRecorrido } from './recorrido';
+import type { ITracker } from './tracker';
+import type { IUsuario } from './usuario';
+
+/**
+ * Último reporte por combinación única idCliente+tipoReporte+idEntidad
+ * (índice unique del legacy: ultimo-reporte-generico/schema.ts). `valores` es
+ * `@Prop({type: Object})` — Mixed de verdad, sin casteo adentro — a
+ * diferencia de `ReporteGenerico` no se modela como unión discriminada por
+ * variante: acá alcanza con un registro abierto porque ningún consumidor
+ * actual de este paquete lee `valores` tipado (grep sin resultados al crear
+ * este archivo, 2026-08-06).
+ *
+ * Metadata de persistencia por `.meta()` — convención documentada arriba de
+ * `ProveedorSchema` en proveedor.ts. Populates intra-SCC como z.custom
+ * (import type-only): mismo motivo que en reporte-generico.ts.
+ */
+export const UltimoReporteGenericoSchema = z
+  .object({
+    _id: z.string().optional(),
+    fechaCreacion: z.string().optional().meta({ 'x-bson': 'date' }),
+    expireAt: z.string().optional().meta({ 'x-bson': 'date' }),
+
+    // Tenant / relaciones
+    idCliente: z
+      .string()
+      .optional()
+      .meta({ 'x-bson': 'objectId', 'x-ref': 'ClienteSchema' }),
+    idsAncestros: z
+      .array(z.string())
+      .optional()
+      .meta({ 'x-bson': 'objectId', 'x-ref': 'ClienteSchema' }),
+    // String plano (a diferencia de ReporteGenerico, donde es ObjectId): sin
+    // x-bson. Se popula bajo los nombres "dispositivoLora"/"tracker"
+    // (virtuals con nombre distinto al path).
+    idEntidad: z.string().optional(),
+    idsAsignados: z.array(z.string()).optional(),
+
+    // Tipo y datos
+    tipoEntidad: TipoEntidadReporteSchema.optional(),
+    tipoReporte: TipoValoresReporteSchema.optional(),
+    // @Prop({type: Object}) en el legacy: Mixed, Mongoose no castea adentro.
+    valores: z
+      .record(z.string(), z.unknown())
+      .optional()
+      .meta({ 'x-bson': 'mixed' }),
+
+    // Populate
+    cliente: ClienteSchema.optional().meta({
+      'x-populate': {
+        ref: 'ClienteSchema',
+        localField: 'idCliente',
+        foreignField: '_id',
+        justOne: true,
+      },
+    }),
+    ancestros: z.array(ClienteSchema).optional().meta({
+      'x-populate': {
+        ref: 'ClienteSchema',
+        localField: 'idsAncestros',
+        foreignField: '_id',
+        justOne: false,
+      },
+    }),
+    dispositivoLora: z.custom<IDispositivoLorawan>().optional().meta({
+      'x-populate': {
+        ref: 'DispositivoLorawanSchema',
+        localField: 'idEntidad',
+        foreignField: '_id',
+        justOne: true,
+      },
+    }),
+    tracker: z.custom<ITracker>().optional().meta({
+      'x-populate': {
+        ref: 'TrackerSchema',
+        localField: 'idEntidad',
+        foreignField: '_id',
+        justOne: true,
+      },
+    }),
+    grupos: z.array(z.custom<IGrupo>()).optional().meta({
+      'x-populate': {
+        ref: 'GrupoSchema',
+        localField: 'idsAsignados',
+        foreignField: '_id',
+        justOne: false,
+      },
+    }),
+    // "single" (justOne:false en el schema legacy, colapsado a objeto único
+    // por el post-hook cleanNullsFromPopulated — no acá): activo, recorrido,
+    // usuario y luminaria populan desde idsAsignados igual que grupos, pero
+    // se modelan singulares porque la app siempre los ve colapsados. Mismo
+    // criterio que IReporteBase en reporte-generico.ts.
+    activo: z.custom<IActivo>().optional().meta({
+      'x-populate': {
+        ref: 'ActivoSchema',
+        localField: 'idsAsignados',
+        foreignField: '_id',
+        justOne: false,
+      },
+    }),
+    recorrido: z.custom<IRecorrido>().optional().meta({
+      'x-populate': {
+        ref: 'RecorridoSchema',
+        localField: 'idsAsignados',
+        foreignField: '_id',
+        justOne: false,
+      },
+    }),
+    usuario: z.custom<IUsuario>().optional().meta({
+      'x-populate': {
+        ref: 'UsuarioSchema',
+        localField: 'idsAsignados',
+        foreignField: '_id',
+        justOne: false,
+      },
+    }),
+    luminaria: z.custom<ILuminaria>().optional().meta({
+      'x-populate': {
+        ref: 'LuminariaSchema',
+        localField: 'idsAsignados',
+        foreignField: '_id',
+        justOne: false,
+      },
+    }),
+  })
+  .meta({ 'x-collection': 'ultimoreportegenericos' });
+export type IUltimoReporteGenerico = z.infer<
+  typeof UltimoReporteGenericoSchema
+>;
+
+export const CreateUltimoReporteGenericoSchema =
+  UltimoReporteGenericoSchema.omit({
+    _id: true,
+    idsAncestros: true,
+    cliente: true,
+    ancestros: true,
+    dispositivoLora: true,
+    tracker: true,
+    grupos: true,
+    activo: true,
+    recorrido: true,
+    usuario: true,
+    luminaria: true,
+  });
+export type ICreateUltimoReporteGenerico = z.infer<
+  typeof CreateUltimoReporteGenericoSchema
+>;
+
+export const UpdateUltimoReporteGenericoSchema =
+  UltimoReporteGenericoSchema.omit({
+    _id: true,
+    idsAncestros: true,
+    cliente: true,
+    ancestros: true,
+    dispositivoLora: true,
+    tracker: true,
+    grupos: true,
+    activo: true,
+    recorrido: true,
+    usuario: true,
+    luminaria: true,
+  });
+export type IUpdateUltimoReporteGenerico = z.infer<
+  typeof UpdateUltimoReporteGenericoSchema
+>;

--- a/src/interfaces/ultimo-trackeo.ts
+++ b/src/interfaces/ultimo-trackeo.ts
@@ -5,8 +5,11 @@ import { GrupoSchema } from './grupo';
 import { ParadaSchema, RecorridoSchema } from './recorrido';
 
 // Metadata de persistencia por `.meta()` — convención documentada arriba de
-// `ProveedorSchema` en proveedor.ts.
-export const TrackeoSchema = z.object({
+// `ProveedorSchema` en proveedor.ts. Mismo shape que TrackeoSchema (ver
+// trackeo.ts), salvo que acá NO existe el populate/virtual "ancestros": el
+// legacy (ultimo-trackeo/schema.ts) nunca lo declaró, así que el meta.go de
+// ultimotrackeos no tiene esa clave en Virtuals — fiel al legacy, no un error.
+export const UltimoTrackeoSchema = z.object({
   _id: z.string().optional(),
   //
   idCliente: z
@@ -53,14 +56,6 @@ export const TrackeoSchema = z.object({
       justOne: true,
     },
   }),
-  ancestros: z.array(ClienteSchema).optional().meta({
-    'x-populate': {
-      ref: 'ClienteSchema',
-      localField: 'idsAncestros',
-      foreignField: '_id',
-      justOne: false,
-    },
-  }),
   // Rareza del schema legacy: grupo matchea idGrupo contra traccar.uniqueId
   // del grupo, no contra su _id.
   grupo: GrupoSchema.optional().meta({
@@ -105,10 +100,10 @@ export const TrackeoSchema = z.object({
       justOne: true,
     },
   }),
-}).meta({ 'x-collection': 'trackeos' });
-export type ITrackeo = z.infer<typeof TrackeoSchema>;
+}).meta({ 'x-collection': 'ultimotrackeos' });
+export type IUltimoTrackeo = z.infer<typeof UltimoTrackeoSchema>;
 
-export const CreateTrackeoSchema = TrackeoSchema.omit({
+export const CreateUltimoTrackeoSchema = UltimoTrackeoSchema.omit({
   _id: true,
   cliente: true,
   grupo: true,
@@ -117,9 +112,9 @@ export const CreateTrackeoSchema = TrackeoSchema.omit({
   parada: true,
   proximaParada: true,
 });
-export type ICreateTrackeo = z.infer<typeof CreateTrackeoSchema>;
+export type ICreateUltimoTrackeo = z.infer<typeof CreateUltimoTrackeoSchema>;
 
-export const UpdateTrackeoSchema = TrackeoSchema.omit({
+export const UpdateUltimoTrackeoSchema = UltimoTrackeoSchema.omit({
   _id: true,
   cliente: true,
   grupo: true,
@@ -128,4 +123,4 @@ export const UpdateTrackeoSchema = TrackeoSchema.omit({
   parada: true,
   proximaParada: true,
 });
-export type IUpdateTrackeo = z.infer<typeof UpdateTrackeoSchema>;
+export type IUpdateUltimoTrackeo = z.infer<typeof UpdateUltimoTrackeoSchema>;

--- a/src/interfaces/usuario.ts
+++ b/src/interfaces/usuario.ts
@@ -69,6 +69,8 @@ export type IConfigUsuario = z.infer<typeof ConfigUsuarioSchema>;
 // Populates intra-SCC como z.custom (import type-only): un schema real acá
 // arrastra el shape completo del ciclo y revienta la serialización de
 // declarations (TS7056) acá y en los consumidores NestJS.
+// Metadata de persistencia por `.meta()` — convención documentada arriba de
+// `ProveedorSchema` en proveedor.ts.
 export const UsuarioSchema = z.object({
   _id: z.string().optional(),
   identificacionInterna: z.string().optional(),
@@ -78,28 +80,63 @@ export const UsuarioSchema = z.object({
    * campo. No usar para agrupar/scopear por cliente: los auto-registrados lo
    * tienen vacío.
    */
-  idCliente: z.string().optional(),
+  idCliente: z
+    .string()
+    .optional()
+    .meta({ 'x-bson': 'objectId', 'x-ref': 'ClienteSchema' }),
   /** @deprecated Deriva de {@link idCliente} (deprecado). Usar el permiso. */
-  idsAncestros: z.array(z.string()).optional(),
+  idsAncestros: z
+    .array(z.string())
+    .optional()
+    .meta({ 'x-bson': 'objectId', 'x-ref': 'ClienteSchema' }),
   //
   idExterno: z.string().optional(),
-  fechaCreacion: z.string().optional(),
-  usuario: z.string().optional(),
+  fechaCreacion: z.string().optional().meta({ 'x-bson': 'date' }),
+  // @Prop({lowercase: true, ...}): el setter de Mongoose corre en save y en
+  // updates ($set) — gana sobre cualquier cast de tipo, igual que en el resto
+  // del repo.
+  usuario: z.string().optional().meta({ 'x-setter': 'lowercase' }),
   hash: z.string().optional(),
-  datosPersonales: DatosPersonalesSchema.optional(),
-  config: ConfigUsuarioSchema.optional(),
+  // @Prop({type: Object}) en el legacy: Mixed, Mongoose no castea adentro.
+  datosPersonales: DatosPersonalesSchema.optional().meta({
+    'x-bson': 'mixed',
+  }),
+  config: ConfigUsuarioSchema.optional().meta({ 'x-bson': 'mixed' }),
   // Estadísticas de uso (actividad). Se actualizan en cada login exitoso
   // (grant password o Google / auto-registro), NO en los refresh de token.
   // Detalle temporal (DAU/WAU/MAU, series) vive en la colección LoginEvento.
-  ultimoLogin: z.string().optional(),
-  primerLogin: z.string().optional(),
+  ultimoLogin: z.string().optional().meta({ 'x-bson': 'date' }),
+  primerLogin: z.string().optional().meta({ 'x-bson': 'date' }),
   cantidadLogins: z.number().optional(),
   // Populate / Virtual
-  cliente: ClienteSchema.optional(),
-  ancestros: z.array(ClienteSchema).optional(),
+  cliente: ClienteSchema.optional().meta({
+    'x-populate': {
+      ref: 'ClienteSchema',
+      localField: 'idCliente',
+      foreignField: '_id',
+      justOne: true,
+    },
+  }),
+  ancestros: z.array(ClienteSchema).optional().meta({
+    'x-populate': {
+      ref: 'ClienteSchema',
+      localField: 'idsAncestros',
+      foreignField: '_id',
+      justOne: false,
+    },
+  }),
   // Permisos del usuario. Ya no es un array embebido: es un virtual poblado
   // desde la colección Permiso por match de nombreUsuario (Permiso.nombreUsuario === Usuario.usuario).
-  permisos: z.array(z.custom<IPermiso>()).optional(),
+  // ref por string literal (`ref: 'Permiso'`) en el legacy, para evitar el
+  // import circular Usuario <-> Permiso — igual que en usuarios/meta.go.
+  permisos: z.array(z.custom<IPermiso>()).optional().meta({
+    'x-populate': {
+      ref: 'PermisoSchema',
+      localField: 'usuario',
+      foreignField: 'nombreUsuario',
+      justOne: false,
+    },
+  }),
 }).meta({ 'x-collection': 'usuarios' });
 
 /**


### PR DESCRIPTION
Primera parte de la etapa 2 del roadmap "aprovechar Go". **Aditivo: no cambia ningún tipo TS.**

## Qué hace

`gestion-modelos` define qué campos existen pero nunca declaró **cómo se persisten**. Esa mitad vive copiada a mano en 81 `meta.go` de `gestion-datos-go`, y nada verificaba que coincidieran — cuando se separan no falla nada, el campo simplemente no se guarda o el filtro no matchea.

Este PR anota **80 de 81 entidades** con seis claves: `x-collection`, `x-bson`, `x-ref`, `x-populate`, `x-setter`, `x-computed`. El PR hermano en `gestion-datos-go` agrega el test que las compara contra los metas.

## Por qué es seguro

`.meta()` agrega claves que TypeScript ignora. **No toca `z.infer`.** Verificado de tres formas:

- Sacando programáticamente todos los `.meta(...)` de cada archivo y comparando byte a byte contra el original: **idénticos**.
- Conteo de `z.custom<` sin cambios (ninguno se convirtió en schema real — eso dispara TS7056 en los 14 archivos que embeben).
- **Diff de los `.d.ts` emitidos** entre `main` y esta rama: solo reordenamiento de propiedades más los exports nuevos. Cero cambios de tipo.

`npm run build` exit 0. `nest build` en `gestion-api-gestion` y `ng build --configuration production` en `gestion-web-cliente`: **exit 0 los dos**, corridos contra `origin/main` fresco de cada consumidor y con el swap de `node_modules/modelos` verificado por grep antes de creerle al exit code.

## Tres schemas nuevos

`ultimo-trackeo.ts`, `ultimo-reporte-generico.ts` y `export-job.ts` no existían. Los tres verificados campo a campo contra su `meta.go` y contra el schema legacy archivado.

En `ExportJob` la trampa era `idCliente`/`idUsuario`: el nombre invita a castearlos a ObjectId y el legacy los declara `@Prop({type: String})`. Quedaron sin anotación de casteo, a propósito.

## Una entidad queda sin anotar, con motivo

**`ConfigMarker`**: `idUsuario` es escalar en zod y array en el legacy y en el meta. Alinearlo cambia `z.infer` y rompe `gestion-api-gestion` (`config-marker/service.ts:55` y `:157`). Es una decisión de contrato y va en su propio PR. Sus otros 14 campos ya están anotados.

## Orden de merge

**Este PR va primero.** El de `gestion-datos-go` commitea un snapshot del bundle; si entra antes, ese repo codifica anotaciones que no existen upstream y nada lo detecta.

🤖 Generated with [Claude Code](https://claude.com/claude-code)