### PR TITLE
fix: sacar el x-ref de idParada e idProximaParada

### DIFF
--- a/src/interfaces/trackeo.ts
+++ b/src/interfaces/trackeo.ts
@@ -34,7 +34,7 @@ export const TrackeoSchema = z.object({
   idParada: z
     .string()
     .optional()
-    .meta({ 'x-bson': 'objectId', 'x-ref': 'ParadaSchema' }),
+    .meta({ 'x-bson': 'objectId' }),
   indiceParada: z.number().optional(),
   fechaProximaParada: z.string().optional().meta({ 'x-bson': 'date' }),
   // Contraintuitivo pero fiel al legacy: @Prop({ref: Recorrido.name}) en

--- a/src/interfaces/trackeo.ts
+++ b/src/interfaces/trackeo.ts
@@ -42,7 +42,7 @@ export const TrackeoSchema = z.object({
   idProximaParada: z
     .string()
     .optional()
-    .meta({ 'x-bson': 'objectId', 'x-ref': 'RecorridoSchema' }),
+    .meta({ 'x-bson': 'objectId' }),
 
   // Populate
   cliente: ClienteSchema.optional().meta({

--- a/src/interfaces/ultimo-trackeo.ts
+++ b/src/interfaces/ultimo-trackeo.ts
@@ -45,7 +45,7 @@ export const UltimoTrackeoSchema = z.object({
   idProximaParada: z
     .string()
     .optional()
-    .meta({ 'x-bson': 'objectId', 'x-ref': 'RecorridoSchema' }),
+    .meta({ 'x-bson': 'objectId' }),
 
   // Populate
   cliente: ClienteSchema.optional().meta({

--- a/src/interfaces/ultimo-trackeo.ts
+++ b/src/interfaces/ultimo-trackeo.ts
@@ -37,7 +37,7 @@ export const UltimoTrackeoSchema = z.object({
   idParada: z
     .string()
     .optional()
-    .meta({ 'x-bson': 'objectId', 'x-ref': 'ParadaSchema' }),
+    .meta({ 'x-bson': 'objectId' }),
   indiceParada: z.number().optional(),
   fechaProximaParada: z.string().optional().meta({ 'x-bson': 'date' }),
   // Contraintuitivo pero fiel al legacy: @Prop({ref: Recorrido.name}) en


### PR DESCRIPTION
Par del revert en `gestion-datos-go`. **Ese va después de este.**

La anotación decía que `idParada` se popula en su lugar contra la colección `paradas`. Medido en teste:

```
GET /ultimotrackeos?limit=1                                → idParada: "67d882a3ff20fa6e52bbb815"
GET /ultimotrackeos?limit=1&populate=[{"path":"idParada"}] → idParada: null
```

El populate **pierde el id**: no hay documentos en `paradas` — una parada es un subdocumento de `recorridos`, y el virtual que sí funciona es `parada`, con `foreignField: "paradas._id"`.

Además `ParadaSchema` no es una entidad: no tiene `x-collection` ni `meta.go`, así que el `x-ref` apuntaba a algo que no es populable por sí solo.

Queda `x-bson: 'objectId'`, que sigue siendo cierto.

Detalle y medición en `gestion-datos-go`, `docs/MIGRACION.md` §7 item 23.

🤖 Generated with [Claude Code](https://claude.com/claude-code)