### PR TITLE
feat: anotar los huecos que encontró el chequeo inverso meta→zod

### DIFF
--- a/src/interfaces/certificado-entidad.ts
+++ b/src/interfaces/certificado-entidad.ts
@@ -27,7 +27,14 @@ export const CertificadoEntidadSchema = z
     fechaComienzo: z.string().optional().meta({ 'x-bson': 'date' }),
     fechaEmision: z.string().optional().meta({ 'x-bson': 'date' }),
     eventosRegistrados: z.array(z.custom<IEventoGenerico>()).optional(),
-    codigosEsperados: z.array(CodigoDispositivoSchema).optional(),
+    // @Prop({type: [Object]}) en el schema Mongoose legacy: adentro de un
+    // Mixed, Mongoose no declara NADA — no castea ni inicializa esos paths. La
+    // anotación se lo dice al chequeo de drift, que si no exigiría en el
+    // meta.go de gestion-datos-go casts que el legacy nunca tuvo.
+    codigosEsperados: z
+      .array(CodigoDispositivoSchema)
+      .optional()
+      .meta({ 'x-bson': 'mixed' }),
     // Populate
     tracker: TrackerSchema.optional().meta({
       'x-populate': {
@@ -59,6 +66,14 @@ export const CertificadoEntidadSchema = z
         localField: 'idCliente',
         foreignField: '_id',
         justOne: true,
+      },
+    }),
+    ancestros: z.array(ClienteSchema).optional().meta({
+      'x-populate': {
+        ref: 'ClienteSchema',
+        localField: 'idsAncestros',
+        foreignField: '_id',
+        justOne: false,
       },
     }),
   })

--- a/src/interfaces/codigos-dispositivo.ts
+++ b/src/interfaces/codigos-dispositivo.ts
@@ -44,8 +44,23 @@ export const CodigoDispositivoSchema = z.object({
   cierraCodigosEventos: z.array(z.string()).optional(), // Si se genera un evento con este codigo, se cierran los eventos con estos codigos del array
 
   flagsTrackers: z.array(FlagsTrackersSchema).optional(),
-  // Populate
-  categoriaEvento: CategoriaEventoSchema.optional(),
+  // Populate. `localField` RELATIVO al sub-documento: el path absoluto que
+  // resuelve el motor es `codigos.idCategoriaEvento`. `codigos` es Mixed, pero
+  // un Mixed apaga el CASTEO de lo de adentro, no los virtuals — el schema
+  // legacy declara este con schema.virtual(), aparte del @Prop.
+  //
+  // El `categoriaEvento` de CodigoDispositivoEntradaSchema (arriba) queda SIN
+  // anotar a propósito: el schema legacy declara los virtuals `cliente`,
+  // `ancestros` y `codigos.categoriaEvento`, y ninguno para `codigosEntrada`.
+  // Anotarlo afirmaría un populate que el legacy nunca tuvo.
+  categoriaEvento: CategoriaEventoSchema.optional().meta({
+    'x-populate': {
+      ref: 'CategoriaEventoSchema',
+      localField: 'idCategoriaEvento',
+      foreignField: '_id',
+      justOne: true,
+    },
+  }),
 });
 export type ICodigoDispositivo = z.infer<typeof CodigoDispositivoSchema>;
 

--- a/src/interfaces/config-deseada.ts
+++ b/src/interfaces/config-deseada.ts
@@ -149,6 +149,11 @@ const ConfigDeseadaCamposSchema = z.object({
   ultimaReconciliacion: z.string().optional().meta({ 'x-bson': 'date' }), // ISO timestamp del último set disparado
   reintentosReconciliacion: z.number().optional(), // counter para back-off
   bloqueadoHasta: z.string().optional().meta({ 'x-bson': 'date' }), // ISO. Si > now no se reintenta (circuit breaker)
+  // Estaba en la interface IConfigDeseada de arriba pero NO en el schema zod:
+  // el meta.go lo tiene en Fields y lo castea a Date, así que Go lo persiste y
+  // lo filtra, pero el bundle no lo veía. Lo encontró el chequeo inverso
+  // meta→zod (2026-08-07).
+  divergenteDesde: z.string().optional().meta({ 'x-bson': 'date' }), // ISO. Instante de la PRIMERA detección 'No coincide' (se limpia al converger). Mide el tiempo-a-convergencia.
 
   // Virtuals
   // z.custom para no arrastrar el shape completo del dispositivo al
@@ -179,20 +184,24 @@ const ConfigDeseadaCamposSchema = z.object({
   }),
 });
 
+// `config` es @Prop({type: Object}) en el schema Mongoose legacy: adentro de un
+// Mixed, Mongoose no declara NADA — no castea ni inicializa esos paths. Va
+// anotado en las TRES variantes: el chequeo de drift hace la unión de las
+// properties de la unión y avisa si dos variantes discrepan en la anotación.
 const VarianteConfigDeseadaGPE = ConfigDeseadaCamposSchema.extend({
   // Discriminante
   tipo: z.literal('Luminaria GPE').optional(),
-  config: ConfigDeseadaLuminariaGPESchema.optional(),
+  config: ConfigDeseadaLuminariaGPESchema.optional().meta({ 'x-bson': 'mixed' }),
 });
 const VarianteConfigDeseadaWellness = ConfigDeseadaCamposSchema.extend({
   // Discriminante
   tipo: z.literal('Luminaria Wellness').optional(),
-  config: ConfigDeseadaLuminariaWellnessSchema.optional(),
+  config: ConfigDeseadaLuminariaWellnessSchema.optional().meta({ 'x-bson': 'mixed' }),
 });
 const VarianteConfigDeseadaACTIS = ConfigDeseadaCamposSchema.extend({
   // Discriminante
   tipo: z.literal('Luminaria ACTIS FING').optional(),
-  config: ConfigDeseadaLuminariaACTISSchema.optional(),
+  config: ConfigDeseadaLuminariaACTISSchema.optional().meta({ 'x-bson': 'mixed' }),
 });
 
 /* ────────────────────────────────────────────────

--- a/src/interfaces/config-marker.ts
+++ b/src/interfaces/config-marker.ts
@@ -68,7 +68,9 @@ export const ConfigMarkerSchema = z
     // un único `ref` de destino.
     idRef: z.string().meta({ 'x-bson': 'objectId' }),
 
-    vistas: z.array(VistaMarkerSchema).optional(),
+    // @Prop({type: [Object]}) en el schema Mongoose legacy: adentro de un
+    // Mixed, Mongoose no declara NADA — no castea ni inicializa esos paths.
+    vistas: z.array(VistaMarkerSchema).optional().meta({ 'x-bson': 'mixed' }),
 
     // Populate
     cliente: ClienteSchema.optional().meta({

--- a/src/interfaces/dispositivo-alarma.ts
+++ b/src/interfaces/dispositivo-alarma.ts
@@ -321,6 +321,9 @@ export const DispositivoAlarmaSchema = z.object({
   serviciosContratados: z.array(ServicioContratadoSchema).optional().meta({
     'x-populate': { ref: 'ServicioContratadoSchema', localField: 'idServiciosContratados', foreignField: '_id', justOne: false },
   }),
+  clientesQuePuedenAtenderEventosTecnicos: z.array(ClienteSchema).optional().meta({
+    'x-populate': { ref: 'ClienteSchema', localField: 'idsClientesQuePuedenAtenderEventosTecnicos', foreignField: '_id', justOne: false },
+  }),
 }).meta({ 'x-collection': 'dispositivoalarmas' });
 /**
  * Interface hand-written (misma forma que el schema): los tipos de entidad del

--- a/src/interfaces/evento-generico.ts
+++ b/src/interfaces/evento-generico.ts
@@ -272,8 +272,19 @@ export const DetallesTecnicosSchema = z.object({
   fechaDisponibleParaTratar: z.string().optional(),
   cambioEntidadPropuesto: CambioEntidadPropuestoSchema.optional(),
 
-  // Populate opcional
-  tecnico: z.custom<IUsuario>().optional(),
+  // Populate opcional. El `localField` va RELATIVO al sub-documento, igual que
+  // en VehiculoSchema (activo.ts): el path absoluto que resuelve el motor es
+  // `detallesTecnicos.idTecnicoAsignado`. `detallesTecnicos` es Mixed, pero un
+  // Mixed apaga el casteo, no los virtuals — el schema legacy los declara con
+  // schema.virtual() aparte del @Prop.
+  tecnico: z.custom<IUsuario>().optional().meta({
+    'x-populate': {
+      ref: 'UsuarioSchema',
+      localField: 'idTecnicoAsignado',
+      foreignField: '_id',
+      justOne: true,
+    },
+  }),
 });
 export type DetallesTecnicos = z.infer<typeof DetallesTecnicosSchema>;
 
@@ -292,17 +303,91 @@ export const DetallesEmergenciasSchema = z.object({
   idUsuarioResponsable: z.string().optional(),
   idMovilAsignado: z.string().optional(),
 
-  // Populate opcional
-  destinatarioAsistencia: z.custom<IDestinatarioAsistencia>().optional(),
-  emergencia: z.custom<IEmergencia>().optional(),
-  chofer: z.custom<IUsuario>().optional(),
-  centroDeAtencion: z.custom<IUbicacion>().optional(),
-  movilUsuario: z.custom<IUsuario>().optional(),
-  medicos: z.array(PersonalSaludSchema).optional(),
-  enfermeros: z.array(PersonalSaludSchema).optional(),
-  hospital: z.custom<IUbicacion>().optional(),
-  usuarioResponsable: z.custom<IUsuario>().optional(),
-  movilAsignado: z.custom<IActivo>().optional(),
+  // Populate opcional. Los 10 son schema.virtual() del schema legacy
+  // (entidades/eventoGenerico/schema.ts), declarados aparte de los @Prop:
+  // `detallesEmergencias` es Mixed, y un Mixed apaga el CASTEO de lo que tiene
+  // adentro, no los virtuals. El `localField` va RELATIVO al sub-documento,
+  // igual que en VehiculoSchema (activo.ts).
+  destinatarioAsistencia: z.custom<IDestinatarioAsistencia>().optional().meta({
+    'x-populate': {
+      ref: 'DestinatarioAsistenciaSchema',
+      localField: 'idDestinatarioAsistencia',
+      foreignField: '_id',
+      justOne: true,
+    },
+  }),
+  emergencia: z.custom<IEmergencia>().optional().meta({
+    'x-populate': {
+      ref: 'EmergenciaSchema',
+      localField: 'idEmergencia',
+      foreignField: '_id',
+      justOne: true,
+    },
+  }),
+  chofer: z.custom<IUsuario>().optional().meta({
+    'x-populate': {
+      ref: 'UsuarioSchema',
+      localField: 'idChofer',
+      foreignField: '_id',
+      justOne: true,
+    },
+  }),
+  centroDeAtencion: z.custom<IUbicacion>().optional().meta({
+    'x-populate': {
+      ref: 'UbicacionSchema',
+      localField: 'idCentroDeAtencion',
+      foreignField: '_id',
+      justOne: true,
+    },
+  }),
+  movilUsuario: z.custom<IUsuario>().optional().meta({
+    'x-populate': {
+      ref: 'UsuarioSchema',
+      localField: 'idMovilUsuario',
+      foreignField: '_id',
+      justOne: true,
+    },
+  }),
+  medicos: z.array(PersonalSaludSchema).optional().meta({
+    'x-populate': {
+      ref: 'PersonalSaludSchema',
+      localField: 'idsMedicos',
+      foreignField: '_id',
+      justOne: false,
+    },
+  }),
+  enfermeros: z.array(PersonalSaludSchema).optional().meta({
+    'x-populate': {
+      ref: 'PersonalSaludSchema',
+      localField: 'idsEnfermeros',
+      foreignField: '_id',
+      justOne: false,
+    },
+  }),
+  hospital: z.custom<IUbicacion>().optional().meta({
+    'x-populate': {
+      ref: 'UbicacionSchema',
+      localField: 'idHospital',
+      foreignField: '_id',
+      justOne: true,
+    },
+  }),
+  usuarioResponsable: z.custom<IUsuario>().optional().meta({
+    'x-populate': {
+      ref: 'UsuarioSchema',
+      localField: 'idUsuarioResponsable',
+      foreignField: '_id',
+      justOne: true,
+    },
+  }),
+  movilAsignado: z.custom<IActivo>().optional().meta({
+    'x-populate': {
+      ref: 'ActivoSchema',
+      localField: 'idMovilAsignado',
+      foreignField: '_id',
+      justOne: true,
+    },
+  }),
 });
 export type DetallesEmergencias = z.infer<typeof DetallesEmergenciasSchema>;
 
@@ -767,7 +852,10 @@ const varianteEvento = <
     ...camposComunesEvento,
     tipoEvento: z.literal(tipo),
     estado: estado.optional(),
-    valores: valores.optional(),
+    // @Prop({type: Object}) en el schema Mongoose legacy: adentro de un Mixed,
+    // Mongoose no declara NADA — no castea ni inicializa esos paths. Anotarlo
+    // acá, en la fábrica, cubre las 20 variantes de una sola vez.
+    valores: valores.optional().meta({ 'x-bson': 'mixed' }),
   });
 
 const vEvtColectivo = varianteEvento('Evento Colectivo', ValoresEventoTrackerSchema, EstadoEventoSchema);

--- a/src/interfaces/log-evento.ts
+++ b/src/interfaces/log-evento.ts
@@ -64,6 +64,18 @@ export const LogEventoSchema = z
         justOne: true,
       },
     }),
+    // El virtual que el schema legacy declara DE VERDAD. Convive con
+    // `dispositivoLorawan` de arriba en vez de reemplazarlo: renombrar sería un
+    // cambio de contrato para los consumidores que ya lo piden con ese nombre,
+    // y este `dispositivo` es el que realmente resuelve un ?populate.
+    dispositivo: DispositivoLorawanSchema.optional().meta({
+      'x-populate': {
+        ref: 'DispositivoLorawanSchema',
+        localField: 'deveui',
+        foreignField: 'deveui',
+        justOne: true,
+      },
+    }),
   })
   .meta({ 'x-collection': 'logeventos' });
 export type ILogEvento = z.infer<typeof LogEventoSchema>;

--- a/src/interfaces/puesta.ts
+++ b/src/interfaces/puesta.ts
@@ -28,7 +28,11 @@ export const PuestaSchema = z
     fechaCreacion: z.string().optional().meta({ 'x-bson': 'date' }),
 
     identificacion: z.string().optional(),
-    ubicacion: GeoJSONPointSchema.optional(), // fuente de verdad de la georreferencia, es la que adquieren las luminarias asignadas a esta puesta
+    // fuente de verdad de la georreferencia, es la que adquieren las
+    // luminarias asignadas a esta puesta. @Prop({type: Object}) en el schema
+    // Mongoose legacy: adentro de un Mixed, Mongoose no declara NADA — no
+    // castea ni inicializa esos paths.
+    ubicacion: GeoJSONPointSchema.optional().meta({ 'x-bson': 'mixed' }),
     direccion: z.string().optional(),
 
     idsGrupos: z

--- a/src/interfaces/resumen-datos.ts
+++ b/src/interfaces/resumen-datos.ts
@@ -464,59 +464,63 @@ const ResumenDatosCamposSchema = z.object({
   }),
 });
 
+// `resumen` es @Prop({type: Object}) en el schema Mongoose legacy: adentro de
+// un Mixed, Mongoose no declara NADA — no castea ni inicializa esos paths. Va
+// anotado en las 13 variantes: el chequeo de drift hace la unión de las
+// properties de la unión y avisa si dos variantes discrepan en la anotación.
 const VarianteConsumoMensualLuminarias = ResumenDatosCamposSchema.extend({
   tipo: z.literal('Consumo Mensual Luminarias').optional(),
-  resumen: ConsumoMensualLuminariasSchema.optional(),
+  resumen: ConsumoMensualLuminariasSchema.optional().meta({ 'x-bson': 'mixed' }),
 });
 const VarianteEncendidoDiarioLuminarias = ResumenDatosCamposSchema.extend({
   tipo: z.literal('Encendido Diario Luminarias').optional(),
-  resumen: EncendidoDiarioLuminariasSchema.optional(),
+  resumen: EncendidoDiarioLuminariasSchema.optional().meta({ 'x-bson': 'mixed' }),
 });
 const VarianteInformeDiarioLuminarias = ResumenDatosCamposSchema.extend({
   tipo: z.literal('Informe Diario Luminarias').optional(),
-  resumen: InformeDiarioLuminariasSchema.optional(),
+  resumen: InformeDiarioLuminariasSchema.optional().meta({ 'x-bson': 'mixed' }),
 });
 const VarianteConsumoMensualCombustibleVehiculos =
   ResumenDatosCamposSchema.extend({
     tipo: z.literal('Consumo Mensual Combustible Vehículos').optional(),
-    resumen: ConsumoCombustibleVehiculosSchema.optional(),
+    resumen: ConsumoCombustibleVehiculosSchema.optional().meta({ 'x-bson': 'mixed' }),
   });
 const VarianteTemperaturaHorariaVehiculos = ResumenDatosCamposSchema.extend({
   tipo: z.literal('Temperatura Horaria Vehículos').optional(),
-  resumen: TemperaturaHorariaVehiculoSchema.optional(),
+  resumen: TemperaturaHorariaVehiculoSchema.optional().meta({ 'x-bson': 'mixed' }),
 });
 const VarianteCombustibleHorarioVehiculos = ResumenDatosCamposSchema.extend({
   tipo: z.literal('Combustible Horario Vehículos').optional(),
-  resumen: CombustibleHorarioVehiculoSchema.optional(),
+  resumen: CombustibleHorarioVehiculoSchema.optional().meta({ 'x-bson': 'mixed' }),
 });
 const VarianteInformeCargasCombustible = ResumenDatosCamposSchema.extend({
   tipo: z.literal('Informe Cargas Combustible').optional(),
-  resumen: InformeCargasCombustibleSchema.optional(),
+  resumen: InformeCargasCombustibleSchema.optional().meta({ 'x-bson': 'mixed' }),
 });
 const VarianteInformeEventosSospechososCombustible =
   ResumenDatosCamposSchema.extend({
     tipo: z.literal('Informe Eventos Sospechosos Combustible').optional(),
-    resumen: InformeEventosSospechososSchema.optional(),
+    resumen: InformeEventosSospechososSchema.optional().meta({ 'x-bson': 'mixed' }),
   });
 const VarianteInformeMensualFlotaCombustible = ResumenDatosCamposSchema.extend({
   tipo: z.literal('Informe Mensual Flota Combustible').optional(),
-  resumen: InformeMensualFlotaCombustibleSchema.optional(),
+  resumen: InformeMensualFlotaCombustibleSchema.optional().meta({ 'x-bson': 'mixed' }),
 });
 const VarianteGastosDelCliente = ResumenDatosCamposSchema.extend({
   tipo: z.literal('Gastos del Cliente').optional(),
-  resumen: ResumenGastosClienteSchema.optional(),
+  resumen: ResumenGastosClienteSchema.optional().meta({ 'x-bson': 'mixed' }),
 });
 const VarianteDownlinksSistema = ResumenDatosCamposSchema.extend({
   tipo: z.literal('Downlinks Métricas Sistema').optional(),
-  resumen: ResumenDownlinksSistemaSchema.optional(),
+  resumen: ResumenDownlinksSistemaSchema.optional().meta({ 'x-bson': 'mixed' }),
 });
 const VarianteDownlinksLuminaria = ResumenDatosCamposSchema.extend({
   tipo: z.literal('Downlinks Luminaria').optional(),
-  resumen: ResumenDownlinksLuminariaSchema.optional(),
+  resumen: ResumenDownlinksLuminariaSchema.optional().meta({ 'x-bson': 'mixed' }),
 });
 const VarianteGatewayStats = ResumenDatosCamposSchema.extend({
   tipo: z.literal('Gateway Stats').optional(),
-  resumen: ResumenGatewayStatsSchema.optional(),
+  resumen: ResumenGatewayStatsSchema.optional().meta({ 'x-bson': 'mixed' }),
 });
 
 /* ────────────────────────────────────────────────

--- a/src/interfaces/sirena.ts
+++ b/src/interfaces/sirena.ts
@@ -37,7 +37,9 @@ export const SirenaSchema = z
     idExterno: z.string().optional(), /// El _id que tiene la sirena en seguridad
     chipId: z.string().optional(), /// El chipId de la sirena en seguridad
     fechaSincronizacion: z.string().optional().meta({ 'x-bson': 'date' }),
-    ubicacion: GeoJSONPointSchema.optional(),
+    // @Prop({type: Object}) en el schema Mongoose legacy: adentro de un Mixed,
+    // Mongoose no declara NADA — no castea ni inicializa esos paths.
+    ubicacion: GeoJSONPointSchema.optional().meta({ 'x-bson': 'mixed' }),
     direccion: z.string().optional(),
     activa: z.boolean().optional(),
     estado: EstadoSirenaSchema.optional(),

--- a/src/interfaces/tema.ts
+++ b/src/interfaces/tema.ts
@@ -62,7 +62,12 @@ export const TemaSchema = z
     // @Prop() pelados en el legacy → String, sin cast.
     fechaInicio: z.string().optional(),
     fechaFin: z.string().optional(),
-    diasRecurrentes: RangoRecurrenteAnualSchema.optional(),
+    // @Prop({type: Object}) en el schema Mongoose legacy: adentro de un Mixed,
+    // Mongoose no declara NADA — no castea ni inicializa esos paths. Vale para
+    // este campo y para `payload` más abajo.
+    diasRecurrentes: RangoRecurrenteAnualSchema.optional().meta({
+      'x-bson': 'mixed',
+    }),
     prioridad: z.number().optional(), // 0-100
     global: z.boolean().optional(),
     idCliente: z
@@ -73,7 +78,7 @@ export const TemaSchema = z
       .array(z.string())
       .optional()
       .meta({ 'x-bson': 'objectId', 'x-ref': 'ClienteSchema' }),
-    payload: TemaPayloadSchema.optional(),
+    payload: TemaPayloadSchema.optional().meta({ 'x-bson': 'mixed' }),
     fechaCreacion: z.string().optional().meta({ 'x-bson': 'date' }),
     fechaActualizacion: z.string().optional().meta({ 'x-bson': 'date' }),
     // Populate


### PR DESCRIPTION
Acompaña a GPE-Sistemas/gestion-datos-go#46, que agrega el chequeo de drift en la dirección **meta → zod**: antes solo verificaba que una anotación no *mintiera*, ahora también que no *falte*.

Eso importa porque en la etapa 2 parte 2 del roadmap las anotaciones dejan de verificarse y pasan a **generar** los `meta.go`. Una anotación faltante generaría un meta sin ese cast, y un cast que falta no rompe nada visible: el filtro deja de matchear y devuelve 200 con lista vacía.

De los 40 hallazgos del RED, **33 eran anotaciones que de verdad faltaban acá**.

## 1. `x-bson: 'mixed'` sobre las 9 raíces que el legacy declara `@Prop({type: Object})` (23 líneas)

`CertificadoEntidad.codigosEsperados`, `ConfigDeseada.config` (3 variantes), `ConfigMarker.vistas`, `EventoGenerico.valores` (en la fábrica `varianteEvento`, cubre las 20 variantes de una), `Puesta.ubicacion`, `ResumenDatos.resumen` (13 variantes), `Sirena.ubicacion`, `Tema.diasRecurrentes` y `Tema.payload`.

Adentro de un Mixed, Mongoose no declara **nada**: no castea ni inicializa esos paths. Sin la anotación, la cosecha entraba igual y exigía en los `meta.go` casts que el legacy nunca tuvo (45 falsos hallazgos).

Las 9 salieron de cruzar el snapshot de los schemas Mongoose legacy contra las raíces donde la cosecha recursaba: son exactamente las que tienen `tipo: ''` y ningún subcampo. Las únicas dos raíces con sub-schema real (`Activo.vehiculo`, `Recorrido.paradas`) quedaron sin tocar.

## 2. `x-populate` sobre virtuals anidados (11)

Los 10 de `DetallesEmergenciasSchema`, `DetallesTecnicosSchema.tecnico` y `CodigoDispositivoSchema.categoriaEvento`. Las props ya existían en zod, sin anotar.

El detalle que había que entender: sus padres están anotados `mixed`, pero **un Mixed apaga el casteo de lo que tiene adentro, no los virtuals** — el legacy los declara con `schema.virtual()` aparte del `@Prop`. La cosecha se ajustó para seguir recorriendo bajo un Mixed emitiendo solo las props con populate.

El `categoriaEvento` de `CodigoDispositivoEntradaSchema` queda **sin** anotar a propósito: el schema legacy declara `cliente`, `ancestros` y `codigos.categoriaEvento`, y ninguno para `codigosEntrada`. Anotarlo afirmaría un populate que nunca existió.

## 3. Virtuals del legacy sin prop en zod (3)

- `CertificadoEntidad.ancestros`
- `DispositivoAlarma.clientesQuePuedenAtenderEventosTecnicos`
- `LogEvento.dispositivo` — el virtual que el schema legacy declara **de verdad**. Convive con `dispositivoLorawan` en vez de reemplazarlo: renombrar sería un cambio de contrato para los consumidores que ya lo piden con ese nombre.

## 4. `ConfigDeseada.divergenteDesde`

Estaba en la interface TS y en el `meta.go` (en `Fields`, casteado a Date) pero **no** en el `z.object()` real, así que el bundle no lo veía. Lo dejaba anotado como pendiente el item 26 de `MIGRACION.md`, que además predijo que ningún test lo podía detectar por construcción. Es el primer hallazgo del chequeo nuevo.

## Compatibilidad

Todo aditivo: `.meta()` no cambia `z.infer`, y las props nuevas son opcionales. Ningún `z.custom<T>()` se convirtió a schema real (TS7056).

## Gate de consumidores

| | resultado |
|---|---|
| `npm run build` | ✅ verde |
| NestJS — `gestion-api-gestion` @ `origin/main` (worktree limpio, swap verificado por grep) | ✅ verde, 0 errores TS |
| Angular — `gestion-web-cliente` @ `origin/main` | ❌ 42 errores, **todos preexistentes** |

El rojo del Angular **no lo introduce este diff**, y está probado con un control: se buildeó el mismo front contra `gestion-modelos` en `origin/main` **sin** estos cambios y salieron **los mismos 42 errores, idénticos uno a uno**.

Son `comunicador` / `idComunicador` / `passwordComunicador` / `fechaUltimaComunicacion` sobre `IDispositivoAlarma`, propiedades que salieron del modelo en el refactor `comunicadores-v2` (#365) y que el front todavía no acompañó.

**No mergear a main hasta que `gestion-web-cliente` se ponga al día**, según la regla de los dos consumidores.

🤖 Generated with [Claude Code](https://claude.com/claude-code)