### PR TITLE
chore: sincronizar el versionado de npm y del módulo Go

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -147,7 +147,7 @@ diseño está en `gestion-datos-go`, en
 Lo que viene y conviene no contradecir:
 
 - **El módulo Go ya existe: `go/`.** Module path
-  `github.com/GPE-Sistemas/gestion-modelos/go`, y `go/esquema` expone la
+  `github.com/GPE-Sistemas/gestion-modelos/go/v2`, y `go/esquema` expone la
   metadata de persistencia derivada de las anotaciones `.meta()`
   (`Collection`, `Fields`, `FieldTypes`, `ArrayFields`, `SubSchemas`,
   `Virtuals`). La generación ocurre **acá**, una sola vez; los consumidores
@@ -176,9 +176,23 @@ Lo que viene y conviene no contradecir:
     campo no determinista del bundle, y sin sacarlo el chequeo de
     sincronización daría rojo en todos los PR.
 
-  Los tags del módulo Go llevan prefijo (`go/v1.0.0`) porque el módulo vive en
-  un subdirectorio, y son **independientes** de la versión de npm: un cambio
-  que no toca schemas no necesita tag de Go, y al revés.
+  **Versionado: npm y Go llevan el MISMO número**, no dos historias
+  independientes — son los mismos modelos, así que la versión tiene que
+  contar la misma historia (decidido el 2026-08-10). Dos reglas de Go son el
+  costo de esa decisión, y no hay que confundirlas:
+
+  - El tag lleva el **prefijo obligatorio** porque el módulo vive en un
+    subdirectorio: `2.2.0` se tagea `go/v2.2.0`, nunca `v2.2.0` a secas —
+    Go solo reconoce tags con ese prefijo para un módulo en subdirectorio.
+  - El **module path lleva el sufijo del major** (`go/v2`, no `go`) porque
+    Go exige eso para cualquier major ≥ 2: sin el sufijo, Go ignora un tag
+    `go/v2.x.y`. Si esto sube a 3.x, el path pasa a `go/v3` y hay que tocar
+    el import en cada consumidor (`gestion-datos-go` incluido) — no es
+    automático.
+
+  Un release que solo cambia `src/` sin tocar `go/esquema` igual sube el
+  número de Go (y viceversa): lo que se sincroniza es el número, no el
+  contenido de cada lado.
 - Los schemas ganan metadata de persistencia vía `.meta()`. Es **aditiva**: los
   consumidores TS ignoran las claves desconocidas y los tipos inferidos no
   cambian. **Ya está aplicada en `proveedor.ts`, `recorrido.ts` y `activo.ts`**

--- a/README.md
+++ b/README.md
@@ -125,13 +125,27 @@ Estado de verificación y lista completa de consumidores: **`CONSUMIDORES.md`**.
 
 ### El módulo Go
 
-`go/` es un módulo Go aparte (`github.com/GPE-Sistemas/gestion-modelos/go`) que
-expone la metadata de persistencia derivada de las anotaciones `.meta()`.
+`go/` es un módulo Go aparte (`github.com/GPE-Sistemas/gestion-modelos/go/v2`)
+que expone la metadata de persistencia derivada de las anotaciones `.meta()`.
 
 Si tocaste un schema en `src/`, regenerá su bundle antes de commitear:
 
     npm run build && npm run gen:json-schema && npm run gen:bundle-go
 
-El workflow `bundle-go` lo verifica y falla si queda diff. Los tags del módulo
-Go llevan prefijo (`go/v1.0.0`) y son **independientes** de la versión de npm:
-un cambio que no toca schemas no necesita tag de Go, y al revés.
+El workflow `bundle-go` lo verifica y falla si queda diff.
+
+**Versionado: npm y Go llevan el MISMO número**, porque son los mismos
+modelos — la decisión es que la versión cuente una sola historia, no dos. Dos
+reglas de Go son el costo de eso:
+
+- El módulo vive en un subdirectorio, así que el tag lleva el prefijo
+  obligatorio: la versión `2.2.0` se tagea `go/v2.2.0` (no `v2.2.0` a secas).
+- Un módulo de major 2 o más tiene que llevar el sufijo del major en el
+  *module path* — por eso `go/v2`, no `go`. Es la otra regla de Go, separada
+  del prefijo del subdirectorio. Si el día de mañana esto pasa a 3.x, hay que
+  renombrar el path a `go/v3` y actualizar los imports de todos los
+  consumidores (`gestion-datos-go` incluido).
+
+Un cambio de npm que no toca `go/esquema` igual sube el número de Go (aunque
+el contenido del módulo no cambie) y viceversa: el número es compartido, no el
+contenido.

--- a/go/go.mod
+++ b/go/go.mod
@@ -1,3 +1,3 @@
-module github.com/GPE-Sistemas/gestion-modelos/go
+module github.com/GPE-Sistemas/gestion-modelos/go/v2
 
 go 1.26

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "gestion-modelos",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "gestion-modelos",
-      "version": "2.1.0",
+      "version": "2.2.0",
       "license": "Private",
       "dependencies": {
         "zod": "^4.4.3"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gestion-modelos",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "description": "Modelos para el sistema de gestión. Schemas Zod + tipos TypeScript inferidos.",
   "author": "GPE Sistemas",
   "license": "Private",


### PR DESCRIPTION
Son los mismos modelos, así que las versiones tienen que contar la misma historia. Hasta ahora no coincidían por dos reglas de Go, y este PR paga el costo de una de ellas para que coincidan.

## Las dos reglas de Go que estorbaban

1. **Un módulo en un subdirectorio solo reconoce tags con ese prefijo.** Para el módulo que vive en `go/`, los tags tienen que llamarse `go/vX.Y.Z`. Un tag plano `v2.0.0` existe pero Go **no lo ve**.
2. **Un módulo de major ≥ 2 tiene que llevar el sufijo del major en el module path.** Sin eso, Go ignora un tag `go/v2.x.y`.

Por la regla 2, el módulo Go estaba condenado a quedarse en la línea 1.x mientras npm iba por 2.x — dos números distintos para el mismo modelo de datos.

## Qué cambia

| | antes | ahora |
|---|---|---|
| module path Go | `github.com/GPE-Sistemas/gestion-modelos/go` | `github.com/GPE-Sistemas/gestion-modelos/go/v2` |
| `package.json` | `2.1.0` | `2.2.0` |
| tag npm | `v2.0.0` | `v2.2.0` |
| tag Go | (ninguno) | `go/v2.2.0` |

El número es **el mismo** en los dos lados. El prefijo `go/` del tag es la regla 1 y no se puede evitar; el `/v2` del path es la regla 2, y es el costo que se paga una vez.

**Forward-only a `2.2.0` y no hacia atrás a `2.0.0`**: la release anterior cambió el `z.infer` (el `.omit({ categoriaEvento: true })` de `certificado-entidad.ts`) y el `package-lock.json` de los consumidores ya registra `2.1.0` resuelto a un commit anterior. Bajar el número declarado confundiría más de lo que aclara.

## Lo que hay que saber para el próximo major

Si algún día el paquete npm va a `3.x`, el module path de Go tiene que renombrarse a `…/go/v3` y **eso cambia la línea de `import` de todos los consumidores Go**. Queda documentado en el `README.md` y en el `CLAUDE.md` §5, junto con el esquema de versionado, para que no haya que redescubrirlo.

Este PR también corrige el texto que decía que las versiones eran independientes: ya no lo son.

## Riesgo para los consumidores TypeScript: ninguno

**Cero cambios en `src/`** — el diff son `package.json`, `package-lock.json`, `go/go.mod`, `README.md` y `CLAUDE.md`. La superficie de tipos es idéntica, así que no puede haber ruptura de tipos. Se corrió el gate igual:

| | resultado |
|---|---|
| `npm run build` | ✅ |
| `go test ./...` + `go vet` en `go/` | ✅ |
| NestJS — `gestion-api-gestion` @ `origin/main` (worktree limpio, swap verificado) | ✅ exit 0, 0 errores TS |
| Angular — `gestion-web-cliente` @ `origin/main` (swap verificado) | ✅ exit 0, 0 errores |

## Después de mergear

1. Tags `v2.2.0` y `go/v2.2.0` sobre `main`, los dos en el mismo commit.
2. `gestion-datos-go` actualiza sus imports a `…/go/v2/esquema` y su `go.mod` a `v2.2.0`.

El tag `v2.0.0` que ya existe queda como marca del commit donde aterrizó el módulo; no molesta.

🤖 Generated with [Claude Code](https://claude.com/claude-code)