### PR TITLE
fix: resincronizar el bundle Go con el zod (idsClientesQueVen)

### DIFF
--- a/go/esquema/bundle.json
+++ b/go/esquema/bundle.json
@@ -21916,6 +21916,13 @@
         "type": "string"
        }
       },
+      "idsClientesQueVen": {
+       "x-bson": "objectId",
+       "type": "array",
+       "items": {
+        "type": "string"
+       }
+      },
       "configHorariosAtencion": {
        "x-bson": "mixed",
        "type": "array",
@@ -22157,6 +22164,13 @@
       "idsClientesQuePuedenAtender": {
        "x-bson": "objectId",
        "x-ref": "ClienteSchema",
+       "type": "array",
+       "items": {
+        "type": "string"
+       }
+      },
+      "idsClientesQueVen": {
+       "x-bson": "objectId",
        "type": "array",
        "items": {
         "type": "string"
@@ -22408,6 +22422,13 @@
         "type": "string"
        }
       },
+      "idsClientesQueVen": {
+       "x-bson": "objectId",
+       "type": "array",
+       "items": {
+        "type": "string"
+       }
+      },
       "configHorariosAtencion": {
        "x-bson": "mixed",
        "type": "array",
@@ -22649,6 +22670,13 @@
       "idsClientesQuePuedenAtender": {
        "x-bson": "objectId",
        "x-ref": "ClienteSchema",
+       "type": "array",
+       "items": {
+        "type": "string"
+       }
+      },
+      "idsClientesQueVen": {
+       "x-bson": "objectId",
        "type": "array",
        "items": {
         "type": "string"
@@ -22900,6 +22928,13 @@
         "type": "string"
        }
       },
+      "idsClientesQueVen": {
+       "x-bson": "objectId",
+       "type": "array",
+       "items": {
+        "type": "string"
+       }
+      },
       "configHorariosAtencion": {
        "x-bson": "mixed",
        "type": "array",
@@ -23141,6 +23176,13 @@
       "idsClientesQuePuedenAtender": {
        "x-bson": "objectId",
        "x-ref": "ClienteSchema",
+       "type": "array",
+       "items": {
+        "type": "string"
+       }
+      },
+      "idsClientesQueVen": {
+       "x-bson": "objectId",
        "type": "array",
        "items": {
         "type": "string"
@@ -23392,6 +23434,13 @@
         "type": "string"
        }
       },
+      "idsClientesQueVen": {
+       "x-bson": "objectId",
+       "type": "array",
+       "items": {
+        "type": "string"
+       }
+      },
       "configHorariosAtencion": {
        "x-bson": "mixed",
        "type": "array",
@@ -23633,6 +23682,13 @@
       "idsClientesQuePuedenAtender": {
        "x-bson": "objectId",
        "x-ref": "ClienteSchema",
+       "type": "array",
+       "items": {
+        "type": "string"
+       }
+      },
+      "idsClientesQueVen": {
+       "x-bson": "objectId",
        "type": "array",
        "items": {
         "type": "string"
@@ -23884,6 +23940,13 @@
         "type": "string"
        }
       },
+      "idsClientesQueVen": {
+       "x-bson": "objectId",
+       "type": "array",
+       "items": {
+        "type": "string"
+       }
+      },
       "configHorariosAtencion": {
        "x-bson": "mixed",
        "type": "array",
@@ -24125,6 +24188,13 @@
       "idsClientesQuePuedenAtender": {
        "x-bson": "objectId",
        "x-ref": "ClienteSchema",
+       "type": "array",
+       "items": {
+        "type": "string"
+       }
+      },
+      "idsClientesQueVen": {
+       "x-bson": "objectId",
        "type": "array",
        "items": {
         "type": "string"
@@ -24376,6 +24446,13 @@
         "type": "string"
        }
       },
+      "idsClientesQueVen": {
+       "x-bson": "objectId",
+       "type": "array",
+       "items": {
+        "type": "string"
+       }
+      },
       "configHorariosAtencion": {
        "x-bson": "mixed",
        "type": "array",
@@ -24617,6 +24694,13 @@
       "idsClientesQuePuedenAtender": {
        "x-bson": "objectId",
        "x-ref": "ClienteSchema",
+       "type": "array",
+       "items": {
+        "type": "string"
+       }
+      },
+      "idsClientesQueVen": {
+       "x-bson": "objectId",
        "type": "array",
        "items": {
         "type": "string"
@@ -24868,6 +24952,13 @@
         "type": "string"
        }
       },
+      "idsClientesQueVen": {
+       "x-bson": "objectId",
+       "type": "array",
+       "items": {
+        "type": "string"
+       }
+      },
       "configHorariosAtencion": {
        "x-bson": "mixed",
        "type": "array",
@@ -25109,6 +25200,13 @@
       "idsClientesQuePuedenAtender": {
        "x-bson": "objectId",
        "x-ref": "ClienteSchema",
+       "type": "array",
+       "items": {
+        "type": "string"
+       }
+      },
+      "idsClientesQueVen": {
+       "x-bson": "objectId",
        "type": "array",
        "items": {
         "type": "string"
@@ -25360,6 +25458,13 @@
         "type": "string"
        }
       },
+      "idsClientesQueVen": {
+       "x-bson": "objectId",
+       "type": "array",
+       "items": {
+        "type": "string"
+       }
+      },
       "configHorariosAtencion": {
        "x-bson": "mixed",
        "type": "array",
@@ -25606,6 +25711,13 @@
         "type": "string"
        }
       },
+      "idsClientesQueVen": {
+       "x-bson": "objectId",
+       "type": "array",
+       "items": {
+        "type": "string"
+       }
+      },
       "configHorariosAtencion": {
        "x-bson": "mixed",
        "type": "array",
@@ -25847,6 +25959,13 @@
       "idsClientesQuePuedenAtender": {
        "x-bson": "objectId",
        "x-ref": "ClienteSchema",
+       "type": "array",
+       "items": {
+        "type": "string"
+       }
+      },
+      "idsClientesQueVen": {
+       "x-bson": "objectId",
        "type": "array",
        "items": {
         "type": "string"


### PR DESCRIPTION
`773554a` agregó `idsClientesQueVen` al `EventoGenericoSchema` pero **no regeneró `go/esquema/bundle.json`**, que es la copia commiteada que embebe el módulo Go. Resultado: el módulo sirve metadata sin ese campo.

## Por qué importa

`gestion-datos-go` está por tomar la metadata de este módulo. Con el bundle viejo, el meta de eventos-genéricos pierde el cast a ObjectId de ese campo, y entonces:

```
GET /eventos-genericos?idsClientesQueVen=<hex>   → 200 con lista vacía
```

El filtro llega como string contra ObjectIds guardados en Mongo y no matchea nada. Sin error, sin log. Y ese campo existe justamente para el control de visibilidad por cliente.

## El chequeo que debía atajarlo no corrió

El workflow `bundle-go` se agregó para exactamente esto: regenera y falla si queda diff. Nunca se ejecutó, porque **GitHub Actions está deshabilitado a nivel repositorio**:

```
repos/GPE-Sistemas/gestion-modelos/actions/permissions  → {"enabled": false}
repos/GPE-Sistemas/gestion-datos-go/actions/permissions → {"enabled": false}
```

Mientras siga así, el chequeo es decorativo y la sincronización depende de que cada uno se acuerde de correr `npm run gen:bundle-go`. Vale la pena decidirlo aparte de este PR.

## El diff

Solo `go/esquema/bundle.json` regenerado: +119 líneas, el nodo del campo nuevo. **Cero cambios en `src/`**, así que la superficie de tipos de TypeScript es idéntica y no hay riesgo para los consumidores npm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)